### PR TITLE
Add MPLS support to Stratum

### DIFF
--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -508,6 +508,7 @@ message BcmNonMultipathNexthop {
   int32 vlan = 3;  // 0-based.
   fixed64 src_mac = 4;
   fixed64 dst_mac = 5;
+  uint32 mpls_label = 8;
   // The BCM-specific value of the port (aka BCM logical port) or trunk (aka
   // BCM trunk id or tid or simply trunk).
   oneof port {

--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -311,6 +311,7 @@ message BcmField {
     VFP_DST_CLASS_ID = 24;    // VFP Destination Class ID.
     L3_DST_CLASS_ID = 25;     // L3 Destination Class ID.
     CLONE_PORT = 26;          // Logical destination port for packet clone.
+    MPLS_LABEL = 27;          // MPLS label.
   };
   Type type = 1;                 // required
   BcmTableEntryValue value = 2;  // required
@@ -454,6 +455,7 @@ message BcmFlowEntry {
     BCM_TABLE_L2_MULTICAST = 7;
     BCM_TABLE_TUNNEL = 8;
     BCM_TABLE_L2_UNICAST = 9;
+    BCM_TABLE_MPLS = 10;
   }
   // The unit to program this flow.
   int32 unit = 1;  // required
@@ -509,6 +511,7 @@ message BcmNonMultipathNexthop {
   fixed64 src_mac = 4;
   fixed64 dst_mac = 5;
   uint32 mpls_label = 8;
+  uint32 mpls_ttl = 9;
   // The BCM-specific value of the port (aka BCM logical port) or trunk (aka
   // BCM trunk id or tid or simply trunk).
   oneof port {

--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -312,6 +312,7 @@ message BcmField {
     L3_DST_CLASS_ID = 25;     // L3 Destination Class ID.
     CLONE_PORT = 26;          // Logical destination port for packet clone.
     MPLS_LABEL = 27;          // MPLS label.
+    MPLS_BOS = 28;            // MPLS bottom-of-stack bit.
   };
   Type type = 1;                 // required
   BcmTableEntryValue value = 2;  // required

--- a/stratum/hal/lib/bcm/bcm_l3_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.cc
@@ -515,7 +515,7 @@ BcmL3Manager::~BcmL3Manager() {}
   RETURN_IF_ERROR(ExtractMplsActionParams(bcm_flow_entry, &action_params));
 
   return bcm_sdk_interface_->AddMplsRoute(unit_, key.port, key.mpls_label,
-      action_params.egress_intf_id);
+      action_params.egress_intf_id, action_params.is_intf_multipath);
 }
 
 ::util::Status BcmL3Manager::ModifyMplsFlow(const BcmFlowEntry& bcm_flow_entry) {

--- a/stratum/hal/lib/bcm/bcm_l3_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.cc
@@ -88,6 +88,7 @@ BcmL3Manager::~BcmL3Manager() {}
   int vlan = nexthop.vlan();
   uint64 src_mac = nexthop.src_mac();
   uint64 dst_mac = nexthop.dst_mac();
+  uint32 mpls_label = nexthop.mpls_label();
   int router_intf_id = -1, egress_intf_id = -1;
 
   // Given the router intf, find or create the egress intf.
@@ -98,7 +99,7 @@ BcmL3Manager::~BcmL3Manager() {}
         ASSIGN_OR_RETURN(
             egress_intf_id,
             bcm_sdk_interface_->FindOrCreateL3CpuEgressIntf(unit_));
-      } else if (logical_port >= 0 && src_mac > 0 && dst_mac > 0) {
+      } else if (logical_port >= 0 && src_mac > 0 && dst_mac > 0 && mpls_label == 0) {
         ASSIGN_OR_RETURN(
             router_intf_id,
             bcm_sdk_interface_->FindOrCreateL3RouterIntf(unit_, src_mac, vlan));
@@ -106,6 +107,16 @@ BcmL3Manager::~BcmL3Manager() {}
             egress_intf_id,
             bcm_sdk_interface_->FindOrCreateL3PortEgressIntf(
                 unit_, dst_mac, logical_port, vlan, router_intf_id));
+      } else if (logical_port >= 0 && src_mac > 0 && dst_mac > 0 && mpls_label > 0) {
+        // TODO(max): separate L3_EIF from TNL_MPLS_ENCAP creation?
+        ASSIGN_OR_RETURN(
+            router_intf_id,
+            bcm_sdk_interface_->FindOrCreateL3MplsRouterIntf(
+                unit_, src_mac, vlan, mpls_label));
+        ASSIGN_OR_RETURN(
+            egress_intf_id,
+            bcm_sdk_interface_->FindOrCreateL3MplsEgressIntf(
+                unit_, dst_mac, logical_port, router_intf_id));
       } else {
         return MAKE_ERROR(ERR_INVALID_PARAM)
                << "Invalid nexthop of type NEXTHOP_TYPE_PORT: "

--- a/stratum/hal/lib/bcm/bcm_l3_manager.h
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.h
@@ -70,6 +70,25 @@ struct LpmOrHostActionParams {
       : class_id(-1), egress_intf_id(-1), is_intf_multipath(false) {}
 };
 
+// This struct encapsulates the key for a Mpls flow.
+struct MplsKey {
+    // The ingress port to match on.
+    int port;
+    // The mpls label to match on.
+    uint32 mpls_label;
+    MplsKey()
+        : port(-1), mpls_label(-1) {}
+};
+
+struct MplsActionParams {
+  // Egress intf ID for the nexthop.
+  int egress_intf_id;
+  // A boolean determining whether the nexthop is an ECMP/WCMP group
+  bool is_intf_multipath;
+  MplsActionParams()
+      : egress_intf_id(-1), is_intf_multipath(false) {}
+};
+
 // The "BcmL3Manager" class implements the L3 routing functionality.
 class BcmL3Manager {
  public:
@@ -179,6 +198,20 @@ class BcmL3Manager {
   // define the key for the flow (the egress_intf_id or class_id not needed).
   ::util::Status DeleteLpmOrHostFlow(const BcmFlowEntry& bcm_flow_entry);
 
+  // Inserts a MPLS LSR (transit) flow. The function programs the
+  // low level routes into the given unit based on the given BcmFlowEntry.
+  ::util::Status InsertMplsFlow(const BcmFlowEntry& bcm_flow_entry);
+
+  // Inserts a MPLS LSR (transit) flow. The function programs the
+  // low level routes into the given unit based on the given BcmFlowEntry. The
+  // fields populated in BcmFlowEntry are the same as the ones populated when
+  // adding the flow in InsertLpmOrHostFlow().
+  ::util::Status ModifyMplsFlow(const BcmFlowEntry& bcm_flow_entry);
+
+  // Inserts a MPLS LSR (transit) flow. The fields populated in BcmFlowEntry
+  // define the key for the flow (the egress_intf_id or class_id not needed).
+  ::util::Status DeleteMplsFlow(const BcmFlowEntry& bcm_flow_entry);
+
   // Helper to extract IPv4/IPv6 L3 LPM/Host flow keys given BcmFlowEntry.
   ::util::Status ExtractLpmOrHostKey(const BcmFlowEntry& bcm_flow_entry,
                                      LpmOrHostKey* key);
@@ -186,6 +219,14 @@ class BcmL3Manager {
   // Helper to extract IPv4/IPv6 L3 LPM/Host flow actions given BcmFlowEntry.
   ::util::Status ExtractLpmOrHostActionParams(
       const BcmFlowEntry& bcm_flow_entry, LpmOrHostActionParams* action_params);
+
+  // Helper to extract Mpls LSR (transit) flow keys given BcmFlowEntry.
+  ::util::Status ExtractMplsKey(const BcmFlowEntry& bcm_flow_entry,
+                                MplsKey* key);
+
+  // Helper to extract Mpls LSR (transit) flow actions given BcmFlowEntry.
+  ::util::Status ExtractMplsActionParams(
+      const BcmFlowEntry& bcm_flow_entry, MplsActionParams* action_params);
 
   // A helper to find the sorted vector of the member egress intf ids of an
   // ECMP group. The output vector is going to have the following format:

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -520,6 +520,7 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
         case BcmFlowEntry::BCM_TABLE_IPV4_HOST:
         case BcmFlowEntry::BCM_TABLE_IPV6_LPM:
         case BcmFlowEntry::BCM_TABLE_IPV6_HOST:
+        case BcmFlowEntry::BCM_TABLE_MPLS:
           RETURN_IF_ERROR(bcm_l3_manager_->InsertTableEntry(entry));
           // BcmL3Manager updates the internal records in BcmTableManager.
           consumed = true;

--- a/stratum/hal/lib/bcm/bcm_sdk_interface.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_interface.h
@@ -429,9 +429,9 @@ class BcmSdkInterface {
   // The egress intf used is given by egress_intf_id and is assumed to be
   // already created. The function will return error if a route with the same
   // (port, mpls_label) exists.
-  // TODO(max): Add options for ECMP/normal egress intf.
-  virtual ::util::Status AddMplsRoute(int unit_, int port, uint32 mpls_label,
-                                      int egress_intf_id) = 0;
+  virtual ::util::Status AddMplsRoute(int unit, int port, uint32 mpls_label,
+                                      int egress_intf_id,
+                                      bool is_intf_multipath) = 0;
 
   // Modifies class_id and/or egress_intf_id of an existing IPv4 L3 LPM route
   // with key (vrf, subnet, mask). If vrf == 0, default VRF is used. If
@@ -480,7 +480,8 @@ class BcmSdkInterface {
   // and is assumed to be already created. The function will return error if a
   // route with key (port, mpls_label) does not exist.
   virtual ::util::Status ModifyMplsRoute(int unit_, int port, uint32 mpls_label,
-                                         int egress_intf_id) = 0;
+                                         int egress_intf_id,
+                                         bool is_intf_multipath) = 0;
 
   // Deletes an IPv4 L3 LPM route given its (vrf, subnet, mask) key. Returns
   // error if the route with the given key does not exist.

--- a/stratum/hal/lib/bcm/bcm_sdk_interface.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_interface.h
@@ -284,7 +284,7 @@ class BcmSdkInterface {
   // (vlan, router_mac, mpls_label) given to this method. If vlan == 0,
   // default VLAN will be used.
   virtual ::util::StatusOr<int> FindOrCreateL3MplsRouterIntf(int unit,
-      uint64 router_mac, int vlan, uint32 mpls_label) = 0;
+      uint64 router_mac, int vlan, uint32 mpls_label, uint32 mpls_ttl) = 0;
 
   // Finds an L3 egress intf for sending packets unchanged to CPU port on a
   // given unit. If it does not exist, tries to create it. In either case,
@@ -311,6 +311,15 @@ class BcmSdkInterface {
   // FindOrCreateL3RouterIntf().
   virtual ::util::StatusOr<int> FindOrCreateL3MplsEgressIntf(
     int unit, uint64 nexthop_mac, int port, int router_intf_id) = 0;
+
+  // Finds an L3 mpls transit egress intf defining the nexthop, given its (nexthop_mac,
+  // port, router_intf_id). If it does not exist, tries to create it. In either
+  // case, returns the ID of the egress intf. Packets sent to the intf
+  // will be sent through the given port. DA will be the given nexthop_mac, and
+  // SA will be found using the given router_intf_id, created previously using
+  // FindOrCreateL3RouterIntf().
+  virtual ::util::StatusOr<int> FindOrCreateL3MplsTransitEgressIntf(int unit,
+      uint64 nexthop_mac, int port, int router_intf_id, uint32 mpls_label) = 0;
 
   // Finds an L3 trunk/lag egress intf defining the nexthop, given its
   // (nexthop_mac, trunk, vlan, router_intf_id). If it does not exist, tries to
@@ -416,6 +425,14 @@ class BcmSdkInterface {
                                        const std::string& ipv6, int class_id,
                                        int egress_intf_id) = 0;
 
+  // Add a MPLS LSR (transit) route for the given source port and MPLS label.
+  // The egress intf used is given by egress_intf_id and is assumed to be
+  // already created. The function will return error if a route with the same
+  // (port, mpls_label) exists.
+  // TODO(max): Add options for ECMP/normal egress intf.
+  virtual ::util::Status AddMplsRoute(int unit_, int port, uint32 mpls_label,
+                                      int egress_intf_id) = 0;
+
   // Modifies class_id and/or egress_intf_id of an existing IPv4 L3 LPM route
   // with key (vrf, subnet, mask). If vrf == 0, default VRF is used. If
   // class_id == 0, class ID will not be modified. The new egress intf to use is
@@ -458,6 +475,13 @@ class BcmSdkInterface {
                                           const std::string& ipv6, int class_id,
                                           int egress_intf_id) = 0;
 
+  // Modifies egress_intf_id of a existing MPLS LSR (transit) route with key
+  // (port, mpls_label). The new egress intf to use is given by egress_intf_id
+  // and is assumed to be already created. The function will return error if a
+  // route with key (port, mpls_label) does not exist.
+  virtual ::util::Status ModifyMplsRoute(int unit_, int port, uint32 mpls_label,
+                                         int egress_intf_id) = 0;
+
   // Deletes an IPv4 L3 LPM route given its (vrf, subnet, mask) key. Returns
   // error if the route with the given key does not exist.
   virtual ::util::Status DeleteL3RouteIpv4(int unit, int vrf, uint32 subnet,
@@ -477,6 +501,11 @@ class BcmSdkInterface {
   // the host with the given key does not exist.
   virtual ::util::Status DeleteL3HostIpv6(int unit, int vrf,
                                           const std::string& ipv6) = 0;
+
+  // Deletes a MPLS LSR (transit) route given its (port, mpls_label) key.
+  // Returns error if the given key does not exist.
+  virtual ::util::Status DeleteMplsRoute(int unit_, int port,
+                                         uint32 mpls_label) = 0;
 
   // Adds an entry to match the given (vlan, vlan_mask, dst_mac, dst_mac_mask)
   // to the my station TCAM, with the given priority. NOOP if the entry already

--- a/stratum/hal/lib/bcm/bcm_sdk_interface.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_interface.h
@@ -278,6 +278,14 @@ class BcmSdkInterface {
   // Deletes an L3 router intf given its ID from a given unit.
   virtual ::util::Status DeleteL3RouterIntf(int unit, int router_intf_id) = 0;
 
+  // Finds an L3 router intf given its (vlan, router_mac) and if it does not
+  // exist tries to create it. In either case, returns the L3 intf ID of the
+  // router intf. Packets sent out through this intf will be encapsulated with
+  // (vlan, router_mac, mpls_label) given to this method. If vlan == 0,
+  // default VLAN will be used.
+  virtual ::util::StatusOr<int> FindOrCreateL3MplsRouterIntf(int unit,
+      uint64 router_mac, int vlan, uint32 mpls_label) = 0;
+
   // Finds an L3 egress intf for sending packets unchanged to CPU port on a
   // given unit. If it does not exist, tries to create it. In either case,
   // returns the ID of the egress intf.
@@ -287,7 +295,7 @@ class BcmSdkInterface {
   // port, vlan, router_intf_id). If it does not exist, tries to create it. In
   // either case, returns the ID of the egress intf. Packets sent to the intf
   // will be sent through the given port. DA will be the given nexthop_mac, and
-  // SA will be found using the given l3_intf_id, created previously using
+  // SA will be found using the given router_intf_id, created previously using
   // FindOrCreateL3RouterIntf(). The given port can be for CPU as well, in which
   // case nexthop_mac and router_intf_id are not used. If vlan == 0, default
   // VLAN will be used.
@@ -295,11 +303,20 @@ class BcmSdkInterface {
       int unit, stratum::uint64 nexthop_mac, int port, int vlan,
       int router_intf_id) = 0;
 
+  // Finds an L3 mpls egress intf defining the nexthop, given its (nexthop_mac,
+  // port, router_intf_id). If it does not exist, tries to create it. In either
+  // case, returns the ID of the egress intf. Packets sent to the intf
+  // will be sent through the given port. DA will be the given nexthop_mac, and
+  // SA will be found using the given router_intf_id, created previously using
+  // FindOrCreateL3RouterIntf().
+  virtual ::util::StatusOr<int> FindOrCreateL3MplsEgressIntf(
+    int unit, uint64 nexthop_mac, int port, int router_intf_id) = 0;
+
   // Finds an L3 trunk/lag egress intf defining the nexthop, given its
   // (nexthop_mac, trunk, vlan, router_intf_id). If it does not exist, tries to
   // create it. In either case, returns the ID of the egress intf. Packets sent
   // to the intf will be sent through the given trunk/LAG. DA will be the given
-  // nexthop_mac, and SA will be found using the given l3_intf_id, created
+  // nexthop_mac, and SA will be found using the given router_intf_id, created
   // previously using FindOrCreateL3RouterIntf(). If vlan == 0, default VLAN
   // will be used.
   virtual ::util::StatusOr<int> FindOrCreateL3TrunkEgressIntf(
@@ -321,6 +338,10 @@ class BcmSdkInterface {
   virtual ::util::Status ModifyL3PortEgressIntf(int unit, int egress_intf_id,
                                                 stratum::uint64 nexthop_mac,
                                                 int port, int vlan,
+                                                int router_intf_id) = 0;
+
+  virtual ::util::Status ModifyL3MplsEgressIntf(int unit, int egress_intf_id,
+                                                uint64 nexthop_mac, int port,
                                                 int router_intf_id) = 0;
 
   // Modifies an already existing L3 intf on a unit given its ID to become an

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.cc
@@ -1225,6 +1225,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
       bcmlt_entry_field_array_add(entry_hdl, UNTAGGED_MEMBER_PORTSs, 0,
                                   all_ports_no_cpu_bitmap, 3));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, VLAN_STG_IDs, kDefaultVlanStgId));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLSs, 1));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, L3_IIF_IDs, 1));
   RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
                                                 BCMLT_PRIORITY_NORMAL));
@@ -1243,6 +1244,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
         bcmlt_entry_field_symbol_add(entry_hdl, PORT_TYPEs, ETHERNETs));
     RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, V4L3s, 1));
     RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, V6L3s, 1));
