### PR TITLE
Fix empty ChassisConfig problem in YangParseTreeTest

### DIFF
--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -111,7 +111,7 @@ class YangParseTreeTest : public ::testing::Test {
 
   // A proxy for YangParseTree::AddSubtreeInterface().
   void AddSubtreeInterface(const std::string& name,
-                           SingletimePort* singleton_p = nullptr) {
+                           SingletonPort* singleton_p = nullptr) {
     absl::WriterMutexLock l(&parse_tree_.root_access_lock_);
 
     // Add one singleton port.

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -110,16 +110,19 @@ class YangParseTreeTest : public ::testing::Test {
   }
 
   // A proxy for YangParseTree::AddSubtreeInterface().
-  void AddSubtreeInterface(const std::string& name) {
+  void AddSubtreeInterface(const std::string& name,
+                           SingletimePort* singleton_p = nullptr) {
     absl::WriterMutexLock l(&parse_tree_.root_access_lock_);
 
     // Add one singleton port.
     SingletonPort singleton;
-    singleton.set_name(name);
-    singleton.set_node(kInterface1NodeId);
-    singleton.set_id(kInterface1PortId);
-    singleton.set_speed_bps(kTwentyFiveGigBps);
-    singleton.mutable_config_params()->set_mac_address(kInterfaceMac);
+    SingletonPort* singleton_ptr =
+        (singleton_p == nullptr) ? &singleton : singleton_p;
+    singleton_ptr->set_name(name);
+    singleton_ptr->set_node(kInterface1NodeId);
+    singleton_ptr->set_id(kInterface1PortId);
+    singleton_ptr->set_speed_bps(kTwentyFiveGigBps);
+    singleton_ptr->mutable_config_params()->set_mac_address(kInterfaceMac);
     // Add one per port per queue stat for this interface.
     NodeConfigParams node_config;
     {
@@ -133,7 +136,7 @@ class YangParseTreeTest : public ::testing::Test {
       entry->set_internal_priority(2);  // some internal priority
       entry->set_q_num(kInterface1QueueId);
     }
-    parse_tree_.AddSubtreeInterfaceFromSingleton(singleton, node_config);
+    parse_tree_.AddSubtreeInterfaceFromSingleton(*singleton_ptr, node_config);
   }
 
   // A proxy for YangParseTree::AddSubtreeChassis().
@@ -335,12 +338,13 @@ class YangParseTreeTest : public ::testing::Test {
     // /interfaces/interface[name=*]/state/ifindex
     // /interfaces/interface[name=*]/state/name
 
+    ChassisConfig chassis_config;
     // The test requires one interface branch to be added.
-    AddSubtreeInterface("interface-1");
+    AddSubtreeInterface("interface-1",
+                        chassis_config.add_singleton_ports());
     // The test requires one node branch to be added.
     AddSubtreeNode("node-1", kInterface1NodeId);
     // Make a copy-on-write pointer to current chassis configuration.
-    ChassisConfig chassis_config;
     CopyOnWriteChassisConfig config(&chassis_config);
 
     // Expect the SetValue() call only if the 'req' is not nullptr.


### PR DESCRIPTION
@Yi-Tseng Empty ChassisConfig results in low coverage because
some codes in on_set_functor will never be hit