### PR TITLE
Update .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,14 @@
-build --conlyopt='-std=gnu11' --cxxopt='-std=gnu++11'
+# General build options
+build --conlyopt='-std=gnu11'
+build --cxxopt='-std=gnu++11'
+build --copt -Wall
+build --copt -Wno-sign-compare
+
+# Address sanitizer
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address

--- a/.circleci/bazelrc
+++ b/.circleci/bazelrc
@@ -25,5 +25,3 @@ build --profile=/tmp/bazel.profile
 # Coverage
 coverage --combined_report=lcov --coverage_report_generator @bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main
 
-# C options
-build --conlyopt='-std=gnu11' --cxxopt='-std=gnu++11'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ store_bazel_profile: &store_bazel_profile
 set_bazelrc: &set_bazelrc
   run:
     name: Set bazelrc
-    command: cp .circleci/bazelrc .bazelrc
+    command: cat .circleci/bazelrc >> .bazelrc
 
 # Convenience anchors to update published Docker images. Images are first pulled
 # to allow for layer cache hits and reduce build times.


### PR DESCRIPTION
This PR enables "all" compiler warnings and add a ASAN build mode.

Currently this creates a lot of output during compilation from scratch, but is very useful when working on a few files only. In the future we want per-target flags so we don't get warnings for library code, but this serves as intermediate step. We could also add -Werror flags for certain warnings.

ASAN mode only works with clang, but is disabled by default. ASAN builds of stratum have successfully been tested on real hardware without issues (apart from the detected ones).