+    RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLSs, 1));
     RETURN_IF_BCM_ERROR(
         bcmlt_entry_field_add(entry_hdl, PORT_PKT_CONTROL_IDs, 1));
     RETURN_IF_BCM_ERROR(
@@ -2155,7 +2157,8 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 ::util::StatusOr<int> BcmSdkWrapper::FindOrCreateL3MplsRouterIntf(int unit,
                                                               uint64 router_mac,
                                                               int vlan,
-                                                              uint32 mpls_label) {
+                                                              uint32 mpls_label,
+                                                              uint32 mpls_ttl) {
   bcmlt_entry_handle_t entry_hdl;
   bcmlt_entry_info_t entry_info;
   uint64_t max;
@@ -2169,6 +2172,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   }
   CHECK_RETURN_IF_FALSE(router_mac);
   CHECK_RETURN_IF_FALSE(mpls_label);
+  CHECK_RETURN_IF_FALSE(mpls_ttl > 0 && mpls_ttl <= UINT8_MAX);
 
   // check if unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
@@ -2221,7 +2225,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MAX_LABELSs, 2));
   uint64 array_data[1] = {mpls_label};
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_array_add(entry_hdl, LABELs, 0, array_data, 1));
-  array_data[0] = 0x40;
+  array_data[0] = mpls_ttl;
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_array_add(entry_hdl, LABEL_TTLs, 0, array_data, 1));
   RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
                                                 BCMLT_PRIORITY_NORMAL));
