### PR TITLE
ONLP: Fix SFP info strings

### DIFF
--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
@@ -334,7 +334,7 @@ void SfpInfo::GetModuleCaps(SfpModuleCaps* caps) const {
 
 ::util::StatusOr<const SffInfo*> SfpInfo::GetSffInfo() const {
   CHECK_RETURN_IF_FALSE(sfp_info_.sff.sfp_type != SFF_SFP_TYPE_INVALID)
-      << "Cannot get SFF info: Invalid SFP type: " << sfp_info_.sff.sfp_type;
+      << "Cannot get SFF info: Invalid SFP type.";
   return &sfp_info_.sff;
 }
 

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
@@ -18,6 +18,7 @@
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/lib/macros.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/strip.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 
@@ -302,6 +303,26 @@ SfpModuleType SfpInfo::GetSfpModuleType()const {
   }
 }
 
+namespace {
+absl::string_view TrimSuffix(absl::string_view str, absl::string_view suffix) {
+  while (absl::ConsumeSuffix(&str, suffix)) {
+  }
+  return str;
+}
+}  // namespace
+
+std::string SfpInfo::GetSfpVendor() const {
+  return std::string(TrimSuffix(sfp_info_.sff.vendor, " "));
+}
+
+std::string SfpInfo::GetSfpModel() const {
+  return std::string(TrimSuffix(sfp_info_.sff.model, " "));
+}
+
+std::string SfpInfo::GetSfpSerialNumber() const {
+  return std::string(TrimSuffix(sfp_info_.sff.serial, " "));
+}
+
 void SfpInfo::GetModuleCaps(SfpModuleCaps* caps) const {
   // set all relevant capabilities flags
   caps->set_f_100(sfp_info_.sff.caps & SFF_MODULE_CAPS_F_100);
@@ -313,7 +334,7 @@ void SfpInfo::GetModuleCaps(SfpModuleCaps* caps) const {
 
 ::util::StatusOr<const SffInfo*> SfpInfo::GetSffInfo() const {
   CHECK_RETURN_IF_FALSE(sfp_info_.sff.sfp_type != SFF_SFP_TYPE_INVALID)
-      << "Cannot get SFF info: Invalid SFP type.";
+      << "Cannot get SFF info: Invalid SFP type: " << sfp_info_.sff.sfp_type;
   return &sfp_info_.sff;
 }
 

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.h
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.h
@@ -83,6 +83,9 @@ class SfpInfo : public OidInfo {
   MediaType GetMediaType() const;
   SfpType GetSfpType() const;
   SfpModuleType GetSfpModuleType() const;
+  std::string GetSfpVendor() const;
+  std::string GetSfpModel() const;
+  std::string GetSfpSerialNumber() const;
   void GetModuleCaps(SfpModuleCaps* caps) const;
 
   // The lifetimes of pointers returned by these functions are managed by this

--- a/stratum/hal/lib/phal/onlp/sfp_datasource.cc
+++ b/stratum/hal/lib/phal/onlp/sfp_datasource.cc
@@ -105,9 +105,9 @@ OnlpSfpDataSource::OnlpSfpDataSource(int sfp_id,
   sfp_desc_.AssignValue(std::string(oid_info->description));
 
   ASSIGN_OR_RETURN(const SffInfo* sff_info, sfp_info.GetSffInfo());
-  sfp_vendor_.AssignValue(std::string(sff_info->vendor));
-  sfp_serial_number_.AssignValue(std::string(sff_info->serial));
-  sfp_model_name_.AssignValue(std::string(sff_info->model));
+  sfp_vendor_.AssignValue(sfp_info.GetSfpVendor());
+  sfp_serial_number_.AssignValue(sfp_info.GetSfpSerialNumber());
+  sfp_model_name_.AssignValue(sfp_info.GetSfpModel());
   media_type_ = sfp_info.GetMediaType();
   sfp_connector_type_ = sfp_info.GetSfpType();
   sfp_module_type_ = sfp_info.GetSfpModuleType();


### PR DESCRIPTION
ONLPv2 reports strings with trailing spaces, this commit adds getter functions that strip these.