### PR TITLE
Fix use-after-free in handler of periodic sample gNMI subscribtions

### DIFF
--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -595,6 +595,15 @@ constexpr int kThousandMilliseconds = 1000 /* milliseconds */;
       break;
     }
   }
+
+  // Unsubscribe and delete all subscriptions and polls. This stops scheduled
+  // timers and prevents access to freed gRPC resources.
+  for (auto& subscription : subscriptions) {
+    publisher->UnSubscribe(subscription.second);
+  }
+  subscriptions.clear();
+  polls.clear();
+
   return ::grpc::Status::OK;
 }
 

--- a/stratum/hal/lib/common/gnmi_publisher.cc
+++ b/stratum/hal/lib/common/gnmi_publisher.cc
@@ -209,10 +209,13 @@ GnmiPublisher::~GnmiPublisher() {}
   return ::util::OkStatus();
 }
 
-::util::Status GnmiPublisher::UnSubscribe(EventHandlerRecord* h) {
+::util::Status GnmiPublisher::UnSubscribe(const SubscriptionHandle& h) {
   absl::WriterMutexLock l(&access_lock_);
-  // TODO(unknown): Add implementation.
-  return ::util::OkStatus();
+  // There is no way to match a subscription to a certain type of event.
+  // Therefore we have to try removing it from every list we register events
+  // on. Currently this is just TimerEvent.
+  // FIXME: Add UnRegister calls for other EventHandlerLists in use.
+  return EventHandlerList<TimerEvent>::GetInstance()->UnRegister(h);
 }
 
 ::util::Status

--- a/stratum/hal/lib/common/gnmi_publisher.h
+++ b/stratum/hal/lib/common/gnmi_publisher.h
@@ -139,7 +139,7 @@ class GnmiPublisher {
       const ::gnmi::Path& path, ::gnmi::Subscription* subscription)
       LOCKS_EXCLUDED(access_lock_);
 
-  virtual ::util::Status UnSubscribe(EventHandlerRecord* h)
+  virtual ::util::Status UnSubscribe(const SubscriptionHandle& h)
       LOCKS_EXCLUDED(access_lock_);
 
   // The method sends a gNMI message denoting the end of initial set of values.


### PR DESCRIPTION
TODO:

- [ ] ~Add test case testing sampling subscription with low (1 ms) interval~

- [x] Test non-ASAN binary on switch

Fixes #10 