@@ -2441,6 +2445,81 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // TODO(max): print mpls label
   l3_intf_object_t l3_intf_o = {router_intf_id, nexthop_mac, 0, port, 0};
   VLOG(1) << "Created a new L3 mpls egress intf: "
+          << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
+          << unit << ".";
+  return egress_intf_id;
+}
+
+::util::StatusOr<int> BcmSdkWrapper::FindOrCreateL3MplsTransitEgressIntf(
+    int unit, uint64 nexthop_mac, int port, int router_intf_id, uint32 mpls_label) {
+  bcmlt_entry_handle_t entry_hdl;
+  int egress_intf_id = 0;
+  CHECK_RETURN_IF_FALSE(nexthop_mac);
+  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  CHECK_RETURN_IF_FALSE(mpls_label);
+
+  // Check if the unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  // Check if port is valid
+  RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
+
+  InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+  auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
+  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
+      << "Unit " << unit
+      << " not initialized yet. Call InitializeUnit first.";
+
+  // Check if router interface is valid
+  if (!FindIndexOrNull(*unit_to_l3_intf, router_intf_id)) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Router ID " << router_intf_id << " not found.";
+  }
+
+  // get next free slot
+  ASSIGN_OR_RETURN(egress_intf_id,
+      GetFreeSlot(l3_intfs, "L3 Port egress interface table is full."));
+
+  // Create MPLS dst mac entry
+  // TODO(max): better id mapping
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DST_MACs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, DST_MACs, nexthop_mac));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Create mpls transit entry
+  // TODO(max): better id mapping
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_TRANSITs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_TRANSIT_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, LABELs, mpls_label));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Create transit next hop
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_TRANSIT_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, NHOP_IDs, egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_TRANSIT_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, L3_EIF_IDs, router_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // mark slot
+  ConsumeSlot(l3_intfs, egress_intf_id);
+  // TODO(max): print mpls label
+  l3_intf_object_t l3_intf_o = {router_intf_id, nexthop_mac, 0, port, 0};
+  VLOG(1) << "Created a new L3 mpls transit egress intf: "
           << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
           << unit << ".";
   return egress_intf_id;
