### PR TITLE
Bump version of PI, bmv2, and P4Runtime

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -15,8 +15,8 @@
 #
 
 ARG BAZEL_VERSION=0.23.2
-ARG PI_COMMIT=0bcaeda2269a4f2f0539cf8eac49868e389a8c18
-ARG BMV2_COMMIT=10c2d3434a7212631f11d5d1e3bc802ba6365f6a
+ARG PI_COMMIT=1539ecd8a50c159b011d9c5a9c0eba99f122a845
+ARG BMV2_COMMIT=9ef324838b29419040b4f677a3ff65bc72405c44
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch main"
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -23,8 +23,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
      "new_git_repository")
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
-P4RUNTIME_VER = "1.0.0"
-P4RUNTIME_SHA = "667464bd369b40b58dc9552be2c84e190a160b6e77137b735bd86e5b81c6adc0"
+P4RUNTIME_VER = "1.1.0-rc.1"
+P4RUNTIME_SHA = "fb4eb0767ea9e9697b2359be6979942c54abf64187a2d0f5ff61f227500ec195"
 
 GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
 GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108"
@@ -95,7 +95,7 @@ def stratum_deps():
         remote_workspace(
             name = "com_github_p4lang_PI",
             remote = "https://github.com/p4lang/PI.git",
-            commit = "ca0291420b5b47fa2596a00877d1713aab61dc7a",
+            commit = "1539ecd8a50c159b011d9c5a9c0eba99f122a845",
         )
 
     if "com_github_p4lang_PI_bf" not in native.existing_rules():

--- a/stratum/hal/bin/bmv2/README.md
+++ b/stratum/hal/bin/bmv2/README.md
@@ -33,8 +33,9 @@ make [-j4]
 [sudo] make install
 [sudo ldconfig]
 ```
-The *master* branch should work for this repo, but you can also used the commit
-we used for testing: ca0291420b5b47fa2596a00877d1713aab61dc7a.
+The *master* branch should work for this repo. Otherwise, you can use the
+commit we use for testing, which is specified in the `Dockerfile.build` file in
+the root of this repo (look for `ARG PI_COMMIT=...` at the top of the file).
 
 ### Install bmv2
 ```
@@ -46,8 +47,9 @@ make [-j4]
 [sudo] make install
 [sudo ldconfig]
 ```
-The *master* branch should work for this repo, but you can also used the commit
-we used for testing: 6f700badd1c5040d04dec24f446982ad63fa64c9.
+The *master* branch should work for this repo. Otherwise, you can use the
+commit we use for testing, which is specified in the `Dockerfile.build` file in
+the root of this repo (look for `ARG BMV2_COMMIT=...` at the top of the file).
 
 ## Building the `stratum_bmv2` binary
 

--- a/tools/mininet/examples/trellis/README.md
+++ b/tools/mininet/examples/trellis/README.md
@@ -125,27 +125,27 @@ onos> apps -a -s
 Make sure you see the following list of apps displayed:
 
 ```
-*   5 org.onosproject.protocols.grpc        2.1.0    gRPC Protocol Subsystem
-*   6 org.onosproject.protocols.gnmi        2.1.0    gNMI Protocol Subsystem
-*   7 org.onosproject.route-service         2.1.0    Route Service Server
-*  20 org.onosproject.drivers               2.1.0    Default Drivers
-*  24 org.onosproject.generaldeviceprovider 2.1.0    General Device Provider
-*  25 org.onosproject.protocols.p4runtime   2.1.0    P4Runtime Protocol Subsystem
-*  26 org.onosproject.p4runtime             2.1.0    P4Runtime Provider
-*  27 org.onosproject.drivers.p4runtime     2.1.0    P4Runtime Drivers
-*  34 org.onosproject.protocols.gnoi        2.1.0    gNOI Protocol Subsystem
-*  45 org.onosproject.hostprovider          2.1.0    Host Location Provider
-*  46 org.onosproject.lldpprovider          2.1.0    LLDP Link Provider
-*  59 org.onosproject.drivers.gnoi          2.1.0    gNOI Drivers
-*  63 org.onosproject.drivers.gnmi          2.1.0    gNMI Drivers
-*  64 org.onosproject.pipelines.basic       2.1.0    Basic Pipelines
-*  65 org.onosproject.drivers.stratum       2.1.0    Stratum Drivers
-*  94 org.onosproject.portloadbalancer      2.1.0    Port Load Balance Service
-* 109 org.onosproject.mcast                 2.1.0    Multicast traffic control
-* 110 org.onosproject.segmentrouting        2.1.0    Segment Routing
-* 156 org.onosproject.pipelines.fabric      2.1.0    Fabric Pipeline
-* 161 org.onosproject.gui                   2.1.0    ONOS Legacy GUI
-* 181 org.onosproject.drivers.bmv2          2.1.0    BMv2 Drivers
+* ... org.onosproject.protocols.grpc        2.2.0    gRPC Protocol Subsystem
+* ... org.onosproject.protocols.gnmi        2.2.0    gNMI Protocol Subsystem
+* ... org.onosproject.route-service         2.2.0    Route Service Server
+* ... org.onosproject.drivers               2.2.0    Default Drivers
+* ... org.onosproject.generaldeviceprovider 2.2.0    General Device Provider
+* ... org.onosproject.protocols.p4runtime   2.2.0    P4Runtime Protocol Subsystem
+* ... org.onosproject.p4runtime             2.2.0    P4Runtime Provider
+* ... org.onosproject.drivers.p4runtime     2.2.0    P4Runtime Drivers
+* ... org.onosproject.protocols.gnoi        2.2.0    gNOI Protocol Subsystem
+* ... org.onosproject.hostprovider          2.2.0    Host Location Provider
+* ... org.onosproject.lldpprovider          2.2.0    LLDP Link Provider
+* ... org.onosproject.drivers.gnoi          2.2.0    gNOI Drivers
+* ... org.onosproject.drivers.gnmi          2.2.0    gNMI Drivers
+* ... org.onosproject.pipelines.basic       2.2.0    Basic Pipelines
+* ... org.onosproject.drivers.stratum       2.2.0    Stratum Drivers
+* ... org.onosproject.portloadbalancer      2.2.0    Port Load Balance Service
+* ... org.onosproject.mcast                 2.2.0    Multicast traffic control
+* ... org.onosproject.segmentrouting        2.2.0    Segment Routing
+* ... org.onosproject.pipelines.fabric      2.2.0    Fabric Pipeline
+* ... org.onosproject.gui                   2.2.0    ONOS Legacy GUI
+* ... org.onosproject.drivers.bmv2          2.2.0    BMv2 Drivers
 ```
 
 #### Check topology

--- a/tools/mininet/examples/trellis/docker-compose.yml
+++ b/tools/mininet/examples/trellis/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "50004:50004"
     entrypoint: "/topo/entrypoint.sh"
   onos:
-    image: onosproject/onos:2.1.0
+    image: onosproject/onos:2.2.0
     ports:
       - "8181:8181" # HTTP
       - "8101:8101" # SSH (CLI)


### PR DESCRIPTION
Includes fixes to multicast group handling in PI and support for P4 logging
primitives in bmv2.

To make the PI build pass, the version of P4Runtime has been bumped to
1.1.0-rc.1, which should not break backward-compatibility at the P4Runtime
message level.

Changes have been tested end-to-end with stratum_bmv2 on Mininet with ONOS and
Trellis, using the instructions under tools/mininet/examples/trellis. The ONOS
version used by the example was bumped to 2.2.0 which is an LTS release and should be
preferred to 2.1.0.