### PR TITLE
update d10056-r0.json file

### DIFF
--- a/stratum/hal/bin/barefoot/platforms/x86-64-inventec-d10056-r0.json
+++ b/stratum/hal/bin/barefoot/platforms/x86-64-inventec-d10056-r0.json
@@ -1112,7 +1112,7 @@
         "mac_ch": 2,
         "tx_lane": 3,
         "tx_pn_swap": 1,
-        "rx_lane": 2,
+        "rx_lane": 3,
         "rx_pn_swap": 0,
         "serdes_params": {
             "tx_eq_pre": 4,


### PR DESCRIPTION
Typo when creating the json file.
rx_lane and tx_lane  had a mismatch, the value should be 3 for both.
When running in docker or bspless mode got an error related to serdes config.