### PR TITLE
Enable loopback option to BCM target

### DIFF
--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -39,6 +39,12 @@ message BcmPortOptions {
     LINKSCAN_MODE_HW = 2;
     LINKSCAN_MODE_NONE = 3;
   }
+  enum LoopbackMode {
+    LOOPBACK_UNKNOWN = 0;
+    LOOPBACK_NONE = 1;
+    LOOPBACK_MAC = 2;
+    LOOPBACK_PHY = 3;
+  }
   // Is the port enabled?
   TriState enabled = 1;
   // Is the port blocked?
@@ -56,6 +62,8 @@ message BcmPortOptions {
   int32 num_serdes_lanes = 7;
   // Linkscan mode.
   LinkscanMode linkscan_mode = 8;
+  // The loopback mode for this port.
+  LoopbackMode loopback_mode = 9;
 };
 
 // Encapsulates all chassis-level properties (common to all chips on the
@@ -156,6 +164,8 @@ message BcmPort {
   bool internal = 20;
   // Port-level SDK properties (optional).
   repeated string sdk_properties = 21;
+  // Port options
+  BcmPortOptions port_options = 22;
 }
 
 // Defines a chassis map for a BCM-based platform.

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -267,6 +267,12 @@ message PortConfigParams {
     PORT_MODULATION_NRZ = 1;
     PORT_MODULATION_PAM4 = 2;
   }
+  enum LoopbackMode {
+    LOOPBACK_UNKNOWN = 0;
+    LOOPBACK_NONE = 1;
+    LOOPBACK_MAC = 2;
+    LOOPBACK_PHY = 3;
+  }
   // The configured admin state for this port.
   AdminState admin_state = 1;
   // The per port MTU (aka max frame size) for this port.
@@ -281,6 +287,8 @@ message PortConfigParams {
   FecMode fec_mode = 6;
   // The configured mac address for this port.
   uint64 mac_address = 7;
+  // The loopback mode for this port.
+  LoopbackMode loopback_mode = 8;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,


### PR DESCRIPTION
Adds loop back option to both chassis config and BCM chassis map