### PR TITLE
Implement handling of action annotations

### DIFF
--- a/stratum/p4c_backends/fpm/annotation_mapper.cc
+++ b/stratum/p4c_backends/fpm/annotation_mapper.cc
@@ -257,8 +257,6 @@ bool AnnotationMapper::MapActionAnnotation(const std::string& annotation,
       *action_descriptor->add_device_data() = device_data;
     }
 
-    // TODO(max): Check if assignment or primitive_op already exists and replace.
-    LOG(WARNING) << "P4ActionAddenda replacements are not implemented for " << annotation;
     if (action_addendum->has_assignments_addenda()) {
       *action_descriptor->add_assignments() = action_addendum->assignments_addenda();
     }

--- a/stratum/p4c_backends/fpm/annotation_mapper.cc
+++ b/stratum/p4c_backends/fpm/annotation_mapper.cc
@@ -107,6 +107,7 @@ bool AnnotationMapper::ProcessAnnotations(
             table_map_iter.first, p4_info_manager,
             table_map_iter.second.mutable_action_descriptor()))
           success = false;
+        break;
       case hal::P4TableMapValue::kHeaderDescriptor:
         break;
       case hal::P4TableMapValue::kInternalAction:
@@ -260,7 +261,7 @@ bool AnnotationMapper::MapActionAnnotation(const std::string& annotation,
     if (action_addendum->has_assignments_addenda()) {
       *action_descriptor->add_assignments() = action_addendum->assignments_addenda();
     }
-    if (action_addendum->primitive_ops_addenda()) {
+    if (action_addendum->primitive_ops_addenda() != P4_ACTION_TYPE_UNKNOWN) {
       action_descriptor->add_primitive_ops(action_addendum->primitive_ops_addenda());
     }
   }

--- a/stratum/p4c_backends/fpm/annotation_mapper.h
+++ b/stratum/p4c_backends/fpm/annotation_mapper.h
@@ -152,6 +152,15 @@ class AnnotationMapper {
   bool MapTableAnnotation(const std::string& annotation,
                           hal::P4TableDescriptor* table_descriptor);
 
+  // These two methods process any annotations in the given action descriptor,
+  // adjusting the action_descriptor as specified by any annotation mappings
+  // found.
+  bool HandleActionAnnotations(const std::string& action_name,
+                              const hal::P4InfoManager& p4_info_manager,
+                              hal::P4ActionDescriptor* action_descriptor);
+  bool MapActionAnnotation(const std::string& annotation,
+                           hal::P4ActionDescriptor* action_descriptor);
+
   bool initialized_;  // Becomes true after one of the init methods runs.
 
   // This P4AnnotationMap contains the initialized annotations mapping data

--- a/stratum/p4c_backends/fpm/p4c_switch_main.cc
+++ b/stratum/p4c_backends/fpm/p4c_switch_main.cc
@@ -45,7 +45,10 @@ using stratum::p4c_backends::SwitchP4cBackend;
 using stratum::p4c_backends::TableMapGenerator;
 using stratum::p4c_backends::TargetInfo;
 
+DECLARE_int32(stderrthreshold);
+
 int main(int argc, char** argv) {
+  FLAGS_stderrthreshold = 1;
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();
   std::unique_ptr<BcmTargetInfo> bcm_target_info(new BcmTargetInfo);

--- a/stratum/p4c_backends/fpm/testdata/annotation_string_map.pb.txt
+++ b/stratum/p4c_backends/fpm/testdata/annotation_string_map.pb.txt
@@ -25,13 +25,6 @@ table_addenda_map {
     addenda_names: "table-addenda-A1"
   }
 }
-action_addenda_map {
-  key: "action-annotation-1"
-  value {
-    type: P4_ACTION_TYPE_PROFILE_GROUP_ID
-    addenda_names: "action-addenda-A1"
-  }
-}
 field_addenda {
   name: "match-field-addenda-A1"
   device_data {
@@ -43,14 +36,4 @@ table_addenda {
   device_data {
     name: "fake-table-device-data"
   }
-}
-action_addenda {
-  name: "action-addenda-A1"
-  assignments_addenda {
-    assigned_value {
-      constant_param: 1
-    }
-    destination_field_name: "fake-destination-field-name"
-  }
-  assignment_primitive_replace: true
 }

--- a/stratum/p4c_backends/fpm/testdata/annotation_string_map.pb.txt
+++ b/stratum/p4c_backends/fpm/testdata/annotation_string_map.pb.txt
@@ -1,11 +1,11 @@
 # Copyright 2019 Google LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,13 @@ table_addenda_map {
     addenda_names: "table-addenda-A1"
   }
 }
+action_addenda_map {
+  key: "action-annotation-1"
+  value {
+    type: P4_ACTION_TYPE_PROFILE_GROUP_ID
+    addenda_names: "action-addenda-A1"
+  }
+}
 field_addenda {
   name: "match-field-addenda-A1"
   device_data {
@@ -36,4 +43,14 @@ table_addenda {
   device_data {
     name: "fake-table-device-data"
   }
+}
+action_addenda {
+  name: "action-addenda-A1"
+  assignments_addenda {
+    assigned_value {
+      constant_param: 1
+    }
+    destination_field_name: "fake-destination-field-name"
+  }
+  assignment_primitive_replace: true
 }

--- a/stratum/p4c_backends/fpm/testdata/object_name_map.pb.txt
+++ b/stratum/p4c_backends/fpm/testdata/object_name_map.pb.txt
@@ -1,11 +1,11 @@
 # Copyright 2019 Google LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -59,6 +59,32 @@ table_addenda_map {
     addenda_names: "table-addenda-N2"
   }
 }
+action_addenda_map {
+  key: "action-name-with-type"
+  value {
+    type: P4_ACTION_TYPE_FUNCTION
+  }
+}
+action_addenda_map {
+  key: "action-name-with-addenda"
+  value {
+    addenda_names: "action-addenda-N2"
+  }
+}
+action_addenda_map {
+  key: "action-name-with-replace-addenda"
+  value {
+    addenda_names: "action-addenda-N1"
+  }
+}
+action_addenda_map {
+  key: "action-name-with-type-and-multiple-addenda"
+  value {
+    type: P4_ACTION_TYPE_FUNCTION
+    addenda_names: "action-addenda-N1"
+    addenda_names: "action-addenda-N2"
+  }
+}
 field_addenda {
   name: "match-field-addenda-N1"
   device_data {
@@ -83,5 +109,33 @@ table_addenda {
   device_data {
     name: "device-data-name-N2"
     data: "dummy-device-data-in-table-addenda-N2"
+  }
+}
+action_addenda {
+  name: "action-addenda-N1"
+  assignment_primitive_replace: true
+  assignments_addenda {
+    assigned_value {
+      constant_param: 1
+    }
+    destination_field_name: "dummy-destination-field-name-N1"
+  }
+  device_data {
+    name: "device-data-name-N1"
+    data: "dummy-device-data-in-action-addenda-N1"
+  }
+  primitive_ops_addenda: P4_ACTION_OP_DROP
+}
+action_addenda {
+  name: "action-addenda-N2"
+  assignments_addenda {
+    assigned_value {
+      parameter_name: "dummy-parameter-action-name-N2"
+    }
+    destination_field_name: "dummy-destination-field-name-N2"
+  }
+  device_data {
+    name: "device-data-name-N2"
+    data: "dummy-device-data-in-action-addenda-N2"
   }
 }


### PR DESCRIPTION
This PR implements the missing annotations for actions from the `p4c_annotation_map_files` compiler flag. We already had and used annotations for tables and and match fields, with this we can also enhance table actions.

It also sets the default log level for `p4c-fpm` backend messages down to `WARNING` from `ERROR`, which yields important information when using the compiler:

### Example

In our `main.p4` example P4 program, we have the following action to the set next hop in IPv4 routing:

```p4
    action set_nexthop(PortNum port, EthernetAddress smac, EthernetAddress dmac,
                       bit<12> dst_vlan) {
        standard_metadata.egress_spec = port;
        local_metadata.dst_vlan = dst_vlan;
        hdr.ethernet.src_addr = smac;
        hdr.ethernet.dst_addr = dmac;
        hdr.ipv4_base.ttl = hdr.ipv4_base.ttl - 1;
    }
```

The `dst_vlan` parameter is only there because BCM operates on VLANs internally and we have to get the default VLAN id into the action somehow. `main.p4` does not use VLAN tags in incomming or outgoing packets, the VLAN id here is purely an implementation detail of stratum_bcm.

By using action annotations we can hide these details from the P4 program, when not needed:

In the table map file, we add the following addenda:

```
action_addenda_map {
  key: "ingress.l3_fwd.set_nexthop"
  value {
    addenda_names: "default-vlan-action-fallback"
  }
}

# Defines an internal action parameter on the default VLAN ID
action_addenda {
  name: "default-vlan-action-fallback"
  assignments_addenda {
    assigned_value {
      constant_param: 1
    }
    destination_field_name: "local_metadata.dst_vlan"
  }
}
```

This will be incorporated into the bcm pipeline config, so that stratum_bcm knows to add a vlan ID of 1 to all `set_nexthop` actions: 
```
table_map {
  key: "ingress.l3_fwd.set_nexthop"
  value {
    action_descriptor {
      type: P4_ACTION_TYPE_FUNCTION
      [...]
      assignments {
        assigned_value {
          constant_param: 1
        }
        destination_field_name: "local_metadata.dst_vlan"
      }
    }
  }
}
```

The action then is simplified to:

```p4
    action set_nexthop(PortNum port, EthernetAddress smac, EthernetAddress dmac) {
        standard_metadata.egress_spec = port;
        hdr.ethernet.src_addr = smac;
        hdr.ethernet.dst_addr = dmac;
        hdr.ipv4_base.ttl = hdr.ipv4_base.ttl - 1;
    }
```