@@ -3307,6 +3386,42 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::AddMplsRoute(int unit, int port,
+    uint32 mpls_label, int egress_intf_id) {
+  // Check if the unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
+  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  CHECK_RETURN_IF_FALSE(mpls_label > 0);
+
+  // Check if egress interface is valid
+  InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+      << "Unit " << unit
+      << " not initialized yet. Call InitializeUnit first.";
+  auto exists = gtl::FindOrNull(*l3_egress_intf, egress_intf_id);
+  if (!exists || !*exists) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+        << "Invalid L3 Egress interface "
+        << egress_intf_id << ".";
+  }
+
+  bcmlt_entry_handle_t entry_hdl;
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_allocate(unit, TNL_MPLS_DECAPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLS_LABELs, mpls_label));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, ECMP_IDs, egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, BOS_ACTIONSs, SWAP_ECMPs));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, NON_BOS_ACTIONSs, SWAP_ECMPs));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  return ::util::OkStatus();
+}
+
 ::util::Status BcmSdkWrapper::AddL3HostIpv4(int unit, int vrf, uint32 ipv4,
                                             int class_id, int egress_intf_id) {
   bcmlt_entry_handle_t entry_hdl;
@@ -3751,6 +3866,11 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::ModifyMplsRoute(int unit, int port,
+    uint32 mpls_label, int egress_intf_id) {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << "not implemented";
+}
+
 ::util::Status BcmSdkWrapper::DeleteL3RouteIpv4(int unit, int vrf,
                                                 uint32 subnet, uint32 mask) {
   bcmlt_entry_handle_t entry_hdl;
@@ -3998,6 +4118,12 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::DeleteMplsRoute(int unit, int port,
+    uint32 mpls_label) {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << "not implemented";
+};
+
+
 ::util::StatusOr<int> BcmSdkWrapper::AddMyStationEntry(int unit, int priority,
                                                        int vlan, int vlan_mask,
                                                        uint64 dst_mac,
@@ -4065,6 +4191,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
       bcmlt_entry_field_add(entry_hdl, MAC_ADDR_MASKs, dst_mac_mask));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, IPV4_TERMINATIONs, 1));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, IPV6_TERMINATIONs, 1));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLS_TERMINATIONs, 1));
   RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
                                                 BCMLT_PRIORITY_NORMAL));
   RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.cc
@@ -3387,34 +3387,112 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 }
 
 ::util::Status BcmSdkWrapper::AddMplsRoute(int unit, int port,
-    uint32 mpls_label, int egress_intf_id) {
+    uint32 mpls_label, int egress_intf_id, bool is_intf_multipath) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
   CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
   CHECK_RETURN_IF_FALSE(mpls_label > 0);
 
-  // Check if egress interface is valid
-  InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
-      << "Unit " << unit
-      << " not initialized yet. Call InitializeUnit first.";
-  auto exists = gtl::FindOrNull(*l3_egress_intf, egress_intf_id);
-  if (!exists || !*exists) {
-    return MAKE_ERROR(ERR_INVALID_PARAM)
-        << "Invalid L3 Egress interface "
-        << egress_intf_id << ".";
+  // In SDKLT the MPLS action (POP, SWAP, L3_NHI) is part of the same table
+  // (TNL_MPLS_DECAP) that defines the flow match (port and label). But usually
+  // the actions are allocated before the matches, especially with actions groups.
+  // When a new MPLS route is requested, we therefore look at the next hop given,
+  // and try to deduct the intended action from it.
+  // If egress is an ECMP interface, we have to "pierce through" it to
+  // see what's the real next hop type.
+  uint64 nhop_to_check = egress_intf_id;
+
+  if (!is_intf_multipath) {
+    // Check if egress interface is valid
+    InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+    CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+        << "Unit " << unit
+        << " not initialized yet. Call InitializeUnit first.";
+    auto exists = gtl::FindOrNull(*l3_egress_intf, egress_intf_id);
+    if (!exists || !*exists) {
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+          << "Invalid L3 Egress interface "
+          << egress_intf_id << ".";
+    }
+  } else {
+    // Check if ECMP egress interface is valid
+    InUseMap* ecmp_intfs = gtl::FindOrNull(l3_ecmp_egress_interface_ids_, unit);
+    CHECK_RETURN_IF_FALSE(ecmp_intfs != nullptr)
+        << "Unit " << unit
+        << " not initialized yet. Call InitializeUnit first.";
+    auto exists = gtl::FindOrNull(*ecmp_intfs, egress_intf_id);
+    if (!exists || !*exists) {
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+          << "Invalid L3 ECMP Egress interface "
+          << egress_intf_id << ".";
+    }
+
+    // Fetch first ECMP group member. We assume that an ECMP group only
+    // contains one type of next hops.
+    bcmlt_entry_handle_t entry_hdl;
+    bcmlt_entry_info_t entry_info;
+    RETURN_IF_BCM_ERROR(
+        bcmlt_entry_allocate(unit, ECMPs, &entry_hdl));
+    RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, ECMP_IDs, egress_intf_id));
+    RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_LOOKUP,
+                                          BCMLT_PRIORITY_NORMAL));
+    uint64 nhops[1] = {};
+    uint32 nhop_count = 0;
+    RETURN_IF_BCM_ERROR(bcmlt_entry_field_array_get(entry_hdl, NHOP_IDs, 0, nhops, 1, &nhop_count));
+    RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+    CHECK_RETURN_IF_FALSE(nhop_count != 0) << "Empty ECMP group.";
+    nhop_to_check = nhops[0];
   }
 
+  // Check if egress interface is transit or normal (decap)
+  auto bos_action = INVALIDs;
+  auto non_bos_action = INVALIDs;
   bcmlt_entry_handle_t entry_hdl;
