### PR TITLE
Add test coverage target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,9 +8,10 @@ coverage:
   range: "85...100"
 
   status:
-    project: yes
-    patch: yes
-    changes: no
+    project:
+      default:
+        target: 85%
+    patch: false
 
 parsers:
   gcov:


### PR DESCRIPTION
We now target the unit test coverage to 85%.
We may move the unit test coverage to target 90% or 95% in the future.
Currently, we only care about the coverage for the entire project, so we disable the coverage report for a patch. (see the yaml file)