### PR TITLE
CI: Lower bazel cpu usage

### DIFF
--- a/.circleci/bazelrc
+++ b/.circleci/bazelrc
@@ -5,8 +5,8 @@ startup --output_user_root=/tmp/bazel-cache/output-root
 
 # Bazel doesn't calculate resource ceiling correctly when running under Docker.
 # Memory, CPU cores, disk I/O
-build --local_resources=3072,2.0,1.0
-build --jobs=2
+build --local_resources=3072,1.0,1.0
+build --jobs=1
 
 # Also limit memory allocated to the JVM
 startup --host_jvm_args=-Xmx3g --host_jvm_args=-Xms2g


### PR DESCRIPTION
CircleCI seems to aggressively killing jobs that consume too many resources. This reduces the usage to a minimum.