+  bcmlt_entry_info_t entry_info;
   RETURN_IF_BCM_ERROR(
-      bcmlt_entry_allocate(unit, TNL_MPLS_DECAPs, &entry_hdl));
+      bcmlt_entry_allocate(unit, TNL_MPLS_TRANSIT_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, NHOP_IDs, nhop_to_check));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_commit(entry_hdl, BCMLT_OPCODE_LOOKUP,
+                                         BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_info_get(entry_hdl, &entry_info));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+  if (entry_info.status == SHR_E_NONE) {
+    // Transit (LSR) route
+    bos_action = is_intf_multipath ? SWAP_ECMPs : SWAP_NHIs;
+    non_bos_action = is_intf_multipath ? SWAP_ECMPs : SWAP_NHIs;
+    VLOG(1) << "Adding MPLS transit route for label " << mpls_label
+      << " from port " << port << " to egress interface " << egress_intf_id
+      << " on unit " << unit << ".";
+  }
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_allocate(unit, L3_UC_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, NHOP_IDs, nhop_to_check));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_commit(entry_hdl, BCMLT_OPCODE_LOOKUP,
+                                         BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_info_get(entry_hdl, &entry_info));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+  if (entry_info.status == SHR_E_NONE) {
+    // Decap route
+    bos_action = is_intf_multipath ? L3_ECMPs : L3_NHIs;
+    non_bos_action = POPs;
+    VLOG(1) << "Adding MPLS decap route for label " << mpls_label
+      << " from port " << port << " to egress interface " << egress_intf_id
+      << " on unit " << unit << ".";
+  }
+
+  CHECK_RETURN_IF_FALSE(bos_action != INVALIDs && non_bos_action != INVALIDs)
+      << "Could not resolve type of next hop from egress interface "
+      << egress_intf_id << "on unit " << unit;
+
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DECAPs, &entry_hdl));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLS_LABELs, mpls_label));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, IPV4_PAYLOADs, 1));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, ECMP_IDs, egress_intf_id));
-  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, BOS_ACTIONSs, SWAP_ECMPs));
-  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, NON_BOS_ACTIONSs, SWAP_ECMPs));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, BOS_ACTIONSs, bos_action));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, NON_BOS_ACTIONSs, non_bos_action));
   RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
                                                 BCMLT_PRIORITY_NORMAL));
   RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
@@ -3867,7 +3945,8 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 }
 
 ::util::Status BcmSdkWrapper::ModifyMplsRoute(int unit, int port,
-    uint32 mpls_label, int egress_intf_id) {
+    uint32 mpls_label, int egress_intf_id, bool is_intf_multipath) {
+  // TODO(max): implement
   return MAKE_ERROR(ERR_UNIMPLEMENTED) << "not implemented";
 }
 
@@ -4120,7 +4199,19 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 
 ::util::Status BcmSdkWrapper::DeleteMplsRoute(int unit, int port,
     uint32 mpls_label) {
-  return MAKE_ERROR(ERR_UNIMPLEMENTED) << "not implemented";
+  bcmlt_entry_handle_t entry_hdl;
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DECAPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLS_LABELs, mpls_label));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_DELETE,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  VLOG(1) << "Deleted MPLS route for label " << mpls_label << " from port "
+      << port << " on unit " << unit << ".";
+
+  return ::util::OkStatus();
 };
 
 

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
@@ -127,7 +127,7 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::StatusOr<int> FindOrCreateL3RouterIntf(int unit, uint64 router_mac,
                                                  int vlan) override;
   ::util::StatusOr<int> FindOrCreateL3MplsRouterIntf(int unit,
-      uint64 router_mac, int vlan, uint32 mpls_label) override;
+      uint64 router_mac, int vlan, uint32 mpls_label, uint32 mpls_ttl) override;
   ::util::Status DeleteL3RouterIntf(int unit, int router_intf_id) override;
   ::util::StatusOr<int> FindOrCreateL3CpuEgressIntf(int unit) override;
   ::util::StatusOr<int> FindOrCreateL3PortEgressIntf(
@@ -135,6 +135,9 @@ class BcmSdkWrapper : public BcmSdkInterface {
       int router_intf_id) override;
   ::util::StatusOr<int> FindOrCreateL3MplsEgressIntf(
       int unit, uint64 nexthop_mac, int port, int router_intf_id) override;
+  ::util::StatusOr<int> FindOrCreateL3MplsTransitEgressIntf(int unit,
+    uint64 nexthop_mac, int port, int router_intf_id,
+    uint32 mpls_label) override;
   ::util::StatusOr<int> FindOrCreateL3TrunkEgressIntf(
       int unit, uint64 nexthop_mac, int trunk, int vlan,
       int router_intf_id) override;
@@ -170,6 +173,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                int egress_intf_id) override;
   ::util::Status AddL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                int class_id, int egress_intf_id) override;
+  ::util::Status AddMplsRoute(int unit_, int port, uint32 mpls_label,
+                              int egress_intf_id) override;
   ::util::Status ModifyL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask, int class_id,
                                    int egress_intf_id,
@@ -182,6 +187,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                   int egress_intf_id) override;
   ::util::Status ModifyL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                   int class_id, int egress_intf_id) override;
