### PR TITLE
Preventing gNMI from complaining about empty update for get requests

### DIFF
--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -326,7 +326,9 @@ ConfigMonitoringService::~ConfigMonitoringService() {
       // `msg` PROTOBUF to the response that will be sent to the controller.
       InlineGnmiSubscribeStream stream(
           [resp](const ::gnmi::SubscribeResponse& msg) -> bool {
-            if (!msg.has_update()) return false;
+            //If update is empty, then it may be a sync_response for get request
+            if (!msg.has_update())
+                return msg.sync_response();
             *resp->add_notification() = msg.update();
             return true;
           });

--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -326,7 +326,7 @@ ConfigMonitoringService::~ConfigMonitoringService() {
       // `msg` PROTOBUF to the response that will be sent to the controller.
       InlineGnmiSubscribeStream stream(
           [resp](const ::gnmi::SubscribeResponse& msg) -> bool {
-            //If update is empty, then it may be a sync_response for get request
+            // If msg has empty update, it might be a sync_response for GetRequest
             if (!msg.has_update())
                 return msg.sync_response();
             *resp->add_notification() = msg.update();


### PR DESCRIPTION
While issuing gnmi get /interfaces/interface[name=*], you will get the following message:
```
stratum_dummy[3656]: INFO dummy_switch.cc:245] RetrieveValue             
E1009 20:11:35.721181  3929 yang_parse_tree_paths.cc:98] StratumErrorSpac
e::ERR_INTERNAL: Writing response to stream failed: sync_response: true  
stratum_dummy[3656]: ERROR yang_parse_tree_paths.cc:98] StratumErrorSpace
::ERR_INTERNAL: Writing response to stream failed: sync_response: true   
E1009 20:11:35.721248  3929 yang_parse_tree.cc:71] Return Error: (this->*
handler)(event, path, stream) failed with StratumErrorSpace::ERR_INTERNAL
: Writing response to stream failed: sync_response: true.                
stratum_dummy[3656]: ERROR yang_parse_tree.cc:71] Return Error: (this->*h
andler)(event, path, stream) failed with StratumErrorSpace::ERR_INTERNAL:
 Writing response to stream failed: sync_response: true.                 
E1009 20:11:35.721313  3929 gnmi_publisher.cc:127] Handler returned non-O
K status: StratumErrorSpace::ERR_INTERNAL: Writing response to stream fai
led: sync_response: true.                                                
stratum_dummy[3656]: ERROR gnmi_publisher.cc:127] Handler returned non-OK
 status: StratumErrorSpace::ERR_INTERNAL: Writing response to stream fail
ed: sync_response: true.    
```