+  ::util::Status ModifyMplsRoute(int unit_, int port, uint32 mpls_label,
+                                 int egress_intf_id) override;
   ::util::Status DeleteL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask) override;
   ::util::Status DeleteL3RouteIpv6(int unit, int vrf, const std::string& subnet,
@@ -189,6 +196,7 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status DeleteL3HostIpv4(int unit, int vrf, uint32 ipv4) override;
   ::util::Status DeleteL3HostIpv6(int unit, int vrf,
                                   const std::string& ipv6) override;
+  ::util::Status DeleteMplsRoute(int unit_, int port, uint32 mpls_label) override;
   ::util::StatusOr<int> AddMyStationEntry(int unit, int priority, int vlan,
                                           int vlan_mask, uint64 dst_mac,
                                           uint64 dst_mac_mask) override;

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
@@ -126,11 +126,15 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status SetMtu(int unit, int mtu) override LOCKS_EXCLUDED(data_lock_);
   ::util::StatusOr<int> FindOrCreateL3RouterIntf(int unit, uint64 router_mac,
                                                  int vlan) override;
+  ::util::StatusOr<int> FindOrCreateL3MplsRouterIntf(int unit,
+      uint64 router_mac, int vlan, uint32 mpls_label) override;
   ::util::Status DeleteL3RouterIntf(int unit, int router_intf_id) override;
   ::util::StatusOr<int> FindOrCreateL3CpuEgressIntf(int unit) override;
   ::util::StatusOr<int> FindOrCreateL3PortEgressIntf(
       int unit, uint64 nexthop_mac, int port, int vlan,
       int router_intf_id) override;
+  ::util::StatusOr<int> FindOrCreateL3MplsEgressIntf(
+      int unit, uint64 nexthop_mac, int port, int router_intf_id) override;
   ::util::StatusOr<int> FindOrCreateL3TrunkEgressIntf(
       int unit, uint64 nexthop_mac, int trunk, int vlan,
       int router_intf_id) override;
@@ -139,7 +143,9 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status ModifyL3PortEgressIntf(int unit, int egress_intf_id,
                                         uint64 nexthop_mac, int port, int vlan,
                                         int router_intf_id) override;
-
+  ::util::Status ModifyL3MplsEgressIntf(int unit, int egress_intf_id,
+                                        uint64 nexthop_mac, int port,
+                                        int router_intf_id) override;
   ::util::Status ModifyL3TrunkEgressIntf(int unit, int egress_intf_id,
                                          uint64 nexthop_mac, int trunk,
                                          int vlan, int router_intf_id) override;
@@ -497,11 +503,14 @@ class BcmSdkWrapper : public BcmSdkInterface {
   absl::flat_hash_map<int, int> unit_to_l3_intf_min_limit_
       GUARDED_BY(data_lock_);
 
-  // Map from unit number to l3 interfaces
+  // Map from unit number to l3 interfaces.
+  // L3_EIF in SDKLT.
   absl::flat_hash_map<int, std::map<L3Interfaces, int>> l3_interface_ids_
       GUARDED_BY(data_lock_);
 
-  // Map from unit number to l3 egress interfaces
+  // Map from unit number to l3 egress interfaces.
+  // NHOP_ID in SDKLT. Unique across tables L3_UC_NHOP, TNL_MPLS_ENCAP_NHOP,
+  // TNL_MPLS_TRANSIT_NHOP.
   absl::flat_hash_map<int, InUseMap> l3_egress_interface_ids_
       GUARDED_BY(data_lock_);
 

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
@@ -174,7 +174,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status AddL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                int class_id, int egress_intf_id) override;
   ::util::Status AddMplsRoute(int unit_, int port, uint32 mpls_label,
-                              int egress_intf_id) override;
+                              int egress_intf_id,
+                              bool is_intf_multipath) override;
   ::util::Status ModifyL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask, int class_id,
                                    int egress_intf_id,
@@ -188,7 +189,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status ModifyL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                   int class_id, int egress_intf_id) override;
   ::util::Status ModifyMplsRoute(int unit_, int port, uint32 mpls_label,
-                                 int egress_intf_id) override;
+                                 int egress_intf_id,
+                                 bool is_intf_multipath) override;
   ::util::Status DeleteL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask) override;
   ::util::Status DeleteL3RouteIpv6(int unit, int vrf, const std::string& subnet,

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -168,6 +168,7 @@ BcmField::Type GetBcmFieldType(P4FieldType p4_field_type) {
           {P4_FIELD_TYPE_L3_CLASS_ID, BcmField::L3_DST_CLASS_ID},
           {P4_FIELD_TYPE_CLONE_PORT, BcmField::CLONE_PORT},
           {P4_FIELD_TYPE_MPLS_LABEL, BcmField::MPLS_LABEL},
+          {P4_FIELD_TYPE_MPLS_BOS, BcmField::MPLS_BOS},
           // Currently unsupported field types below.
           {P4_FIELD_TYPE_IPV4_IHL, BcmField::UNKNOWN},
           {P4_FIELD_TYPE_IPV4_TOTAL_LENGTH, BcmField::UNKNOWN},
@@ -866,7 +867,7 @@ namespace {
               break;
             }
             case P4_FIELD_TYPE_VLAN_VID:
-              bcm_non_multipath_nexthop->set_vlan(field.u32());
+              bcm_non_multipath_nexthop->set_vlan(field.u32() + field.u64());
               break;
             case P4_FIELD_TYPE_L3_CLASS_ID:
               // TODO: Ignore class_id for now till we have a

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -167,6 +167,7 @@ BcmField::Type GetBcmFieldType(P4FieldType p4_field_type) {
           {P4_FIELD_TYPE_ICMP_TYPE, BcmField::ICMP_TYPE_CODE},
           {P4_FIELD_TYPE_L3_CLASS_ID, BcmField::L3_DST_CLASS_ID},
           {P4_FIELD_TYPE_CLONE_PORT, BcmField::CLONE_PORT},
+          {P4_FIELD_TYPE_MPLS_LABEL, BcmField::MPLS_LABEL},
           // Currently unsupported field types below.
           {P4_FIELD_TYPE_IPV4_IHL, BcmField::UNKNOWN},
           {P4_FIELD_TYPE_IPV4_TOTAL_LENGTH, BcmField::UNKNOWN},
@@ -872,8 +873,10 @@ namespace {
               // resolution for b/73264766.
               break;
             case P4_FIELD_TYPE_MPLS_LABEL:
-              // TODO(max):
               bcm_non_multipath_nexthop->set_mpls_label(field.u32());
+              break;
+            case P4_FIELD_TYPE_MPLS_TTL:
+              bcm_non_multipath_nexthop->set_mpls_ttl(field.u32());
               break;
             default:
               return MAKE_ERROR(ERR_INVALID_PARAM)
@@ -2320,6 +2323,8 @@ BcmTableManager::GetBcmMultipathNexthopInfo(uint32 group_id) const {
     case P4_TABLE_L2_MY_STATION:
       bcm_table_type = BcmFlowEntry::BCM_TABLE_MY_STATION;
       break;
+    case P4_TABLE_MPLS:
+      bcm_table_type = BcmFlowEntry::BCM_TABLE_MPLS;
     default:
       break;
   }

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -871,6 +871,10 @@ namespace {
               // TODO: Ignore class_id for now till we have a
               // resolution for b/73264766.
               break;
+            case P4_FIELD_TYPE_MPLS_LABEL:
+              // TODO(max):
+              bcm_non_multipath_nexthop->set_mpls_label(field.u32());
+              break;
             default:
               return MAKE_ERROR(ERR_INVALID_PARAM)
                      << "Invalid or unsupported P4 field type to modify: "

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -838,6 +838,9 @@ namespace {
             case P4_FIELD_TYPE_ETH_DST:
               bcm_non_multipath_nexthop->set_dst_mac(field.u64());
               break;
+            case P4_FIELD_TYPE_ETH_TYPE:
+              // TODO: accept as part of action, but ignore for now
+              break;
             case P4_FIELD_TYPE_EGRESS_PORT: {
               uint32 port_id = static_cast<uint32>(field.u32() + field.u64());
               const int* port = nullptr;
@@ -878,6 +881,12 @@ namespace {
               break;
             case P4_FIELD_TYPE_MPLS_TTL:
               bcm_non_multipath_nexthop->set_mpls_ttl(field.u32());
+              break;
+            case P4_FIELD_TYPE_MPLS_BOS:
+              // TODO: accept as part of action, but ignore for now
+              break;
+            case P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS:
+              // TODO: accept as part of action, but ignore for now
               break;
             default:
               return MAKE_ERROR(ERR_INVALID_PARAM)

--- a/stratum/hal/lib/p4/p4_table_map.proto
+++ b/stratum/hal/lib/p4/p4_table_map.proto
@@ -346,6 +346,7 @@ message P4ActionDescriptor {
     TunnelFieldValue ecn_value = 4;
     TunnelFieldValue dscp_value = 5;
     TunnelFieldValue ttl_value = 6;
+    bool is_mpls_tunnel = 7;
 
     oneof encap_or_decap {
       EncapProperties encap = 10;

--- a/stratum/hal/lib/p4/p4_table_mapper.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper.cc
@@ -161,12 +161,14 @@ P4TableMapper::~P4TableMapper() { Shutdown().IgnoreError(); }
         if (!conversion_found) {
           // TODO(unknown): For now, assume this is due to in-progress
           // table map file development.
+          // FIXME
           LOG(WARNING) << "Match field " << match_field.ShortDebugString()
                        << " in table " << table.preamble().name()
                        << " has no known mapping conversion";
         }
       } else {
         // TODO(unknown): Not all fields are defined yet, so just warn.
+        // FIXME
         LOG(WARNING) << "P4TableMapper is ignoring match field "
                      << match_field.ShortDebugString() << " in table "
                      << table.preamble().name();

--- a/stratum/p4c_backends/fpm/map_data/standard_parser_map.pb.txt
+++ b/stratum/p4c_backends/fpm/map_data/standard_parser_map.pb.txt
@@ -1,11 +1,11 @@
 # Copyright 2019 Google LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -257,10 +257,51 @@ parser_states {
           next_state: "target_parse_arp"
         }
         cases {
+          keyset_values {
+            constant {
+              value: 0x8847
+              mask: 1
+            }
+          }
+          next_state: "target_parse_mpls"
+        }
+        cases {
           is_default: true
           next_state: "accept"
         }
       }
+    }
+  }
+}
+parser_states {
+  key: "target_parse_mpls"
+  value {
+    name: "target_parse_mpls"
+    extracted_header {
+      name: "MPLS Header"
+      header_type: P4_HEADER_MPLS
+      fields {
+        type: P4_FIELD_TYPE_MPLS_LABEL
+        bit_width: 20
+      }
+      fields {
+        type: P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS
+        bit_offset: 20
+        bit_width: 3
+      }
+      fields {
+        type: P4_FIELD_TYPE_MPLS_BOS
+        bit_offset: 23
+        bit_width: 1
+      }
+      fields {
+        type: P4_FIELD_TYPE_MPLS_TTL
+        bit_offset: 24
+        bit_width: 8
+      }
+    }
+    transition {
+      next_state: "accept"
     }
   }
 }

--- a/stratum/p4c_backends/fpm/tunnel_type_mapper.h
+++ b/stratum/p4c_backends/fpm/tunnel_type_mapper.h
@@ -85,6 +85,8 @@ class TunnelTypeMapper {
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
   bool FindGreHeader(
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
+  bool FindMplsHeader(
+      const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
   bool FindInnerDecapHeader(
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
 
@@ -135,6 +137,7 @@ class TunnelTypeMapper {
   std::string action_name_;
   hal::P4ActionDescriptor::P4TunnelProperties p4_tunnel_properties_;
   P4HeaderOp gre_header_op_;
+  P4HeaderOp mpls_header_op_;
   bool is_encap_;
   bool is_decap_;
   std::vector<int> optimized_assignments_;

--- a/stratum/public/proto/p4_annotation.proto
+++ b/stratum/public/proto/p4_annotation.proto
@@ -53,6 +53,7 @@ message P4Annotation {
     ENCAP = 6;
     DECAP = 7;
     HIDDEN = 8;
+    L3_MPLS = 9;
   }
 
   // Defines the hardware pipeline stage of an entity.

--- a/stratum/public/proto/p4_table_defs.proto
+++ b/stratum/public/proto/p4_table_defs.proto
@@ -56,6 +56,7 @@ enum P4TableType {
   P4_TABLE_L2_MY_STATION = 4;  // The table that identifies whether a packet
                                // can be L3 routed based on (MAC, VLAN).
   P4_TABLE_L2_UNICAST = 5;     // The unicast logical table in L2 stage.
+  P4_TABLE_MPLS = 6;           // The mpls transit table in L3 stage.
 }
 
 // This enum defines values to identify the table mapping output for match

--- a/stratum/public/proto/p4_table_defs.proto
+++ b/stratum/public/proto/p4_table_defs.proto
@@ -152,6 +152,11 @@ enum P4FieldType {
   P4_FIELD_TYPE_DNS_AUTHORITY_RRS = 84;   // Number of NS RRs pointing towards authorities
   P4_FIELD_TYPE_DNS_ADDITIONAL_RRS = 85;  // Number of additional RRs
 
+  P4_FIELD_TYPE_MPLS_LABEL = 90;
+  P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS = 91;
+  P4_FIELD_TYPE_MPLS_BOS = 92;
+  P4_FIELD_TYPE_MPLS_TTL = 93;
+
   // Field IDs over 1000 are reserved for adding more fields to existing
   // headers without renumbering.  Example: P4_FIELD_TYPE_GRE_SEQUENCE.
 }
@@ -175,6 +180,7 @@ enum P4HeaderType {
   P4_HEADER_ERSPAN = 13;
   P4_HEADER_DNS = 14;
   P4_HEADER_L4_PAYLOAD = 15;
+  P4_HEADER_MPLS = 16;
 }
 
 // This enum defines values to identify the mapping output for P4 actions.

--- a/stratum/public/proto/p4_table_defs.proto
+++ b/stratum/public/proto/p4_table_defs.proto
@@ -153,10 +153,10 @@ enum P4FieldType {
   P4_FIELD_TYPE_DNS_AUTHORITY_RRS = 84;   // Number of NS RRs pointing towards authorities
   P4_FIELD_TYPE_DNS_ADDITIONAL_RRS = 85;  // Number of additional RRs
 
-  P4_FIELD_TYPE_MPLS_LABEL = 90;
-  P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS = 91;
-  P4_FIELD_TYPE_MPLS_BOS = 92;
-  P4_FIELD_TYPE_MPLS_TTL = 93;
+  P4_FIELD_TYPE_MPLS_LABEL = 90;          // MPLS label
+  P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS = 91;  // MPLS traffic class
+  P4_FIELD_TYPE_MPLS_BOS = 92;            // MPLS bottom of stack bit
+  P4_FIELD_TYPE_MPLS_TTL = 93;            // MPLS TTL
 
   // Field IDs over 1000 are reserved for adding more fields to existing
   // headers without renumbering.  Example: P4_FIELD_TYPE_GRE_SEQUENCE.


### PR DESCRIPTION
Blocked by #20 

This PR adds basic MPLS support to the bcm variant of stratum.
The supported actions are encapsulation, transit and decapsulation of IPv4 and single-label MPLS traffic.

The sample [P4 implementation](https://github.com/opennetworkinglab/stratum-onos-demo/compare/mpls?expand=1) works on both Tomahawk and Tofino switches.


### Encap

P4Runtime requests:

```
am = action_profile_member['ingress.l3_fwd.wcmp_action_profile'](action='encap_mpls', member_id=1)
am.action['port'] = "62"
am.action['smac'] = "00:00:00:aa:aa:aa"
am.action['dmac'] = "00:00:00:00:00:04"
am.action['mpls_label'] = "300"
am.action['mpls_ttl'] = "64"
am.insert()

ag = action_profile_group["ingress.l3_fwd.wcmp_action_profile"](group_id=1)
ag.add(1)
ag.insert()

te = table_entry["ingress.l3_fwd.l3_fwd_table"]
te.match['local_metadata.vrf_id'] = '0'
te.match['hdr.ipv4_base.dst_addr'] = '10.2.0.0/16'
te.group_id = 1
te.insert()

te = table_entry['ingress.my_station_table'](action='set_l3_admit')
te.match['hdr.ethernet.dst_addr'] = '00:00:00:bb:bb:bb'
te.priority = 10
te.insert()
```

Tcpdump:

```
3c:fd:fe:9d:f1:48 > 00:00:00:bb:bb:bb, ethertype IPv4 (0x0800), length 65: (tos 0x0, ttl 10, id 1, offset 0, flags [none], proto TCP (6), length 51)
    10.1.0.1.20 > 10.2.0.1.80: Flags [S], cksum 0x3388 (correct), seq 0:11, win 8192, length 11: HTTP
	0x0000:  0000 00bb bbbb 3cfd fe9d f148 0800 4500
	0x0010:  0033 0001 0000 0a06 9cc0 0a01 0001 0a02
	0x0020:  0001 0014 0050 0000 0000 0000 0000 5002
	0x0030:  2000 3388 0000 6161 6161 6161 6161 6161
	0x0040:  61

00:00:00:aa:aa:aa > 00:00:00:00:00:04, ethertype MPLS unicast (0x8847), length 69: MPLS (label 300, exp 7, [S], ttl 64)
	(tos 0x0, ttl 9, id 1, offset 0, flags [none], proto TCP (6), length 51)
    10.1.0.1.20 > 10.2.0.1.80: Flags [S], cksum 0x3388 (correct), seq 0:11, win 8192, length 11: HTTP
	0x0000:  0000 0000 0004 0000 00aa aaaa 8847 0012
	0x0010:  cf40 4500 0033 0001 0000 0906 9dc0 0a01
	0x0020:  0001 0a02 0001 0014 0050 0000 0000 0000
	0x0030:  0000 5002 2000 3388 0000 6161 6161 6161
	0x0040:  6161 6161 61
```

### Transit

P4Runtime requests:

```
am = action_profile_member['ingress.l3_fwd.mpls_ecmp_action_profile'](action='swap_mpls', member_id=2)
am.action['port'] = "62"
am.action['smac'] = "00:00:00:aa:aa:aa"
am.action['dmac'] = "00:00:00:00:00:04"
am.action['mpls_label'] = "200"
am.insert()

ag = action_profile_group["ingress.l3_fwd.mpls_ecmp_action_profile"](group_id=2)
ag.add(2)
ag.insert()

te = table_entry['ingress.l3_fwd.l3_mpls_table']
te.match['standard_metadata.ingress_port'] = '58'
te.match['hdr.mpls.label'] = '100'
te.group_id = 2
te.insert()

te = table_entry['ingress.my_station_table'](action='set_l3_admit')
te.match['hdr.ethernet.dst_addr'] = '00:00:00:bb:bb:bb'
te.priority = 10
te.insert()
```

Tcpdump:
```
3c:fd:fe:9d:f1:48 > 00:00:00:bb:bb:bb, ethertype MPLS unicast (0x8847), length 38: MPLS (label 100, exp 0, [S], ttl 64)
	(tos 0x0, ttl 10, id 1, offset 0, flags [none], proto Options (0), length 20)
    10.1.0.1 > 10.2.0.1:  ip-proto-0 0
	0x0000:  0000 00bb bbbb 0000 0000 0000 8847 0006
	0x0010:  4140 4500 0014 0001 0000 0a00 9ce5 0a01
	0x0020:  0001 0a02 0001

00:00:00:aa:aa:aa > 00:00:00:00:00:04, ethertype MPLS unicast (0x8847), length 60: MPLS (label 200, exp 0, [S], ttl 63)
	(tos 0x0, ttl 10, id 1, offset 0, flags [none], proto Options (0), length 20)
    10.1.0.1 > 10.2.0.1:  ip-proto-0 0
	0x0000:  0000 0000 0004 0000 00aa aaaa 8847 000c
	0x0010:  813f 4500 0014 0001 0000 0a00 9ce5 0a01
	0x0020:  0001 0a02 0001 0000 0000 0000 0000 0000
	0x0030:  0000 0000 0000 0000 0000 0000
```

### Decap

P4Runtime requests:

```
am = action_profile_member['ingress.l3_fwd.mpls_ecmp_action_profile'](action='decap_mpls', member_id=3)
am.action['port'] = "62"
am.action['smac'] = "00:00:00:aa:aa:aa"
am.action['dmac'] = "00:00:00:00:00:04"
am.insert()

ag = action_profile_group["ingress.l3_fwd.mpls_ecmp_action_profile"](group_id=3)
ag.add(3)
ag.insert()

te = table_entry['ingress.l3_fwd.l3_mpls_table']
te.match['standard_metadata.ingress_port'] = '58'
te.match['hdr.mpls.label'] = '400'
te.group_id = 3
te.insert()

te = table_entry['ingress.my_station_table'](action='set_l3_admit')
te.match['hdr.ethernet.dst_addr'] = '00:00:00:bb:bb:bb'
te.priority = 10
te.insert()
```

Tcpdump:
```
3c:fd:fe:9d:f1:48 > 00:00:00:bb:bb:bb, ethertype MPLS unicast (0x8847), length 38: MPLS (label 400, exp 0, [S], ttl 64)
	(tos 0x0, ttl 10, id 1, offset 0, flags [none], proto Options (0), length 20)
    10.1.0.1 > 10.2.0.1:  ip-proto-0 0
	0x0000:  0000 00bb bbbb 0000 0000 0000 8847 0019
	0x0010:  0140 4500 0014 0001 0000 0a00 9ce5 0a01
	0x0020:  0001 0a02 0001

00:00:00:aa:aa:aa > 00:00:00:00:00:04, ethertype IPv4 (0x0800), length 60: (tos 0x0, ttl 10, id 1, offset 0, flags [none], proto Options (0), length 20)
    10.1.0.1 > 10.2.0.1:  ip-proto-0 0
	0x0000:  0000 0000 0004 0000 00aa aaaa 0800 4500
	0x0010:  0014 0001 0000 0a00 9ce5 0a01 0001 0a02
	0x0020:  0001 0000 0000 0000 0000 0000 0000 0000
	0x0030:  0000 0000 0000 0000 0000 0000
```