### PR TITLE
Enable C++ style check and fix errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
       - checkout
       - run:
           name: Run cpplint
-          command: cpplint --linelength=110 --recursive stratum
+          command: cpplint --recursive stratum
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
       - checkout
       - run:
           name: Run cpplint
-          command: cpplint --recursive stratum
+          command: cpplint --recursive --exclude=stratum/hal/lib/bcm/bcm_sdk_wrapper.cc stratum
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,12 +160,22 @@ jobs:
             docker run $DOCKER_IMG -version
       - *docker_push
 
+  cpp-style-check:
+    docker:
+      - image: stratumproject/build:build
+    steps:
+      - checkout
+      - run:
+          name: Run cpplint
+          command: cpplint --linelength=110 --recursive stratum
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - unit_tests
       - coverage
+      - cpp-style-check
   docker-publish:
     jobs:
       - publish-docker-build:

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+BasedOnStyle:  Google
+---
+Language:        Cpp
+PointerAlignment: Left
+...

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -40,7 +40,7 @@ ENV PKG_DEPS pkg-config zip zlib1g-dev unzip python wget ca-certificates \
     libfl-dev libgmp-dev libi2c-dev python-yaml libyaml-dev build-essential \
     lcov curl autoconf automake libtool libgmp-dev libpcap-dev \
     libboost-thread-dev libboost-filesystem-dev libboost-program-options-dev \
-    gnupg2 software-properties-common
+    gnupg2 software-properties-common python-pip
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $PKG_DEPS
@@ -89,3 +89,7 @@ RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
     cd targets/simple_switch && \
     make -j${JOBS} && make install && ldconfig && \
     rm -rf /tmp/bmv2
+
+# Tools for style checking
+RUN pip install setuptools wheel && \
+    pip install cpplint

--- a/bazel/external/p4c.BUILD
+++ b/bazel/external/p4c.BUILD
@@ -46,7 +46,7 @@ package(
 
 # Instead of using cmake to generate the config.h, this genrule produces
 # a config.h from p4c's template in cmake/config.h.cmake.
-# TODO: Import libgc garbage collector to enable HAVE_LIBGC.
+# TODO(unknown): Import libgc garbage collector to enable HAVE_LIBGC.
 # This is OK compiling our P4 programs, but you wouldn't want to base a "P4 compile service" off of this.
 genrule(
     name = "sed_config_h",
@@ -396,7 +396,7 @@ cc_library(
     ],
 )
 
-# TODO: This genrule hack turns the version.h.cmake file into version.h
+# TODO(unknown): This genrule hack turns the version.h.cmake file into version.h
 # with the string "0.0.0.0".  Improve version numbering.
 genrule(
     name = "p4c_bmv2_version",
@@ -430,7 +430,7 @@ cc_binary(
 
 # This builds the p4test backend
 
-# TODO: This genrule hack turns the version.h.cmake file into version.h
+# TODO(unknown): This genrule hack turns the version.h.cmake file into version.h
 # with the string "0.0.0.0".  Improve version numbering.
 genrule(
     name = "p4c_p4test_version",

--- a/stratum/glue/status/status_macros.h
+++ b/stratum/glue/status/status_macros.h
@@ -410,14 +410,13 @@ class UtilStatusConvertibleToBool {
  public:
   // Implicity conversion from a status to wrap.
   // Need implicit conversion to allow in if-statement.
-  UtilStatusConvertibleToBool(::util::Status status)  // NOLINT(runtime/explicit)
-      : status_(status) { }
+  // NOLINTNEXTLINE(runtime/explicit)
+  UtilStatusConvertibleToBool(::util::Status status) : status_(status) {}
   // Implicity cast to bool. True on ok() and false on error.
   operator bool() const { return ABSL_PREDICT_TRUE(status_.ok()); }
   // Returns the wrapped status.
-  ::util::Status status() const {
-    return status_;
-  }
+  ::util::Status status() const { return status_; }
+
  private:
   ::util::Status status_;
 };

--- a/stratum/glue/status/status_macros.h
+++ b/stratum/glue/status/status_macros.h
@@ -409,8 +409,8 @@ namespace internal {
 class UtilStatusConvertibleToBool {
  public:
   // Implicity conversion from a status to wrap.
-  // NOLINTNEXTLINE Need implicit conversion to allow in if-statement.
-  UtilStatusConvertibleToBool(::util::Status status)
+  // Need implicit conversion to allow in if-statement.
+  UtilStatusConvertibleToBool(::util::Status status)  // NOLINT(runtime/explicit)
       : status_(status) { }
   // Implicity cast to bool. True on ok() and false on error.
   operator bool() const { return ABSL_PREDICT_TRUE(status_.ok()); }

--- a/stratum/hal/bin/bmv2/main.cc
+++ b/stratum/hal/bin/bmv2/main.cc
@@ -53,7 +53,7 @@ std::unordered_map<std::string, bm::Logger::LogLevel> log_level_map = {
     {"error", bm::Logger::LogLevel::ERROR},
     {"off", bm::Logger::LogLevel::OFF}};
 
-// NOLINTNEXTLINE
+// NOLINTNEXTLINE(runtime/references)
 void ParseInterfaces(int argc, char* argv[], bm::OptionsParser& parser) {
   for (int i = 1; i < argc; i++) {
     char* intf;

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -126,19 +126,24 @@ BFChassisManager::~BFChassisManager() = default;
     RETURN_IF_ERROR(bf_pal_interface_->PortDisable(unit, port_id));
     RETURN_IF_ERROR(bf_pal_interface_->PortDelete(unit, port_id));
 
-    ::util::Status status = AddPortHelper(node_id, unit, port_id, singleton_port, config);
+    ::util::Status status =
+        AddPortHelper(node_id, unit, port_id, singleton_port, config);
     if (status.ok()) {
       return ::util::OkStatus();
     } else {
       // Revert to the old port configuration
       //   -- make a singleton_port from config_old
       //   -- call AddPortHelper with "old" singleton_port
-      SingletonPort port_old = BuildSingletonPort(singleton_port.slot(),
-          singleton_port.port(), singleton_port.channel(), *config_old.speed_bps);
+      SingletonPort port_old =
+          BuildSingletonPort(singleton_port.slot(), singleton_port.port(),
+                             singleton_port.channel(), *config_old.speed_bps);
       port_old.mutable_config_params()->set_admin_state(config_old.admin_state);
-      if (config_old.autoneg) port_old.mutable_config_params()->set_autoneg(*config_old.autoneg);
-      if (config_old.mtu) port_old.mutable_config_params()->set_mtu(*config_old.mtu);
-      if (config_old.fec_mode) port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
+      if (config_old.autoneg)
+        port_old.mutable_config_params()->set_autoneg(*config_old.autoneg);
+      if (config_old.mtu)
+        port_old.mutable_config_params()->set_mtu(*config_old.mtu);
+      if (config_old.fec_mode)
+        port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
       AddPortHelper(node_id, unit, port_id, port_old, config);
       RETURN_ERROR(ERR_INVALID_PARAM)
           << "Could not add port " << port_id

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -1635,9 +1635,9 @@ bool BcmChassisManager::IsSingletonPortMatchesBcmPort(
 ::util::Status BcmChassisManager::WriteBcmConfigFile(
     const BcmChassisMap& base_bcm_chassis_map,
     const BcmChassisMap& target_bcm_chassis_map) const {
-    // TODO(unknown): Implement this function.
-    // std::stringstream buffer;
-    // RETURN_IF_ERROR(WriteStringToFile(buffer.str(), FLAGS_bcm_sdk_config_file));
+  // TODO(unknown): Implement this function.
+  // std::stringstream buffer;
+  // RETURN_IF_ERROR(WriteStringToFile(buffer.str(), FLAGS_bcm_sdk_config_file));
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -1636,9 +1636,10 @@ bool BcmChassisManager::IsSingletonPortMatchesBcmPort(
     const BcmChassisMap& base_bcm_chassis_map,
     const BcmChassisMap& target_bcm_chassis_map) const {
   // TODO(unknown): Implement this function.
-  // std::stringstream buffer;
-  // RETURN_IF_ERROR(WriteStringToFile(buffer.str(), FLAGS_bcm_sdk_config_file));
-
+  /*
+  std::stringstream buffer;
+  RETURN_IF_ERROR(WriteStringToFile(buffer.str(), FLAGS_bcm_sdk_config_file));
+  */
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -452,20 +452,20 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
 ::util::Status BcmChassisManager::SetTrunkMemberBlockState(
     uint64 node_id, uint32 trunk_id, uint32 port_id,
     TrunkMemberBlockState state) {
-  // TODO: Implement this method.
+  // TODO(unknown): Implement this method.
   return ::util::OkStatus();
 }
 
 ::util::Status BcmChassisManager::SetPortAdminState(uint64 node_id,
                                                     uint32 port_id,
                                                     AdminState state) {
-  // TODO: Implement this method.
+  // TODO(unknown): Implement this method.
   return ::util::OkStatus();
 }
 ::util::Status BcmChassisManager::SetPortHealthState(uint64 node_id,
                                                      uint32 port_id,
                                                      HealthState state) {
-  // TODO: Implement this method.
+  // TODO(unknown): Implement this method.
   return ::util::OkStatus();
 }
 
@@ -495,7 +495,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
 
 }  // namespace
 
-// TODO: Include MGMT ports in the config if needed.
+// TODO(unknown): Include MGMT ports in the config if needed.
 ::util::Status BcmChassisManager::GenerateBcmChassisMapFromConfig(
     const ChassisConfig& config, BcmChassisMap* base_bcm_chassis_map,
     BcmChassisMap* target_bcm_chassis_map) const {
@@ -1279,7 +1279,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
     uint64 node_id = trunk_port.node();    // already verified as known
     uint32 trunk_id = trunk_port.id();     // already verified as known
     int unit = node_id_to_unit_[node_id];  // already verified as known
-    // TODO: Populate the rest of trunk related maps. Also add support
+    // TODO(unknown): Populate the rest of trunk related maps. Also add support
     // for restoring trunk state/members. At the moment, we populate the maps
     // with invalid data.
     node_id_to_trunk_ids_[node_id].insert(trunk_id);
@@ -1291,7 +1291,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
     node_id_to_trunk_id_to_members_[node_id][trunk_id] = {};
   }
 
-  // TODO: Update the LED of all the ports.
+  // TODO(unknown): Update the LED of all the ports.
 
   return ::util::OkStatus();
 }
@@ -1635,7 +1635,7 @@ bool BcmChassisManager::IsSingletonPortMatchesBcmPort(
 ::util::Status BcmChassisManager::WriteBcmConfigFile(
     const BcmChassisMap& base_bcm_chassis_map,
     const BcmChassisMap& target_bcm_chassis_map) const {
-    // TODO: Implement this function.
+    // TODO(unknown): Implement this function.
     // std::stringstream buffer;
     // RETURN_IF_ERROR(WriteStringToFile(buffer.str(), FLAGS_bcm_sdk_config_file));
 
@@ -1726,7 +1726,7 @@ void BcmChassisManager::LinkscanEventHandler(int unit, int logical_port,
   SendPortOperStateGnmiEvent(*node_id, *port_id, new_state);
 
   // Log details about the port state change for debugging purposes.
-  // TODO: The extra map lookups here are only for debugging and
+  // TODO(unknown): The extra map lookups here are only for debugging and
   // pretty printing the ports. We may not need them. If not, simplify the
   // state reporting.
   const std::map<uint32, PortKey>* port_id_to_singleton_port_key =

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.h
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.h
@@ -521,7 +521,7 @@ class BcmChassisManager : public BcmChassisRoInterface {
   // Map from node ID to another map from port ID to its trunk membership info,
   // when the port is part of a trunk. Trunk membership of the ports is updated
   // as part of each "trunk event".
-  // TODO: The assumption here is that each port can be part of one
+  // TODO(unknown): The assumption here is that each port can be part of one
   // trunk only. If this assumption is not correct, change the map.
   std::map<uint64, std::map<uint32, TrunkMembershipInfo>>
       node_id_to_port_id_to_trunk_membership_info_;

--- a/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
@@ -3112,8 +3112,8 @@ TEST_P(BcmChassisManagerTest, PushChassisConfigFailure) {
   )";
   const std::string kChassisMapError12 = "is in flex_port_group_keys";
 
-  // Unsupported chip type. Generic Trident2 supports TRIDENT2 while BcmChip here
-  // says TOMAHAWK.
+  // Unsupported chip type. Generic Trident2 supports TRIDENT2 while BcmChip
+  // here says TOMAHAWK.
   const std::string kBcmChassisMapListText13 = R"(
       bcm_chassis_maps {
         auto_add_logical_ports: true

--- a/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
@@ -79,7 +79,7 @@ MATCHER_P(GnmiEventEq, event, "") {
 }
 
 // TODO(unknown): Investigate moving the test protos into a testdata folder.
-// TODO: Use constants for the config args used in tests.
+// TODO(unknown): Use constants for the config args used in tests.
 class BcmChassisManagerTest : public ::testing::TestWithParam<OperationMode> {
  protected:
   BcmChassisManagerTest() {
@@ -5195,7 +5195,7 @@ TEST_P(BcmChassisManagerTest, TestSetTrunkMemberBlockStateByController) {
   // static: (node_id: 7654321, trunk_id: 222, port_id: 12345)
   // LACP: (node_id: 7654321, trunk_id: 333, port_id: NONE)
 
-  // TODO: Extend the tests when the function is implemneted.
+  // TODO(unknown): Extend the tests when the function is implemneted.
   EXPECT_OK(SetTrunkMemberBlockState(kNodeId, 222, kPortId,
                                      TRUNK_MEMBER_BLOCK_STATE_BLOCKED));
   EXPECT_OK(SetTrunkMemberBlockState(kNodeId, 0, kPortId,
@@ -5238,7 +5238,7 @@ TEST_P(BcmChassisManagerTest, TestSetPortAdminStateViaConfigPush) {
 TEST_P(BcmChassisManagerTest, TestSetPortAdminStateByController) {
   ASSERT_OK(PushTestConfig());
 
-  // TODO: Extend the tests when the function is implemneted.
+  // TODO(unknown): Extend the tests when the function is implemneted.
   EXPECT_OK(SetPortAdminState(kNodeId, kPortId, ADMIN_STATE_DISABLED));
   EXPECT_OK(SetPortAdminState(kNodeId, kPortId, ADMIN_STATE_ENABLED));
 
@@ -5248,7 +5248,7 @@ TEST_P(BcmChassisManagerTest, TestSetPortAdminStateByController) {
 TEST_P(BcmChassisManagerTest, TestSetPortHealthStateByController) {
   ASSERT_OK(PushTestConfig());
 
-  // TODO: Extend the tests when the function is implemneted.
+  // TODO(unknown): Extend the tests when the function is implemneted.
   EXPECT_OK(SetPortHealthState(kNodeId, kPortId, HEALTH_STATE_BAD));
   EXPECT_OK(SetPortHealthState(kNodeId, kPortId, HEALTH_STATE_GOOD));
 

--- a/stratum/hal/lib/bcm/bcm_l2_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_l2_manager.cc
@@ -15,6 +15,8 @@
 
 #include "stratum/hal/lib/bcm/bcm_l2_manager.h"
 
+#include <set>
+
 #include "absl/memory/memory.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/hal/lib/common/constants.h"

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -225,16 +225,18 @@ BcmNode::~BcmNode() {}
         action_profile_groups_requested = true;
         break;
       case ::p4::v1::Entity::kPacketReplicationEngineEntry:
-        if (entity.packet_replication_engine_entry().has_multicast_group_entry()) {
-          multicast_group_ids.insert(
-              entity.packet_replication_engine_entry().multicast_group_entry()
-                  .multicast_group_id());
+        if (entity.packet_replication_engine_entry()
+                .has_multicast_group_entry()) {
+          multicast_group_ids.insert(entity.packet_replication_engine_entry()
+                                         .multicast_group_entry()
+                                         .multicast_group_id());
           multicast_groups_requested = true;
         }
-        if (entity.packet_replication_engine_entry().has_clone_session_entry()) {
-            clone_session_ids.insert(
-              entity.packet_replication_engine_entry().clone_session_entry()
-                  .session_id());
+        if (entity.packet_replication_engine_entry()
+                .has_clone_session_entry()) {
+          clone_session_ids.insert(entity.packet_replication_engine_entry()
+                                       .clone_session_entry()
+                                       .session_id());
           clone_sessions_requested = true;
         }
         break;
@@ -747,28 +749,33 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
 ::util::Status BcmNode::PacketReplicationEngineEntryWrite(
     const ::p4::v1::PacketReplicationEngineEntry& entry,
     ::p4::v1::Update::Type type) {
-
   auto replicationType = entry.type_case();
 
   bool consumed = false;
   switch (type) {
     case ::p4::v1::Update::INSERT: {
       switch (replicationType) {
-        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kCloneSessionEntry: {
+        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::
+            kCloneSessionEntry: {
           BcmPacketReplicationEntry bcm_entry;
-          RETURN_IF_ERROR(bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
-          RETURN_IF_ERROR(bcm_table_manager_->AddCloneSession(entry.clone_session_entry()));
+          RETURN_IF_ERROR(
+              bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
+          RETURN_IF_ERROR(
+              bcm_table_manager_->AddCloneSession(entry.clone_session_entry()));
           // There is nothing to be done here. All packets cloned by COPY_TO_CPU
           // are sent to the CPU and then controller on bcm.
           consumed = true;
           break;
         }
-        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kMulticastGroupEntry: {
+        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::
+            kMulticastGroupEntry: {
           BcmPacketReplicationEntry bcm_entry;
-          RETURN_IF_ERROR(bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
-          RETURN_IF_ERROR(bcm_packetio_manager_->InsertPacketReplicationEntry(
-              bcm_entry));
-          RETURN_IF_ERROR(bcm_table_manager_->AddMulticastGroup(entry.multicast_group_entry()));
+          RETURN_IF_ERROR(
+              bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
+          RETURN_IF_ERROR(
+              bcm_packetio_manager_->InsertPacketReplicationEntry(bcm_entry));
+          RETURN_IF_ERROR(bcm_table_manager_->AddMulticastGroup(
+              entry.multicast_group_entry()));
           consumed = true;
           break;
         }
@@ -779,19 +786,25 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
     }
     case ::p4::v1::Update::DELETE: {
       switch (replicationType) {
-        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kCloneSessionEntry: {
+        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::
+            kCloneSessionEntry: {
           BcmPacketReplicationEntry bcm_entry;
-          RETURN_IF_ERROR(bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
-          RETURN_IF_ERROR(bcm_table_manager_->DeleteCloneSession(entry.clone_session_entry()));
+          RETURN_IF_ERROR(
+              bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
+          RETURN_IF_ERROR(bcm_table_manager_->DeleteCloneSession(
+              entry.clone_session_entry()));
           consumed = true;
           break;
         }
-        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kMulticastGroupEntry: {
+        case ::p4::v1::PacketReplicationEngineEntry::TypeCase::
+            kMulticastGroupEntry: {
           BcmPacketReplicationEntry bcm_entry;
-          RETURN_IF_ERROR(bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
-          RETURN_IF_ERROR(bcm_packetio_manager_->DeletePacketReplicationEntry(
-              bcm_entry));
-          RETURN_IF_ERROR(bcm_table_manager_->DeleteMulticastGroup(entry.multicast_group_entry()));
+          RETURN_IF_ERROR(
+              bcm_table_manager_->FillBcmReplicationConfig(entry, &bcm_entry));
+          RETURN_IF_ERROR(
+              bcm_packetio_manager_->DeletePacketReplicationEntry(bcm_entry));
+          RETURN_IF_ERROR(bcm_table_manager_->DeleteMulticastGroup(
+              entry.multicast_group_entry()));
           consumed = true;
           break;
         }
@@ -804,8 +817,9 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
   }
 
   CHECK_RETURN_IF_FALSE(consumed)
-    << "Do not know what to do with this " << ::p4::v1::Update::Type_Name(type)
-    << " PacketReplicationEngineEntry: " << entry.ShortDebugString() << ".";
+      << "Do not know what to do with this "
+      << ::p4::v1::Update::Type_Name(type)
+      << " PacketReplicationEngineEntry: " << entry.ShortDebugString() << ".";
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -778,7 +778,6 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
       break;
     }
     case ::p4::v1::Update::DELETE: {
-
       switch (replicationType) {
         case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kCloneSessionEntry: {
           BcmPacketReplicationEntry bcm_entry;

--- a/stratum/hal/lib/bcm/bcm_packetio_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.cc
@@ -429,10 +429,12 @@ BcmPacketioManager::~BcmPacketioManager() {}
   if (!status.ok()) {
     INCREMENT_TX_COUNTER(purpose, tx_drops_metadata_parse_error);
   }
-  VLOG(1) << "PacketOutMetadata.egress_port_id: " << meta.egress_port_id
-      << "\n" << "PacketOutMetadata.egress_trunk_id: " << meta.egress_trunk_id
-      << "\n" << "PacketOutMetadata.cos: " << meta.cos
-      << "\n" << "PacketOutMetadata.use_ingress_pipeline: " << meta.use_ingress_pipeline;
+  VLOG(1) << "PacketOutMetadata.egress_port_id: " << meta.egress_port_id << "\n"
+          << "PacketOutMetadata.egress_trunk_id: " << meta.egress_trunk_id
+          << "\n"
+          << "PacketOutMetadata.cos: " << meta.cos << "\n"
+          << "PacketOutMetadata.use_ingress_pipeline: "
+          << meta.use_ingress_pipeline;
 
   // Now try to send the packet. There are several cases:
   // 1- Direct packet to physical port.
@@ -484,7 +486,8 @@ BcmPacketioManager::~BcmPacketioManager() {}
     }
     std::string header = "";
     RETURN_IF_ERROR(bcm_sdk_interface_->GetKnetHeaderForDirectTx(
-        unit_, *logical_port, meta.cos, intf->smac, packet.payload().size(), &header));
+        unit_, *logical_port, meta.cos, intf->smac, packet.payload().size(),
+        &header));
     RETURN_IF_ERROR(TxPacket(purpose, intf->tx_sock, intf->vlan,
                              intf->netif_index, true, header,
                              packet.payload()));
@@ -1109,10 +1112,13 @@ std::string BcmPacketioManager::GetKnetIntfNameTemplate(
             }
             meta.egress_port_id = *egress_port_id;
           }
-          VLOG(1) << "PacketInMetadata.ingress_port_id: " << meta.ingress_port_id
-              << "\n" << "PacketInMetadata.ingress_trunk_id: " << meta.ingress_trunk_id
-              << "\n" << "PacketInMetadata.egress_port_id: " << meta.egress_port_id
-              << "\n" << "PacketInMetadata.cos: " << meta.cos;
+          VLOG(1) << "PacketInMetadata.ingress_port_id: "
+                  << meta.ingress_port_id << "\n"
+                  << "PacketInMetadata.ingress_trunk_id: "
+                  << meta.ingress_trunk_id << "\n"
+                  << "PacketInMetadata.egress_port_id: " << meta.egress_port_id
+                  << "\n"
+                  << "PacketInMetadata.cos: " << meta.cos;
           status = DeparsePacketInMetadata(meta, &packet);
           if (!status.ok()) {
             INCREMENT_RX_COUNTER(purpose, rx_drops_metadata_deparse_error);
@@ -1417,7 +1423,8 @@ std::string BcmPacketioManager::GetKnetIntfNameTemplate(
   }
   // If the port/trunk is given we transmit the port directly to the port/trunk.
   // Otherwise, we transmit the packet to ingress pipeline of the given node.
-  // TODO(max): This implicit way is in conflict with the explicit flag in packet_out header
+  // TODO(max): This implicit way is in conflict with the explicit flag in
+  // packet_out header
   meta->use_ingress_pipeline =
       (meta->egress_port_id == 0 && meta->egress_trunk_id == 0);
 

--- a/stratum/hal/lib/bcm/bcm_packetio_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.cc
@@ -284,7 +284,7 @@ BcmPacketioManager::~BcmPacketioManager() {}
 
 ::util::Status BcmPacketioManager::Shutdown() {
   // Simulation mode does not support KNET.
-  // TODO: Find a way to do packet I/O in sim mode.
+  // TODO(unknown): Find a way to do packet I/O in sim mode.
   if (mode_ == OPERATION_MODE_SIM) {
     LOG(WARNING) << "Skipped shutting down BcmPacketioManager for node "
                  << node_id_ << " in sim mode.";
@@ -1096,7 +1096,7 @@ std::string BcmPacketioManager::GetKnetIntfNameTemplate(
           } else if (egress_logical_port == 1) {
             // SDKLT sets egress port to 1 for packets that do not match
             // MY_STATION table or got dropped by the ASIC?
-            // TODO: check this and decide what to report upwards
+            // TODO(unknown): check this and decide what to report upwards
             meta.egress_port_id = 1;
           } else {
             uint32* egress_port_id =
@@ -1312,7 +1312,7 @@ std::string BcmPacketioManager::GetKnetIntfNameTemplate(
     RETURN_IF_ERROR(p4_table_mapper_->DeparsePacketOutMetadata(
         mapped_packet_metadata, packet->add_metadata()));
   }
-  // TODO: Controller has not defined any metadata for CoS yet. Enable
+  // TODO(unknown): Controller has not defined any metadata for CoS yet. Enable
   // this after this is done.
   /*
   if (meta.cos > 0) {

--- a/stratum/hal/lib/bcm/bcm_packetio_manager.h
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.h
@@ -248,7 +248,7 @@ struct PacketInMetadata {
   uint32 egress_port_id;
   // The CoS for the received packet.
   int cos;
-  // TODO: How about reason bit. Should we capture that as well?
+  // TODO(unknown): How about reason bit. Should we capture that as well?
   PacketInMetadata()
       : ingress_port_id(0),
         ingress_trunk_id(0),

--- a/stratum/hal/lib/bcm/bcm_packetio_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager_test.cc
@@ -1881,7 +1881,8 @@ TEST_P(BcmPacketioManagerTest, TransmitPacketAfterChassisConfigPush) {
 
   // 6- A packet sent to ingress pipeline
   packet.clear_metadata();  // no metadata will send packet to ingress pipeline
-  EXPECT_CALL(*bcm_sdk_mock_, GetKnetHeaderForIngressPipelineTx(kUnit1, _, _, _))
+  EXPECT_CALL(*bcm_sdk_mock_,
+              GetKnetHeaderForIngressPipelineTx(kUnit1, _, _, _))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*LibcProxyMock::Instance(), SendMsg(kSocket1, _, _))
       .WillOnce(Return(64));  // 64 is tot_len of the packet.

--- a/stratum/hal/lib/bcm/bcm_sdk_mock.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_mock.h
@@ -47,7 +47,8 @@ class BcmSdkMock : public BcmSdkInterface {
                                               const BcmPortOptions& options));
   MOCK_METHOD3(GetPortOptions,
                ::util::Status(int unit, int port, BcmPortOptions* options));
-  MOCK_METHOD3(GetPortCounters, ::util::Status(int unit, int port, PortCounters* pc));
+  MOCK_METHOD3(GetPortCounters,
+               ::util::Status(int unit, int port, PortCounters* pc));
   MOCK_METHOD0(StartDiagShellServer, ::util::Status());
   MOCK_METHOD1(StartLinkscan, ::util::Status(int unit));
   MOCK_METHOD1(StopLinkscan, ::util::Status(int unit));
@@ -188,7 +189,8 @@ class BcmSdkMock : public BcmSdkInterface {
                ::util::Status(int unit, int port, int cos, uint64 smac,
                               size_t packet_len, std::string* header));
   MOCK_METHOD4(GetKnetHeaderForIngressPipelineTx,
-               ::util::Status(int unit, uint64 smac, size_t packet_len, std::string* header));
+               ::util::Status(int unit, uint64 smac, size_t packet_len,
+                              std::string* header));
   MOCK_METHOD1(GetKnetHeaderSizeForRx, size_t(int unit));
   MOCK_METHOD5(ParseKnetHeaderForRx,
                ::util::Status(int unit, const std::string& header,

--- a/stratum/hal/lib/bcm/bcm_sdk_sim.cc
+++ b/stratum/hal/lib/bcm/bcm_sdk_sim.cc
@@ -171,7 +171,8 @@ BcmSdkSim::~BcmSdkSim() { ShutdownAllUnits().IgnoreError(); }
 }
 
 ::util::Status BcmSdkSim::GetKnetHeaderForDirectTx(int unit, int port, int cos,
-                                                   uint64 smac, size_t packet_len,
+                                                   uint64 smac,
+                                                   size_t packet_len,
                                                    std::string *header) {
   *header = "";
   return MAKE_ERROR(ERR_FEATURE_UNAVAILABLE) << "Not supported in sim mode.";

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
@@ -436,10 +436,6 @@ class BcmSdkWrapper : public BcmSdkInterface {
                           ", dst_mac:", absl::Hex(dst_mac),
                           ", dst_mac_mask:", absl::Hex(dst_mac_mask), ")");
     }
-    template <typename H>
-    friend H AbslHashValue(H h, const MyStationEntry& e) {
-      return H::combine(std::move(h), e.vlan, e.vlan_mask, e.dst_mac, e.dst_mac_mask);
-    }
   };
 
   // Map from unit number to mystation maximum entries

--- a/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_wrapper.h
@@ -23,6 +23,11 @@
 
 #include <functional>
 #include <string>
+#include <set>
+#include <map>
+#include <vector>
+#include <utility>
+#include <memory>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -697,8 +697,8 @@ BcmTableManager::ConstConditionsToBcmFields(const AclTable& table) {
 }
 
 ::util::Status BcmTableManager::FillBcmReplicationConfig(
-      const ::p4::v1::PacketReplicationEngineEntry replication_entry,
-      BcmPacketReplicationEntry* bcm_replication_entry) const {
+    const ::p4::v1::PacketReplicationEngineEntry replication_entry,
+    BcmPacketReplicationEntry* bcm_replication_entry) const {
   bcm_replication_entry->set_unit(unit_);
   switch (replication_entry.type_case()) {
     case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kCloneSessionEntry:
@@ -706,8 +706,10 @@ BcmTableManager::ConstConditionsToBcmFields(const AclTable& table) {
       CHECK_RETURN_IF_FALSE(
           replication_entry.clone_session_entry().packet_length_bytes() == 0);
       // We simulate having one clone session with hard-coded Id
-      CHECK_RETURN_IF_FALSE(replication_entry.clone_session_entry().session_id()
-          == kCloneSessionId) << "Bcm only allows one stub clone session "
+      CHECK_RETURN_IF_FALSE(
+          replication_entry.clone_session_entry().session_id() ==
+          kCloneSessionId)
+          << "Bcm only allows one stub clone session "
           << " with Id " << kCloneSessionId << ".";
       CHECK_RETURN_IF_FALSE(
           replication_entry.clone_session_entry().class_of_service() == 0)
@@ -717,27 +719,32 @@ BcmTableManager::ConstConditionsToBcmFields(const AclTable& table) {
           replication_entry.clone_session_entry().replicas_size() == 1)
           << "Bcm only allows cloning to a single port.";
       CHECK_RETURN_IF_FALSE(
-          replication_entry.clone_session_entry().replicas(0).egress_port() == kCpuPortId)
+          replication_entry.clone_session_entry().replicas(0).egress_port() ==
+          kCpuPortId)
           << "Bcm only allows cloning to the CPU port (" << kCpuPortId << ").";
       break;
-    case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kMulticastGroupEntry: {
+    case ::p4::v1::PacketReplicationEngineEntry::TypeCase::
+        kMulticastGroupEntry: {
       auto mcast_grp = bcm_replication_entry->mutable_multicast_group_entry();
       CHECK_RETURN_IF_FALSE(
           replication_entry.multicast_group_entry().multicast_group_id() != 0);
       CHECK_RETURN_IF_FALSE(
-          replication_entry.multicast_group_entry().multicast_group_id() <= kuint8max);
+          replication_entry.multicast_group_entry().multicast_group_id() <=
+          kuint8max);
       mcast_grp->set_multicast_group_id(
           replication_entry.multicast_group_entry().multicast_group_id());
-      for (auto const& replica : replication_entry.multicast_group_entry().replicas()) {
-        CHECK_RETURN_IF_FALSE(replica.instance() == 1) << "instances are not suppoted";
+      for (auto const& replica :
+           replication_entry.multicast_group_entry().replicas()) {
+        CHECK_RETURN_IF_FALSE(replica.instance() == 1)
+            << "instances are not suppoted";
         mcast_grp->add_ports(replica.egress_port());
       }
       break;
     }
     default:
       return MAKE_ERROR(ERR_INVALID_PARAM)
-          << "Unsupported PacketReplicationEngineEntry "
-          << replication_entry.ShortDebugString();
+             << "Unsupported PacketReplicationEngineEntry "
+             << replication_entry.ShortDebugString();
   }
   return ::util::OkStatus();
 }
@@ -1184,16 +1191,17 @@ namespace {
   // Sanity checking.
   if (!multicast_group.multicast_group_id()) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-        << "Need non-zero multicast_group_id: "
-        << multicast_group.ShortDebugString() << ".";
+           << "Need non-zero multicast_group_id: "
+           << multicast_group.ShortDebugString() << ".";
   }
   uint32 group_id = multicast_group.multicast_group_id();
 
   // Save a copy of P4 MulticastGroupEntry.
-  if (!gtl::InsertIfNotPresent(&multicast_groups_, {group_id, multicast_group})) {
+  if (!gtl::InsertIfNotPresent(&multicast_groups_,
+                               {group_id, multicast_group})) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-        << "Inconsistent state. Multicast group with ID " << group_id
-        << " already exists in multicast_groups_.";
+           << "Inconsistent state. Multicast group with ID " << group_id
+           << " already exists in multicast_groups_.";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -468,7 +468,7 @@ BcmField::Type BcmTableManager::P4FieldTypeToBcmFieldType(
     // Add the table priority. This allows us to separate logical tables within
     // the same physical table. The priority in the CommonFlowEntry is the
     // relative priority within the table.
-    // TODO: Not needed in SDKLT
+    // TODO(unknown): Not needed in SDKLT
     // priority += acl_table->Priority() * kAclTablePriorityRange;
   }
   bcm_flow_entry->set_priority(priority);
@@ -480,7 +480,7 @@ BcmField::Type BcmTableManager::P4FieldTypeToBcmFieldType(
   // and nothing else. Note that there is no need for mapping actions in case of
   // table entry delete. No logic that consumes BcmFlowEntry should rely on
   // actions when deleting a table entry. Otherwise we have a bug.
-  // TODO: Per b/77525702, we still need to clarify what the expected
+  // TODO(unknown): Per b/77525702, we still need to clarify what the expected
   // behavior is in case we have actions populated when deleting a table entry.
   if (type == ::p4::v1::Update::DELETE) return ::util::OkStatus();
   switch (common_flow_entry.action().type()) {
@@ -699,7 +699,6 @@ BcmTableManager::ConstConditionsToBcmFields(const AclTable& table) {
 ::util::Status BcmTableManager::FillBcmReplicationConfig(
       const ::p4::v1::PacketReplicationEngineEntry replication_entry,
       BcmPacketReplicationEntry* bcm_replication_entry) const {
-
   bcm_replication_entry->set_unit(unit_);
   switch (replication_entry.type_case()) {
     case ::p4::v1::PacketReplicationEngineEntry::TypeCase::kCloneSessionEntry:
@@ -868,7 +867,7 @@ namespace {
               bcm_non_multipath_nexthop->set_vlan(field.u32());
               break;
             case P4_FIELD_TYPE_L3_CLASS_ID:
-              // TODO: Ignore class_id for now till we have a
+              // TODO(unknown): Ignore class_id for now till we have a
               // resolution for b/73264766.
               break;
             default:

--- a/stratum/hal/lib/bcm/bcm_table_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager_test.cc
@@ -359,16 +359,17 @@ namespace {
 
 // Returns a BcmField containing the const condition for a P4HeaderType.
 ::util::StatusOr<BcmField> ConstCondition(P4HeaderType p4_header_type) {
-  static const auto* field_map = new absl::flat_hash_map<P4HeaderType, std::string>({
-      {P4_HEADER_ARP, "type: IP_TYPE value { u32: 0x0806 }"},
-      {P4_HEADER_IPV4, "type: IP_TYPE value { u32: 0x0800 }"},
-      {P4_HEADER_IPV6, "type: IP_TYPE value { u32: 0x86dd }"},
-      {P4_HEADER_TCP, "type: IP_PROTO_NEXT_HDR value { u32: 6 }"},
-      {P4_HEADER_UDP, "type: IP_PROTO_NEXT_HDR value { u32: 17 }"},
-      {P4_HEADER_UDP_PAYLOAD, "type: IP_PROTO_NEXT_HDR value { u32: 17 }"},
-      {P4_HEADER_GRE, "type: IP_PROTO_NEXT_HDR value { u32: 47 }"},
-      {P4_HEADER_ICMP, "type: IP_PROTO_NEXT_HDR value { u32: 1 }"},
-  });
+  static const auto* field_map =
+      new absl::flat_hash_map<P4HeaderType, std::string>({
+          {P4_HEADER_ARP, "type: IP_TYPE value { u32: 0x0806 }"},
+          {P4_HEADER_IPV4, "type: IP_TYPE value { u32: 0x0800 }"},
+          {P4_HEADER_IPV6, "type: IP_TYPE value { u32: 0x86dd }"},
+          {P4_HEADER_TCP, "type: IP_PROTO_NEXT_HDR value { u32: 6 }"},
+          {P4_HEADER_UDP, "type: IP_PROTO_NEXT_HDR value { u32: 17 }"},
+          {P4_HEADER_UDP_PAYLOAD, "type: IP_PROTO_NEXT_HDR value { u32: 17 }"},
+          {P4_HEADER_GRE, "type: IP_PROTO_NEXT_HDR value { u32: 47 }"},
+          {P4_HEADER_ICMP, "type: IP_PROTO_NEXT_HDR value { u32: 1 }"},
+      });
 
   BcmField bcm_field;
   std::string bcm_field_proto_string =

--- a/stratum/hal/lib/bcm/bcm_udf_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_udf_manager_test.cc
@@ -18,20 +18,21 @@
 #include <endian.h>
 
 #include <algorithm>
+#include <set>
 #include <string>
 
-#include "stratum/hal/lib/bcm/bcm_sdk_mock.h"
-#include "stratum/hal/lib/p4/p4_table_mapper_mock.h"
-#include "stratum/lib/test_utils/matchers.h"
-#include "stratum/glue/status/status.h"
-#include "stratum/glue/status/status_test_util.h"
-#include "stratum/lib/utils.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/bcm/bcm_sdk_mock.h"
+#include "stratum/hal/lib/p4/p4_table_mapper_mock.h"
+#include "stratum/lib/test_utils/matchers.h"
+#include "stratum/lib/utils.h"
 
 namespace stratum {
 

--- a/stratum/hal/lib/bcm/constants.h
+++ b/stratum/hal/lib/bcm/constants.h
@@ -52,7 +52,8 @@ constexpr int kDefaultVlanStgId = 1;
 constexpr int kAclTablePriorityRange = 1 << 16;
 
 // KNET related constants.
-// TODO(max): 802.1Q says 0x8100 is used as TPID, switch Rx packets also use this value
+// TODO(max): 802.1Q says 0x8100 is used as TPID, switch Rx packets also use
+// this value
 // constexpr uint16 kRcpuVlanEthertype = 0x8101;
 constexpr uint16 kRcpuVlanEthertype = 0x8100;
 constexpr uint16 kRcpuVlanId = 1;  // fixed for all RCPU headers

--- a/stratum/hal/lib/common/admin_service.h
+++ b/stratum/hal/lib/common/admin_service.h
@@ -18,7 +18,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_ADMIN_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_ADMIN_SERVICE_H_
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 
 #include <memory>
 #include <utility>

--- a/stratum/hal/lib/common/admin_service.h
+++ b/stratum/hal/lib/common/admin_service.h
@@ -18,22 +18,21 @@
 #ifndef STRATUM_HAL_LIB_COMMON_ADMIN_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_ADMIN_SERVICE_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <memory>
 #include <utility>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "gnoi/system/system.grpc.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/common/admin_utils_interface.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/lib/security/auth_policy_checker.h"
-#include "stratum/glue/integral_types.h"
-#include "stratum/glue/status/status.h"
-#include "stratum/hal/lib/common/admin_utils_interface.h"
 #include "stratum/lib/timer_daemon.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/admin_service_test.cc
+++ b/stratum/hal/lib/common/admin_service_test.cc
@@ -15,7 +15,6 @@
 
 #include "stratum/hal/lib/common/admin_service.h"
 
-#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 
@@ -25,16 +24,17 @@
 #include "absl/time/clock.h"
 #include "gflags/gflags.h"
 #include "gmock/gmock.h"
+#include "grpcpp/grpcpp.h"
 #include "gtest/gtest.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/common/admin_utils_mock.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_mock.h"
-#include "stratum/hal/lib/common/admin_utils_mock.h"
 #include "stratum/lib/security/auth_policy_checker_mock.h"
 #include "stratum/lib/test_utils/matchers.h"
-#include "stratum/lib/utils.h"
 #include "stratum/lib/timer_daemon.h"
+#include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
 
 namespace stratum {
@@ -547,23 +547,21 @@ TEST_P(AdminServiceTest, SetPackageUnsupportedOptions) {
   ASSERT_OK(admin_service_->Setup(false));
 
   // Configure unexpected calls
-  EXPECT_CALL(*(fs_helper_.get()), CreateTempDir())
-  .Times(0);
+  EXPECT_CALL(*(fs_helper_.get()), CreateTempDir()).Times(0);
 
-  EXPECT_CALL(*(fs_helper_.get()), TempFileName(::testing::_))
-  .Times(0);
-
-  EXPECT_CALL(*(fs_helper_.get()), StringToFile(::testing::_, ::testing::_, ::testing::_))
-  .Times(0);
-
-  EXPECT_CALL(*(fs_helper_.get()), RemoveDir(::testing::_))
-  .Times(0);
-
-  EXPECT_CALL(*(fs_helper_.get()), RemoveFile(::testing::_))
-  .Times(0);
+  EXPECT_CALL(*(fs_helper_.get()), TempFileName(::testing::_)).Times(0);
 
   EXPECT_CALL(*(fs_helper_.get()),
-  CheckHashSumFile(::testing::_, ::testing::_, ::testing::_)).Times(0);
+              StringToFile(::testing::_, ::testing::_, ::testing::_))
+      .Times(0);
+
+  EXPECT_CALL(*(fs_helper_.get()), RemoveDir(::testing::_)).Times(0);
+
+  EXPECT_CALL(*(fs_helper_.get()), RemoveFile(::testing::_)).Times(0);
+
+  EXPECT_CALL(*(fs_helper_.get()),
+              CheckHashSumFile(::testing::_, ::testing::_, ::testing::_))
+      .Times(0);
 
   std::unique_ptr<::grpc::ClientWriter<::gnoi::system::SetPackageRequest> >
   writer = stub_->SetPackage(&context, &resp);

--- a/stratum/hal/lib/common/admin_service_test.cc
+++ b/stratum/hal/lib/common/admin_service_test.cc
@@ -553,7 +553,6 @@ TEST_P(AdminServiceTest, SetPackageUnsupportedOptions) {
   EXPECT_CALL(*(fs_helper_.get()), TempFileName(::testing::_))
   .Times(0);
 
-//  NOLINTNEXTLINE
   EXPECT_CALL(*(fs_helper_.get()), StringToFile(::testing::_, ::testing::_, ::testing::_))
   .Times(0);
 

--- a/stratum/hal/lib/common/admin_service_test.cc
+++ b/stratum/hal/lib/common/admin_service_test.cc
@@ -15,7 +15,7 @@
 
 #include "stratum/hal/lib/common/admin_service.h"
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 

--- a/stratum/hal/lib/common/admin_utils_interface.h
+++ b/stratum/hal/lib/common/admin_utils_interface.h
@@ -109,7 +109,7 @@ class FileSystemHelper {
                               const std::string& old_hash,
                               ::gnoi::types::HashType_HashMethod method) const;
 
-  virtual std::string GetHashSum(std::istream& istream,  // NOLINTNEXTKINE
+  virtual std::string GetHashSum(std::istream& istream,
                                  ::gnoi::types::HashType_HashMethod method) const;
 
   // Create temporary directory and return it name

--- a/stratum/hal/lib/common/admin_utils_interface.h
+++ b/stratum/hal/lib/common/admin_utils_interface.h
@@ -109,8 +109,8 @@ class FileSystemHelper {
                               const std::string& old_hash,
                               ::gnoi::types::HashType_HashMethod method) const;
 
-  virtual std::string GetHashSum(std::istream& istream,
-                                 ::gnoi::types::HashType_HashMethod method) const;
+  virtual std::string GetHashSum(
+      std::istream& istream, ::gnoi::types::HashType_HashMethod method) const;
 
   // Create temporary directory and return it name
   // @return Temporary directory name in std:string

--- a/stratum/hal/lib/common/certificate_management_service.h
+++ b/stratum/hal/lib/common/certificate_management_service.h
@@ -18,7 +18,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_CERTIFICATE_MANAGEMENT_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_CERTIFICATE_MANAGEMENT_SERVICE_H_
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 
 #include <memory>
 

--- a/stratum/hal/lib/common/certificate_management_service.h
+++ b/stratum/hal/lib/common/certificate_management_service.h
@@ -18,19 +18,18 @@
 #ifndef STRATUM_HAL_LIB_COMMON_CERTIFICATE_MANAGEMENT_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_CERTIFICATE_MANAGEMENT_SERVICE_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <memory>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "gnoi/cert/cert.grpc.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/lib/security/auth_policy_checker.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
-#include "stratum/glue/status/status.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/certificate_management_service_test.cc
+++ b/stratum/hal/lib/common/certificate_management_service_test.cc
@@ -15,10 +15,15 @@
 
 #include "stratum/hal/lib/common/certificate_management_service.h"
 
-#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
+#include "absl/synchronization/mutex.h"
+#include "gmock/gmock.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/common/error_buffer.h"
@@ -27,11 +32,6 @@
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/substitute.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/certificate_management_service_test.cc
+++ b/stratum/hal/lib/common/certificate_management_service_test.cc
@@ -15,7 +15,7 @@
 
 #include "stratum/hal/lib/common/certificate_management_service.h"
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 

--- a/stratum/hal/lib/common/client_sync_reader_writer.h
+++ b/stratum/hal/lib/common/client_sync_reader_writer.h
@@ -15,17 +15,16 @@
  * limitations under the License.
  */
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_CLIENT_SYNC_READER_WRITER_H_
 #define STRATUM_HAL_LIB_COMMON_CLIENT_SYNC_READER_WRITER_H_
 
-#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <utility>
 
-#include "stratum/glue/logging.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/logging.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/client_sync_reader_writer.h
+++ b/stratum/hal/lib/common/client_sync_reader_writer.h
@@ -19,7 +19,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_CLIENT_SYNC_READER_WRITER_H_
 #define STRATUM_HAL_LIB_COMMON_CLIENT_SYNC_READER_WRITER_H_
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <utility>
 

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -50,7 +50,7 @@ enum Platform {
   PLT_P4_SOFT_SWITCH = 10;
   PLT_BAREFOOT_TOFINO = 11;
   PLT_BAREFOOT_TOFINO2 = 12;
-  // TODO: Add all the BCM and MLNX based platforms.
+  // TODO(unknown): Add all the BCM and MLNX based platforms.
 }
 
 // List of traffic classes (aka class of services).
@@ -85,11 +85,11 @@ message ChassisConfigParams {
     uint32 lacp_system_priority = 2;
   }
   message NtpConfig {
-    // TODO: See if there is anything in YANG models which can ne
+    // TODO(unknown): See if there is anything in YANG models which can ne
     // used here.
   }
   message PowerConfig {
-    // TODO: See if there is anything in YANG models which can ne
+    // TODO(unknown): See if there is anything in YANG models which can ne
     // used here.
   }
   message FanConfig {
@@ -136,7 +136,7 @@ message ChassisConfigParams {
 
 // Flow-related parameters for for switching nodes (aka chips).
 message NodeFlowParams {
-  // TODO: Complete this.
+  // TODO(unknown): Complete this.
 }
 
 // Config-related parameters for switching nodes (aka chips).
@@ -239,7 +239,7 @@ message NodeConfigParams {
 
 // Flow-related parameters for the ports (singleton and trunk ports).
 message PortFlowParams {
-  // TODO: Complete this.
+  // TODO(unknown): Complete this.
 }
 
 // FEC operational mode for a singleton port.
@@ -256,7 +256,7 @@ message PortConfigParams {
   // These are the only hash config we need to provide per node, for ports that
   // are part of a trunk/lag or ECMP group.
   message HashConfig {
-    // TODO: Instead of hash_select, we need a better way. this is
+    // TODO(unknown): Instead of hash_select, we need a better way. this is
     // RTAG7 specific. Maybe based on the port type?
     int32 rtag7_ecmp_hash_select = 1;
     int32 rtag7_lag_hash_select = 2;
@@ -442,7 +442,7 @@ message GoogleConfig {
       int32 cpu_queue = 2;
       int32 vlan = 3;
       BcmKnetIntfPurpose purpose = 4;
-      // TODO: Anything else?
+      // TODO(unknown): Anything else?
     }
     repeated BcmKnetIntfConfig knet_intf_configs = 1;
   }
@@ -512,8 +512,8 @@ message GoogleConfig {
   }
 
   // BcmBufferConfig defines the buffer carving config for a BCM unit.
-  // TODO: This still needs modification. Not ready yet.
-  // TODO: Add documentation.
+  // TODO(unknown): This still needs modification. Not ready yet.
+  // TODO(unknown): Add documentation.
   message BcmBufferConfig {
     message ServicePoolConfig {
       uint32 sp_num = 1;
@@ -541,7 +541,7 @@ message GoogleConfig {
   }
 
   // BcmRtag7HashConfig defines RTAG7 hash config for a unit.
-  // TODO: Add documentation.
+  // TODO(unknown): Add documentation.
   message BcmRtag7HashConfig {
     enum HashField {
       UNKNOWN_FIELD = 0;
@@ -740,7 +740,7 @@ enum AdminState {
   // HW component is being used by a diagnostics SW underneath and should not be
   // used like a normal component. Setting a HW component to diag mode will
   // eventually change the HW state of the component.
-  // TODO: This mode is not supported at the moment.
+  // TODO(unknown): This mode is not supported at the moment.
   ADMIN_STATE_DIAG = 3;
 }
 
@@ -1200,11 +1200,11 @@ message SetRequest {
     }
     // Data required to set info for a specific node.
     message Node {
-      // TODO: Add this.
+      // TODO(unknown): Add this.
     }
     // Data required to set info for a specific chassis.
     message Chassis {
-      // TODO: Add this.
+      // TODO(unknown): Add this.
     }
     oneof request {
       Port port = 1;

--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -326,9 +326,9 @@ ConfigMonitoringService::~ConfigMonitoringService() {
       // `msg` PROTOBUF to the response that will be sent to the controller.
       InlineGnmiSubscribeStream stream(
           [resp](const ::gnmi::SubscribeResponse& msg) -> bool {
-            // If msg has empty update, it might be a sync_response for GetRequest
-            if (!msg.has_update())
-                return msg.sync_response();
+            // If msg has empty update, it might be a sync_response for
+            // GetRequest
+            if (!msg.has_update()) return msg.sync_response();
             *resp->add_notification() = msg.update();
             return true;
           });

--- a/stratum/hal/lib/common/config_monitoring_service.h
+++ b/stratum/hal/lib/common/config_monitoring_service.h
@@ -15,24 +15,22 @@
  * limitations under the License.
  */
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_CONFIG_MONITORING_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_CONFIG_MONITORING_SERVICE_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <memory>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "gnmi/gnmi.grpc.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/gnmi_publisher.h"
 #include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/lib/security/auth_policy_checker.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/config_monitoring_service.h
+++ b/stratum/hal/lib/common/config_monitoring_service.h
@@ -19,7 +19,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_CONFIG_MONITORING_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_CONFIG_MONITORING_SERVICE_H_
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 
 #include <memory>
 

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -13,15 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 
-#include "stratum/hal/lib/common/config_monitoring_service.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
+#include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
+#include "openconfig/openconfig.pb.h"
 #include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/common/config_monitoring_service.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/gnmi_events.h"
 #include "stratum/hal/lib/common/gnmi_publisher.h"
@@ -32,12 +37,6 @@
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/substitute.h"
-#include "absl/synchronization/mutex.h"
-#include "openconfig/openconfig.pb.h"
 
 DECLARE_string(chassis_config_file);
 DECLARE_string(test_tmpdir);
@@ -1184,7 +1183,8 @@ TEST_P(ConfigMonitoringServiceTest,
 
 TEST_P(ConfigMonitoringServiceTest, CapabilitiesTest) {
   ::gnmi::CapabilityResponse expected_resp;
-  ReadProtoFromTextFile("stratum/hal/lib/common/gnmi_caps.pb.txt", &expected_resp);
+  ReadProtoFromTextFile("stratum/hal/lib/common/gnmi_caps.pb.txt",
+                        &expected_resp);
 
   ::grpc::ServerContext context;
   ::gnmi::CapabilityRequest req;

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -1183,7 +1183,7 @@ TEST_P(ConfigMonitoringServiceTest,
 }
 
 TEST_P(ConfigMonitoringServiceTest, CapabilitiesTest) {
-  ::gnmi::CapabilityResponse expected_resp;  // NOLINTNEXTLINE
+  ::gnmi::CapabilityResponse expected_resp;
   ReadProtoFromTextFile("stratum/hal/lib/common/gnmi_caps.pb.txt", &expected_resp);
 
   ::grpc::ServerContext context;

--- a/stratum/hal/lib/common/diag_service.h
+++ b/stratum/hal/lib/common/diag_service.h
@@ -18,7 +18,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_DIAG_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_DIAG_SERVICE_H_
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 
 #include <memory>
 

--- a/stratum/hal/lib/common/diag_service.h
+++ b/stratum/hal/lib/common/diag_service.h
@@ -18,19 +18,18 @@
 #ifndef STRATUM_HAL_LIB_COMMON_DIAG_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_DIAG_SERVICE_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <memory>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "gnoi/diag/diag.grpc.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/lib/security/auth_policy_checker.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
-#include "stratum/glue/status/status.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/diag_service_test.cc
+++ b/stratum/hal/lib/common/diag_service_test.cc
@@ -13,26 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 
-#include "stratum/hal/lib/common/diag_service.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
+#include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
+#include "gmock/gmock.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/common/diag_service.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_mock.h"
 #include "stratum/lib/security/auth_policy_checker_mock.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/substitute.h"
-#include "absl/synchronization/mutex.h"
 
 using ::testing::IsEmpty;
 

--- a/stratum/hal/lib/common/diag_service_test.cc
+++ b/stratum/hal/lib/common/diag_service_test.cc
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 

--- a/stratum/hal/lib/common/error_buffer.cc
+++ b/stratum/hal/lib/common/error_buffer.cc
@@ -22,7 +22,6 @@
 #include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
 #include "stratum/glue/logging.h"
-#include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 
@@ -41,8 +40,7 @@ void ErrorBuffer::AddError(const ::util::Status& error,
       "): ", msg_to_prepend, error.error_message());
   LOG(ERROR) << error_message;
   if (static_cast<int>(errors_.size()) > FLAGS_max_num_errors_to_track) return;
-  // NOLINTNEXTLINE
-  ::util::Status status = APPEND_ERROR(error.StripMessage())//.SetNoLogging() FIXME
+  ::util::Status status = APPEND_ERROR(error.StripMessage()).without_logging()
                           << error_message;
   errors_.push_back(status);
 }

--- a/stratum/hal/lib/common/file_service.h
+++ b/stratum/hal/lib/common/file_service.h
@@ -18,19 +18,18 @@
 #ifndef STRATUM_HAL_LIB_COMMON_FILE_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_FILE_SERVICE_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <memory>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "gnoi/file/file.grpc.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/lib/security/auth_policy_checker.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
-#include "stratum/glue/status/status.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/file_service.h
+++ b/stratum/hal/lib/common/file_service.h
@@ -18,7 +18,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_FILE_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_FILE_SERVICE_H_
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 
 #include <memory>
 

--- a/stratum/hal/lib/common/file_service_test.cc
+++ b/stratum/hal/lib/common/file_service_test.cc
@@ -15,7 +15,7 @@
 
 #include "stratum/hal/lib/common/file_service.h"
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 

--- a/stratum/hal/lib/common/file_service_test.cc
+++ b/stratum/hal/lib/common/file_service_test.cc
@@ -15,11 +15,16 @@
 
 #include "stratum/hal/lib/common/file_service.h"
 
-#include "grpcpp/grpcpp.h"
 #include <memory>
 #include <string>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
+#include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
+#include "gmock/gmock.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/common/error_buffer.h"
@@ -28,11 +33,6 @@
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/substitute.h"
-#include "absl/synchronization/mutex.h"
 
 using ::testing::IsEmpty;
 

--- a/stratum/hal/lib/common/gnmi_events.h
+++ b/stratum/hal/lib/common/gnmi_events.h
@@ -589,8 +589,8 @@ class EventHandlerListBase {
   mutable absl::Mutex access_lock_;
 
   // A set of event handlers that are interested in this ('E') type of events.
-  std::set<EventHandlerRecordPtr, std::owner_less<EventHandlerRecordPtr>> handlers_
-      GUARDED_BY(access_lock_);
+  std::set<EventHandlerRecordPtr, std::owner_less<EventHandlerRecordPtr>>
+      handlers_ GUARDED_BY(access_lock_);
 };
 
 // A class that keeps track of all event handlers that are interested in

--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -31,7 +31,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/synchronization/mutex.h"
 
-// TODO: Use FLAG_DEFINE for all flags.
+// TODO(unknown): Use FLAG_DEFINE for all flags.
 DEFINE_string(external_stratum_urls, "",
             "Comma-separated list of URLs for server to listen to for external"
             " calls from SDN controller, etc.");

--- a/stratum/hal/lib/common/hal.h
+++ b/stratum/hal/lib/common/hal.h
@@ -15,15 +15,12 @@
  * limitations under the License.
  */
 
-
 // The Hardware Abstraction Layer (HAL) of the stratum stack.
 
 #ifndef STRATUM_HAL_LIB_COMMON_HAL_H_
 #define STRATUM_HAL_LIB_COMMON_HAL_H_
 
 #include <signal.h>
-
-#include "grpcpp/grpcpp.h"
 
 #include <memory>
 #include <string>
@@ -32,6 +29,7 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
+#include "grpcpp/grpcpp.h"
 #include "stratum/hal/lib/common/admin_service.h"
 #include "stratum/hal/lib/common/certificate_management_service.h"
 // #include "stratum/hal/lib/common/cmal_service.h"

--- a/stratum/hal/lib/common/hal.h
+++ b/stratum/hal/lib/common/hal.h
@@ -23,7 +23,7 @@
 
 #include <signal.h>
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 
 #include <memory>
 #include <string>

--- a/stratum/hal/lib/common/hal_test.cc
+++ b/stratum/hal/lib/common/hal_test.cc
@@ -16,8 +16,6 @@
 
 #include "stratum/hal/lib/common/hal.h"
 
-#include <thread>
-
 #include "gflags/gflags.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
@@ -127,7 +125,8 @@ class HalTest : public ::testing::Test {
     FLAGS_forwarding_pipeline_configs_file =
         FLAGS_test_tmpdir + "/forwarding_pipeline_configs_file.pb.txt";
     FLAGS_persistent_config_dir = FLAGS_test_tmpdir + "/config_dir";
-    FLAGS_external_stratum_urls = absl::StrJoin({RandomURL(), RandomURL()}, ",");
+    FLAGS_external_stratum_urls =
+        absl::StrJoin({RandomURL(), RandomURL()}, ",");
     FLAGS_local_stratum_url = RandomURL();
     // FLAGS_cmal_service_url = RandomURL();  // google only
     ASSERT_OK(hal_->SanityCheck());

--- a/stratum/hal/lib/common/openconfig_converter.cc
+++ b/stratum/hal/lib/common/openconfig_converter.cc
@@ -212,7 +212,8 @@ SingletonPortToComponents(const SingletonPort &in) {
       transceiver->set_fec_mode(OPENCONFIGPLATFORMTYPESFECMODETYPE_FEC_ENABLED);
       break;
     case FEC_MODE_OFF:
-      transceiver->set_fec_mode(OPENCONFIGPLATFORMTYPESFECMODETYPE_FEC_DISABLED);
+      transceiver->set_fec_mode(
+          OPENCONFIGPLATFORMTYPESFECMODETYPE_FEC_DISABLED);
       break;
     case FEC_MODE_AUTO:
       transceiver->set_fec_mode(OPENCONFIGPLATFORMTYPESFECMODETYPE_FEC_AUTO);

--- a/stratum/hal/lib/common/openconfig_converter.cc
+++ b/stratum/hal/lib/common/openconfig_converter.cc
@@ -20,12 +20,12 @@
 #include <map>
 #include <string>
 
-#include "stratum/glue/logging.h"
-#include "github.com/openconfig/ygot/proto/ywrapper/ywrapper.pb.h"
-#include "stratum/lib/constants.h"
 #include "absl/strings/substitute.h"
+#include "github.com/openconfig/ygot/proto/ywrapper/ywrapper.pb.h"
 #include "stratum/glue/gtl/map_util.h"
+#include "stratum/glue/logging.h"
 #include "stratum/hal/lib/common/utils.h"
+#include "stratum/lib/constants.h"
 
 namespace stratum {
 
@@ -53,7 +53,7 @@ using namespace openconfig::enums;  // NOLINT
   auto linecard = component->mutable_linecard();
   linecard->mutable_slot_id()->set_value(std::to_string(in.slot()));
 
-  // TODO: There are still a lot of things we are not supporting for
+  // TODO(unknown): There are still a lot of things we are not supporting for
   // nodes, including VLAN configs. Add support for those in the YANG model as
   // well as the proto encodings. Then add support here in the code.
 
@@ -66,8 +66,7 @@ using namespace openconfig::enums;  // NOLINT
 // to:
 //   std::list<openconfig::Device::ComponentKey>
 ////////////////////////////////////////////////////////////////////////////////
-::util::StatusOr<openconfig::Component> ChassisToComponent(
-    const Chassis &in) {
+::util::StatusOr<openconfig::Component> ChassisToComponent(const Chassis &in) {
   openconfig::Component component;
   auto chassis = component.mutable_chassis();
 
@@ -187,8 +186,8 @@ using namespace openconfig::enums;  // NOLINT
     (*bcm_config.mutable_node_id_to_rate_limit_config())[entry.first] =
         oc_rate_limit_cfg;
   }
-// NOLINTNEXTLINE
-  bcm_config.mutable_bcm_chassis_map_id()->set_value(in.google_config().bcm_chassis_map_id());
+  bcm_config.mutable_bcm_chassis_map_id()->set_value(
+      in.google_config().bcm_chassis_map_id());
   return bcm_config;
 }
 
@@ -264,54 +263,53 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   // SingletonPort.speed_bps -> /interfaces/interface/ethernet/config/port-speed
   switch (in.speed_bps()) {
     case 10000000:  // 10Mbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_10MB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_10MB);
       break;
     case 100000000:  // 100Mbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_100MB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_100MB);
       break;
     case 1000000000:  // 1Gbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_1GB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_1GB);
       break;
     case kTenGigBps:  // 10Gbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_10GB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_10GB);
       break;
     case kTwentyFiveGigBps:  // 25Gbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_25GB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_25GB);
       break;
     case kFortyGigBps:  // 40Gbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_40GB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_40GB);
       break;
     case kFiftyGigBps:  // 50Gbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_50GB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_50GB);
       break;
     case kHundredGigBps:  // 100Gbps
-      interface->mutable_ethernet()
-          ->set_port_speed(OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_100GB);
+      interface->mutable_ethernet()->set_port_speed(
+          OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_100GB);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "unknown 'speed_bps' " <<
-      in.ShortDebugString();
+      RETURN_ERROR(ERR_INVALID_PARAM)
+          << "unknown 'speed_bps' " << in.ShortDebugString();
   }
 
   // SingletonPort.config_params.admin_state
   // -> /interfaces/interface/config/enabled
-  if(in.config_params().admin_state() != ADMIN_STATE_UNKNOWN) {
-    interface->mutable_enabled()
-        ->set_value(IsAdminStateEnabled(in.config_params().admin_state()));
+  if (in.config_params().admin_state() != ADMIN_STATE_UNKNOWN) {
+    interface->mutable_enabled()->set_value(
+        IsAdminStateEnabled(in.config_params().admin_state()));
   }
 
   // SingletonPort.config_params.autoneg
   // -> /interfaces/interface/ethernet/config/auto-negotiate
-  interface->mutable_ethernet()
-      ->mutable_auto_negotiate()
-      ->set_value(IsPortAutonegEnabled(in.config_params().autoneg()));
+  interface->mutable_ethernet()->mutable_auto_negotiate()->set_value(
+      IsPortAutonegEnabled(in.config_params().autoneg()));
 
   // FIXME(Yi Tseng): Should we use other field to store interface channel?
   interface->add_physical_channel()->set_value(in.channel());
@@ -327,9 +325,8 @@ SingletonPortToInterfaces(const SingletonPort &in) {
 // to:
 //   std::list<openconfig::Device::ComponentKey>
 ////////////////////////////////////////////////////////////////////////////////
-// NOLINTNEXTLINE
-::util::StatusOr<std::list<openconfig::Device::ComponentKey>> TrunkPortToComponents(
-    const TrunkPort &in) {
+::util::StatusOr<std::list<openconfig::Device::ComponentKey>>
+TrunkPortToComponents(const TrunkPort &in) {
   openconfig::Device::ComponentKey component_key;
   component_key.set_name(in.name());
   auto component = component_key.mutable_component();
@@ -343,9 +340,8 @@ SingletonPortToInterfaces(const SingletonPort &in) {
 // to:
 //   std::list<openconfig::Device::InterfaceKey>
 ////////////////////////////////////////////////////////////////////////////////
-// NOLINTNEXTLINE
-::util::StatusOr<std::list<openconfig::Device::InterfaceKey>> TrunkPortToInterfaces(
-    const ChassisConfig &root, const TrunkPort &in) {
+::util::StatusOr<std::list<openconfig::Device::InterfaceKey>>
+TrunkPortToInterfaces(const ChassisConfig &root, const TrunkPort &in) {
   openconfig::Device::InterfaceKey interface_key;
   interface_key.set_name(in.name());
   auto trunk = interface_key.mutable_interface();
@@ -356,15 +352,17 @@ SingletonPortToInterfaces(const SingletonPort &in) {
 
   // SingletonPort.config_params.admin_state
   // -> /interfaces/interface/config/enabled
-  trunk->mutable_enabled()
-      ->set_value(IsAdminStateEnabled(in.config_params().admin_state()));
+  trunk->mutable_enabled()->set_value(
+      IsAdminStateEnabled(in.config_params().admin_state()));
 
   switch (in.type()) {
-    case TrunkPort::LACP_TRUNK:  // NOLINTNEXTLINE
-      trunk->mutable_aggregation()->set_lag_type(OPENCONFIGIFAGGREGATEAGGREGATIONTYPE_LACP);
+    case TrunkPort::LACP_TRUNK:
+      trunk->mutable_aggregation()->set_lag_type(
+          OPENCONFIGIFAGGREGATEAGGREGATIONTYPE_LACP);
       break;
-    case TrunkPort::STATIC_TRUNK:  // NOLINTNEXTLINE
-      trunk->mutable_aggregation()->set_lag_type(OPENCONFIGIFAGGREGATEAGGREGATIONTYPE_STATIC);
+    case TrunkPort::STATIC_TRUNK:
+      trunk->mutable_aggregation()->set_lag_type(
+          OPENCONFIGIFAGGREGATEAGGREGATIONTYPE_STATIC);
       break;
     default:
       RETURN_ERROR(ERR_INVALID_PARAM) << "unknown trunk type " << in.type();
@@ -378,8 +376,8 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   for (int64 member_id : in.members()) {
     std::string *name = gtl::FindOrNull(id_to_name, member_id);
     if (name == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM) << "unknown 'members' " <<
-      in.ShortDebugString();
+      RETURN_ERROR(ERR_INVALID_PARAM)
+          << "unknown 'members' " << in.ShortDebugString();
     }
 
     auto member = trunk->mutable_aggregation()->add_member();
@@ -453,7 +451,7 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   // TODO(Yi): no index defined in the model
   // to.set_index();
 
-  // TODO: For now by default disable learning on default VLAN.
+  // TODO(unknown): For now by default disable learning on default VLAN.
   // This will eventually come from gNMI.
   auto *vlan_config = to.mutable_config_params()->add_vlan_configs();
   vlan_config->set_block_broadcast(false);
@@ -462,7 +460,7 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  // TODO: There are still a lot of things we are not supporting for
+  // TODO(unknown): There are still a lot of things we are not supporting for
   // nodes, including VLAN configs. Add support for those in the YANG model as
   // well as the proto encodings.  Then add support here in the code.
 
@@ -480,9 +478,7 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   auto component = component_key.component();
   GoogleConfig to;
 
-  if (component.chassis()
-      .vendor_specific()
-      .Is<oc::Bcm::Chassis::Config>()) {
+  if (component.chassis().vendor_specific().Is<oc::Bcm::Chassis::Config>()) {
     oc::Bcm::Chassis::Config bcm_specific;
     component.chassis().vendor_specific().UnpackTo(&bcm_specific);
 
@@ -620,7 +616,6 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   return to;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // converts:
 //   openconfig::Device + openconfig::Interfaces::Interface
@@ -644,8 +639,8 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   }
 
   if (!if_component_key.has_component()) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Cannot find component for interface " <<
-    interface_key.name();
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Cannot find component for interface " << interface_key.name();
   }
 
   const auto &if_component = if_component_key.component();
@@ -680,8 +675,8 @@ SingletonPortToInterfaces(const SingletonPort &in) {
       to.set_speed_bps(kHundredGigBps);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid interface speed " <<
-      interface.ethernet().port_speed();
+      RETURN_ERROR(ERR_INVALID_PARAM)
+          << "Invalid interface speed " << interface.ethernet().port_speed();
   }
 
   auto config_params = to.mutable_config_params();
@@ -715,7 +710,9 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   }
 
   if (interface.has_enabled()) {
-    config_params->set_admin_state(interface.enabled().value() ? ADMIN_STATE_ENABLED : ADMIN_STATE_DISABLED);
+    config_params->set_admin_state(interface.enabled().value()
+                                       ? ADMIN_STATE_ENABLED
+                                       : ADMIN_STATE_DISABLED);
   }
 
   return to;
@@ -724,20 +721,20 @@ SingletonPortToInterfaces(const SingletonPort &in) {
 ////////////////////////////////////////////////////////////////////////////////
 // Some useful macros used in the code.
 ////////////////////////////////////////////////////////////////////////////////
-#define MERGE_ALL_COMPONENTS(list)                                  \
-  for (const auto &component_key : (list)) {                          \
-    to.add_component()->CopyFrom(component_key);                     \
+#define MERGE_ALL_COMPONENTS(list)               \
+  for (const auto &component_key : (list)) {     \
+    to.add_component()->CopyFrom(component_key); \
   }
 
-#define MERGE_ALL_INTERFACES(list)                                  \
-  for (const auto &interface_key : (list)) {                          \
-    to.add_interface()->CopyFrom(interface_key);                      \
+#define MERGE_ALL_INTERFACES(list)               \
+  for (const auto &interface_key : (list)) {     \
+    to.add_interface()->CopyFrom(interface_key); \
   }
 
 }  // namespace
-// NOLINTNEXTLINE
-::util::StatusOr<openconfig::Device> OpenconfigConverter::ChassisConfigToOcDevice(
-    const ChassisConfig &in) {
+
+::util::StatusOr<openconfig::Device>
+OpenconfigConverter::ChassisConfigToOcDevice(const ChassisConfig &in) {
   openconfig::Device to;
 
   // Handle 'description' field.
@@ -749,15 +746,15 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   if (in.has_vendor_config()) {
     ASSIGN_OR_RETURN(auto vendor_config,
                      VendorConfigToBcmConfig(in.vendor_config()));
-    // NOLINTNEXTLINE
-    chassis_component.mutable_chassis()->mutable_vendor_specific()->PackFrom(vendor_config);
+    chassis_component.mutable_chassis()->mutable_vendor_specific()->PackFrom(
+        vendor_config);
   }
 
   auto ckey = to.add_component();
   ckey->set_name(in.chassis().name());
   ckey->mutable_component()->CopyFrom(chassis_component);
 
-//  LOG(INFO) << to.DebugString();
+  //  LOG(INFO) << to.DebugString();
 
   // Handle 'nodes' repeated field.
   for (const auto &hal_node : in.nodes()) {
@@ -784,8 +781,8 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   // Handle 'port_groups' repeated field.
   // Nothing to do here.
 
-  VLOG(1) << "The convetred openconfig::Device proto:\n" <<
-  to.ShortDebugString();
+  VLOG(1) << "The convetred openconfig::Device proto:\n"
+          << to.ShortDebugString();
 
   return to;
 }

--- a/stratum/hal/lib/common/openconfig_converter_test.cc
+++ b/stratum/hal/lib/common/openconfig_converter_test.cc
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <tuple>
-
 #include <google/protobuf/text_format.h>
 
-#include "stratum/hal/lib/common/openconfig_converter.h"
+#include <tuple>
 
+#include "gtest/gtest.h"
 #include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/common/openconfig_converter.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
-#include "gtest/gtest.h"
 
 namespace stratum {
 
@@ -131,16 +130,16 @@ TEST(OpenconfigConverterTest, OcDeviceToVendorConfig) {
       &vendor_config));
   openconfig::Device::ComponentKey *component_key = device.add_component();
 
-  component_key->set_name("dummy switch 1");  // NOLINTNEXTLINE
-  component_key->mutable_component()->mutable_chassis()->mutable_vendor_specific()->PackFrom(vendor_config);
+  component_key->set_name("dummy switch 1");
+  component_key->mutable_component()->mutable_chassis()
+    ->mutable_vendor_specific()->PackFrom(vendor_config);
 
   // linecard
   component_key = device.add_component();
   component_key->set_name(":lc-1");
   component_key->mutable_component()->mutable_id()->set_value("1");
-  // NOLINTNEXTLINE
-  component_key->mutable_component()->mutable_linecard()->mutable_slot_id()->set_value("1");
-
+  component_key->mutable_component()->mutable_linecard()
+    ->mutable_slot_id()->set_value("1");
 
   ::util::StatusOr<ChassisConfig> ret =
       OpenconfigConverter::OcDeviceToChassisConfig(device);
@@ -152,7 +151,6 @@ TEST(OpenconfigConverterTest, OcDeviceToVendorConfig) {
 
   ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
       chassis_config, chassis_config_from_file));
-
 }  // OpenconfigConverterTest.OcDeviceToVendorConfig
 
 #define ASSERT_CONFIG_ERROR(config_class, config_file_path, status_code, \

--- a/stratum/hal/lib/common/openconfig_converter_test.cc
+++ b/stratum/hal/lib/common/openconfig_converter_test.cc
@@ -80,13 +80,15 @@ TEST_P(OpenconfigConverterSimpleTest, OcToChassis) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    ConvertConfig,
-    OpenconfigConverterSimpleTest,
+    ConvertConfig, OpenconfigConverterSimpleTest,
     testing::Values(
-        std::make_tuple("stratum/hal/lib/common/testdata/simple_chassis.pb.txt",
-                        "stratum/hal/lib/common/testdata/simple_oc_device.pb.txt"),
-        std::make_tuple("stratum/hal/lib/common/testdata/port_config_params_chassis.pb.txt",
-                        "stratum/hal/lib/common/testdata/port_config_params_oc_device.pb.txt")));
+        std::make_tuple(
+            "stratum/hal/lib/common/testdata/simple_chassis.pb.txt",
+            "stratum/hal/lib/common/testdata/simple_oc_device.pb.txt"),
+        std::make_tuple(
+            "stratum/hal/lib/common/testdata/port_config_params_chassis.pb.txt",
+            "stratum/hal/lib/common/testdata/"
+            "port_config_params_oc_device.pb.txt")));
 
 TEST(OpenconfigConverterTest, ChassisConfigToOcDevice_VendorConfig) {
   ChassisConfig chassis_config;

--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -15,20 +15,24 @@
  * limitations under the License.
  */
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_P4_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_P4_SERVICE_H_
 
-#include "grpcpp/grpcpp.h"
 #include <pthread.h>
 
+#include <map>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <string>
-#include <set>
 #include <vector>
-#include <map>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/numeric/int128.h"
+#include "absl/synchronization/mutex.h"
+#include "grpcpp/grpcpp.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/common/channel_writer_wrapper.h"
@@ -37,11 +41,6 @@
 #include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/hal/lib/p4/forwarding_pipeline_configs.pb.h"
 #include "stratum/lib/security/auth_policy_checker.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/numeric/int128.h"
-#include "absl/synchronization/mutex.h"
-#include "p4/v1/p4runtime.grpc.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -19,7 +19,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_P4_SERVICE_H_
 #define STRATUM_HAL_LIB_COMMON_P4_SERVICE_H_
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <pthread.h>
 
 #include <memory>

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -16,7 +16,7 @@
 
 #include "stratum/hal/lib/common/p4_service.h"
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 
 #include "gflags/gflags.h"

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -13,30 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "stratum/hal/lib/common/p4_service.h"
 
-#include "grpcpp/grpcpp.h"
 #include <memory>
 
-#include "gflags/gflags.h"
-#include "google/rpc/code.pb.h"
-#include "stratum/glue/net_util/ports.h"
-#include "stratum/glue/status/status_test_util.h"
-#include "stratum/hal/lib/common/error_buffer.h"
-#include "stratum/hal/lib/common/switch_mock.h"
-#include "stratum/lib/security/auth_policy_checker_mock.h"
-#include "stratum/lib/test_utils/matchers.h"
-#include "stratum/lib/utils.h"
-#include "stratum/lib/macros.h"
-#include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "stratum/glue/integral_types.h"
 #include "absl/memory/memory.h"
 #include "absl/numeric/int128.h"
 #include "absl/strings/substitute.h"
 #include "absl/synchronization/mutex.h"
+#include "gflags/gflags.h"
+#include "gmock/gmock.h"
+#include "google/rpc/code.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/net_util/ports.h"
+#include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/common/error_buffer.h"
+#include "stratum/hal/lib/common/switch_mock.h"
+#include "stratum/lib/macros.h"
+#include "stratum/lib/security/auth_policy_checker_mock.h"
+#include "stratum/lib/test_utils/matchers.h"
+#include "stratum/lib/utils.h"
+#include "stratum/public/lib/error.h"
 
 DECLARE_int32(max_num_controllers_per_node);
 DECLARE_int32(max_num_controller_connections);

--- a/stratum/hal/lib/common/server_writer_wrapper.h
+++ b/stratum/hal/lib/common/server_writer_wrapper.h
@@ -19,7 +19,7 @@
 #ifndef STRATUM_HAL_LIB_COMMON_SERVER_WRITER_WRAPPER_H_
 #define STRATUM_HAL_LIB_COMMON_SERVER_WRITER_WRAPPER_H_
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include "stratum/hal/lib/common/writer_interface.h"
 
 namespace stratum {

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -338,7 +338,8 @@ std::string MacAddressToYangString(
     const std::string& yang_string) {
   std::string tmp_str = yang_string;
   // Remove colons
-  tmp_str.erase(std::remove(tmp_str.begin(), tmp_str.end(), ':'), tmp_str.end());
+  tmp_str.erase(std::remove(tmp_str.begin(), tmp_str.end(), ':'),
+                tmp_str.end());
   return strtoull(tmp_str.c_str(), NULL, 16);
 }
 

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -17,7 +17,7 @@
 #include "stratum/hal/lib/common/utils.h"
 
 #include <sstream>  // IWYU pragma: keep
-#include <regex>
+#include <regex>  // NOLINT
 
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -206,8 +206,8 @@ bool ConvertTrunkMemberBlockStateToBool(const TrunkMemberBlockState& state);
 std::string MacAddressToYangString(
     const ::google::protobuf::uint64& mac_address);
 
-// A helper function that convert data received from the gNMI interface into a format
-// expected by the HAL (MAC addresses are expected to be
+// A helper function that convert data received from the gNMI interface into a
+// format expected by the HAL (MAC addresses are expected to be
 // ::google::protobuf::uint64).
 ::google::protobuf::uint64 YangStringToMacAddress(
     const std::string& yang_string);

--- a/stratum/hal/lib/common/yang_parse_tree.cc
+++ b/stratum/hal/lib/common/yang_parse_tree.cc
@@ -16,7 +16,7 @@
 
 #include "stratum/hal/lib/common/yang_parse_tree.h"
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <list>
 #include <string>
 #include <unordered_set>

--- a/stratum/hal/lib/common/yang_parse_tree.cc
+++ b/stratum/hal/lib/common/yang_parse_tree.cc
@@ -13,10 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "stratum/hal/lib/common/yang_parse_tree.h"
 
-#include "grpcpp/grpcpp.h"
 #include <list>
 #include <string>
 #include <unordered_set>
@@ -25,6 +23,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
+#include "grpcpp/grpcpp.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/hal/lib/common/gnmi_publisher.h"
 #include "stratum/hal/lib/common/yang_parse_tree_paths.h"
@@ -162,7 +161,8 @@ void YangParseTree::SendNotification(const GnmiEventPtr& event) {
   std::unordered_set<std::string> singleton_names;
   for (const auto& singleton : change.new_config_.singleton_ports()) {
     if (singleton_names.count(singleton.name())) {
-      return MAKE_ERROR(ERR_INVALID_PARAM) << "Duplicate singleton port name: " << singleton.name();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Duplicate singleton port name: " << singleton.name();
     }
     const NodeConfigParams& node_config =
         node_id_to_node[singleton.node()]
@@ -178,7 +178,8 @@ void YangParseTree::SendNotification(const GnmiEventPtr& event) {
     // TODO(b/70300190): Once TrunkPort message in common.proto is extended to
     // include node_id remove 3 following lines.
     if (trunk_names.count(trunk.name())) {
-      return MAKE_ERROR(ERR_INVALID_PARAM) << "Duplicate trunk name: " << trunk.name();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Duplicate trunk name: " << trunk.name();
     }
     constexpr uint64 kNodeIdUnknown = 0xFFFF;
     uint64 node_id = trunk.members_size() ? port_id_to_node_id[trunk.members(0)]
@@ -196,7 +197,8 @@ void YangParseTree::SendNotification(const GnmiEventPtr& event) {
   std::unordered_set<std::string> node_names;
   for (const auto& node : change.new_config_.nodes()) {
     if (node_names.count(node.name())) {
-      return MAKE_ERROR(ERR_INVALID_PARAM) << "Duplicate node name: " << node.name();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Duplicate node name: " << node.name();
     }
     AddSubtreeNode(node);
     node_names.insert(node.name());

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -2454,7 +2454,7 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   }
 
   for (const auto& e : q_num_to_trafic_class) {
-    // TODO: Use consistent names for queue numbers. Either q_num
+    // TODO(unknown): Use consistent names for queue numbers. Either q_num
     // or q_id or queue_id.
     uint32 queue_id = e.first;
     std::string queue_name = TrafficClass_Name(e.second);

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -1063,12 +1063,12 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
     // Update the chassis config
     ChassisConfig* new_config = config->writable();
     for (int i = 0; i < new_config->singleton_ports_size(); i++) {
-        auto* singleton_port = new_config->mutable_singleton_ports(i);
-        if (singleton_port->node() == node_id &&
-            singleton_port->id() == port_id) {
-            singleton_port->mutable_config_params()->set_mac_address(mac_address);
-            break;
-        }
+      auto* singleton_port = new_config->mutable_singleton_ports(i);
+      if (singleton_port->node() == node_id &&
+          singleton_port->id() == port_id) {
+        singleton_port->mutable_config_params()->set_mac_address(mac_address);
+        break;
+      }
     }
 
     // Update the YANG parse tree.
@@ -1077,8 +1077,8 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
                                       GnmiSubscribeStream* stream) {
       // This leaf represents configuration data. Return what was known when it
       // was configured!
-      return SendResponse(GetResponse(path, MacAddressToYangString(mac_address)),
-                          stream);
+      return SendResponse(
+          GetResponse(path, MacAddressToYangString(mac_address)), stream);
     };
     node->SetOnTimerHandler(poll_functor)
         ->SetOnPollHandler(poll_functor);
@@ -2262,9 +2262,8 @@ void SetUpDebugNodesNodePacketIoDebugString(uint64 node_id, TreeNode* node,
 
 ////////////////////////////////////////////////////////////////////////////////
 // /components/component[name=<name-of-component>]/integrated-circuit/config/node-id
-void SetUpComponentsComponentIntegratedCircuitConfigNodeId(uint64 node_id,
-                                                           TreeNode* node,
-                                                           YangParseTree* tree) {
+void SetUpComponentsComponentIntegratedCircuitConfigNodeId(
+    uint64 node_id, TreeNode* node, YangParseTree* tree) {
   auto poll_functor = [node_id](const GnmiEvent& event,
                                 const ::gnmi::Path& path,
                                 GnmiSubscribeStream* stream) {
@@ -2528,22 +2527,25 @@ void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
   bool port_enabled = false;
   uint64 mac_address = 0;
   if (singleton.has_config_params()) {
-    port_auto_neg_enabled = IsPortAutonegEnabled(singleton.config_params().autoneg());
+    port_auto_neg_enabled =
+        IsPortAutonegEnabled(singleton.config_params().autoneg());
     port_enabled = IsAdminStateEnabled(singleton.config_params().admin_state());
     mac_address = singleton.config_params().mac_address();
   }
 
   node = tree->AddNode(GetPath("interfaces")(
       "interface", name)("ethernet")("config")("auto-negotiate")());
-  SetUpInterfacesInterfaceEthernetConfigAutoNegotiate(node_id, port_id,
-                                                      port_auto_neg_enabled, node, tree);
+  SetUpInterfacesInterfaceEthernetConfigAutoNegotiate(
+      node_id, port_id, port_auto_neg_enabled, node, tree);
   node = tree->AddNode(GetPath("interfaces")(
       "interface", name)("config")("enabled")());
-  SetUpInterfacesInterfaceConfigEnabled(port_enabled, node_id, port_id, node, tree);
+  SetUpInterfacesInterfaceConfigEnabled(port_enabled, node_id, port_id, node,
+                                        tree);
 
   node = tree->AddNode(GetPath("interfaces")(
       "interface", name)("ethernet")("config")("mac-address")());
-  SetUpInterfacesInterfaceEthernetConfigMacAddress(node_id, port_id, mac_address, node, tree);
+  SetUpInterfacesInterfaceEthernetConfigMacAddress(node_id, port_id,
+                                                   mac_address, node, tree);
 
   // Paths for transceiver
   node = tree->AddNode(GetPath("components")(
@@ -2706,9 +2708,10 @@ void YangParseTreePaths::AddSubtreeAllInterfaces(YangParseTree* tree) {
           return node.DoOnChangeRegistration(record);
         });
     return status;
-  };
+  };  // NOLINT(readability/braces)
 
-  auto interfaces_on_poll = [tree](const GnmiEvent& event, const ::gnmi::Path& path,
+  auto interfaces_on_poll = [tree](const GnmiEvent& event,
+                                   const ::gnmi::Path& path,
                                    GnmiSubscribeStream* stream)
   EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_) {
     // Polling a wildcard node means that all matching nodes have to
@@ -2722,7 +2725,7 @@ void YangParseTreePaths::AddSubtreeAllInterfaces(YangParseTree* tree) {
     APPEND_STATUS_IF_ERROR(
         status, YangParseTreePaths::SendEndOfSeriesMessage(stream));
     return status;
-  };
+  };  // NOLINT(readability/braces)
 
   // Add support for "/interfaces/interface/...".
   tree->AddNode(GetPath("interfaces")("interface")("...")())

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -1041,7 +1041,8 @@ TEST_F(YangParseTreeTest,
   EXPECT_EQ(resp.update().update(0).val().string_val(), kMacAddressYangString);
 }
 
-// Check if the 'config/mac-address' OnUpdate action rejects malformed mac string.
+// Check if the 'config/mac-address' OnUpdate action rejects malformed mac
+// string.
 TEST_F(YangParseTreeTest,
        InterfacesInterfaceEthernetConfigMacAddressOnUpdateFailure) {
   auto path = GetPath("interfaces")(
@@ -1077,18 +1078,18 @@ TEST_F(YangParseTreeTest,
               StatusIs(_, _, ContainsRegex("not a TypedValue message")));
 
   for (auto mac_string : kMacStrings) {
-      // Check reaction to wrong value.
-      invalid_val.set_string_val(mac_string);
-      EXPECT_THAT(ExecuteOnUpdate(path, invalid_val,
-                                  /* SetValue will not be called */ nullptr,
-                                  /* Notification will not be called */ nullptr),
-                  StatusIs(_, _, ContainsRegex("wrong value")));
+    // Check reaction to wrong value.
+    invalid_val.set_string_val(mac_string);
+    EXPECT_THAT(ExecuteOnUpdate(path, invalid_val,
+                                /* SetValue will not be called */ nullptr,
+                                /* Notification will not be called */ nullptr),
+                StatusIs(_, _, ContainsRegex("wrong value")));
 
-      // Check if mac_address remains unchanged.
-      ASSERT_OK(ExecuteOnPoll(path, &resp));
+    // Check if mac_address remains unchanged.
+    ASSERT_OK(ExecuteOnPoll(path, &resp));
 
-      ASSERT_THAT(resp.update().update(), SizeIs(1));
-      EXPECT_EQ(resp.update().update(0).val().string_val(), kMacAddressAsString);
+    ASSERT_THAT(resp.update().update(), SizeIs(1));
+    EXPECT_EQ(resp.update().update(0).val().string_val(), kMacAddressAsString);
   }
 }
 

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -1049,25 +1049,25 @@ TEST_F(YangParseTreeTest,
 
   static constexpr char kMacAddressAsString[] = "11:22:33:44:55:66";
   static constexpr char kMacStrings[][21] = {
-      "11:22:33:44:55",       // Too short string
-      "11:22:33:44:55:66:77", // Too long string
-      "11;22;33;44;55;66",    // Incorrect delimiter
-      "11-22-33-44-55-66",    // Unsupported delimiter
-      "11::22:33:44:55:66",   // Too many delimiter in between
-      ":11:22:33:44:55:66",   // Too many delimiter in the beginning
-      "11:22:33:44:55:66:",   // Too many delimiter in the end
-      "1122:3344:5566",       // Unsupported format
-      "0",                    // No colon
-      "00112233445566",       // No colon
-      "11:22:333:44:55:66",   // Too many hex digits
-      "11:22:3:44:55:66",     // Too few hex digits
-      "",                     // empty mac string
-      "st:ra:tu:mr:oc:ks"     // None hex digits
+      "11:22:33:44:55",        // Too short string
+      "11:22:33:44:55:66:77",  // Too long string
+      "11;22;33;44;55;66",     // Incorrect delimiter
+      "11-22-33-44-55-66",     // Unsupported delimiter
+      "11::22:33:44:55:66",    // Too many delimiter in between
+      ":11:22:33:44:55:66",    // Too many delimiter in the beginning
+      "11:22:33:44:55:66:",    // Too many delimiter in the end
+      "1122:3344:5566",        // Unsupported format
+      "0",                     // No colon
+      "00112233445566",        // No colon
+      "11:22:333:44:55:66",    // Too many hex digits
+      "11:22:3:44:55:66",      // Too few hex digits
+      "",                      // empty mac string
+      "st:ra:tu:mr:oc:ks"      // None hex digits
     };
 
   // Set new value.
   ::gnmi::TypedValue invalid_val;
-  ::gnmi::Value wrong_type_val ;
+  ::gnmi::Value wrong_type_val;
   ::gnmi::SubscribeResponse resp;
 
   // Check reaction to wrong value type.
@@ -1076,7 +1076,7 @@ TEST_F(YangParseTreeTest,
                               /* Notification will not be called */ nullptr),
               StatusIs(_, _, ContainsRegex("not a TypedValue message")));
 
-  for(auto mac_string : kMacStrings){
+  for (auto mac_string : kMacStrings) {
       // Check reaction to wrong value.
       invalid_val.set_string_val(mac_string);
       EXPECT_THAT(ExecuteOnUpdate(path, invalid_val,

--- a/stratum/hal/lib/dummy/dummy_box.h
+++ b/stratum/hal/lib/dummy/dummy_box.h
@@ -15,22 +15,21 @@
 #ifndef STRATUM_HAL_LIB_DUMMY_DUMMY_BOX_H_
 #define STRATUM_HAL_LIB_DUMMY_DUMMY_BOX_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <functional>
 #include <memory>
 #include <vector>
 
-#include "absl/time/time.h"
-#include "absl/synchronization/mutex.h"
-#include "stratum/glue/integral_types.h"
-#include "stratum/hal/lib/common/gnmi_events.h"
-#include "stratum/glue/status/status.h"
 #include "absl/container/flat_hash_map.h"
-#include "stratum/hal/lib/dummy/dummy_test.pb.h"
-#include "stratum/hal/lib/dummy/dummy_test.grpc.pb.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+#include "grpcpp/grpcpp.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/common/gnmi_events.h"
 #include "stratum/hal/lib/common/phal_interface.h"
 #include "stratum/hal/lib/common/writer_interface.h"
+#include "stratum/hal/lib/dummy/dummy_test.grpc.pb.h"
+#include "stratum/hal/lib/dummy/dummy_test.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/dummy/dummy_box.h
+++ b/stratum/hal/lib/dummy/dummy_box.h
@@ -15,7 +15,7 @@
 #ifndef STRATUM_HAL_LIB_DUMMY_DUMMY_BOX_H_
 #define STRATUM_HAL_LIB_DUMMY_DUMMY_BOX_H_
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 
 #include <functional>
 #include <memory>

--- a/stratum/hal/lib/p4/p4_table_mapper.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper.cc
@@ -85,7 +85,7 @@ P4TableMapper::~P4TableMapper() { Shutdown().IgnoreError(); }
     return ::util::OkStatus();
   }
 
-  // TODO: If the old pushed forwarding pipeline config needs to be
+  // TODO(unknown): If the old pushed forwarding pipeline config needs to be
   // examined to handle the diff, do this here. At the moment, there is no
   // need to do this though. We recreate the state from scratch as part of any
   // new config push.
@@ -429,7 +429,7 @@ std::string Uint32ToByteStream(uint32 val) {
   return bytes;
 }
 
-// TODO: If needed, add extra validation of the unsigned int values to
+// TODO(unknown): If needed, add extra validation of the unsigned int values to
 // to be in range [1, 2^bitwidth -1].
 ::util::Status DeparseMetadataHelper(
     const MetadataTypeToIdBitwidthMap& metadata_type_to_id_bitwidth_pair,

--- a/stratum/hal/lib/phal/attribute_database.cc
+++ b/stratum/hal/lib/phal/attribute_database.cc
@@ -221,7 +221,8 @@ AttributeDatabase::MakePhalDB(
       AttributeGroup::From(PhalDB::descriptor());
 
   // Now load the config into the attribute database
-  RETURN_IF_ERROR(configurator->ConfigurePhalDB(phal_config, root_group.get()));
+  RETURN_IF_ERROR(
+      configurator->ConfigurePhalDB(&phal_config, root_group.get()));
 
   ASSIGN_OR_RETURN(
       std::unique_ptr<AttributeDatabase> database,

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
@@ -15,12 +15,14 @@
 
 #include "stratum/hal/lib/phal/onlp/onlp_wrapper.h"
 
-#include "stratum/hal/lib/common/common.pb.h"
-#include "stratum/lib/macros.h"
+#include <string>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/strip.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.h
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.h
@@ -19,24 +19,25 @@
 #define STRATUM_HAL_LIB_PHAL_ONLP_ONLP_WRAPPER_H_
 
 extern "C" {
-#include <onlp/onlp.h>
-#include <onlp/oids.h>
-#include <onlp/sfp.h>
 #include <onlp/fan.h>
-#include <onlp/psu.h>
-#include <onlp/thermal.h>
 #include <onlp/led.h>
+#include <onlp/oids.h>
+#include <onlp/onlp.h>
+#include <onlp/psu.h>
+#include <onlp/sfp.h>
+#include <onlp/thermal.h>
 }
 
 #include <bitset>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "stratum/hal/lib/common/common.pb.h"
-#include "stratum/lib/macros.h"
 #include "absl/synchronization/mutex.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/onlp/switch_configurator.cc
+++ b/stratum/hal/lib/phal/onlp/switch_configurator.cc
@@ -117,12 +117,12 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
 // Configure the switch's attribute database with the given
 // PhalInitConfig config.
 ::util::Status OnlpSwitchConfigurator::ConfigurePhalDB(
-    PhalInitConfig& phal_config, AttributeGroup* root) {
+    PhalInitConfig* phal_config, AttributeGroup* root) {
   // Lock the root group
   auto mutable_root = root->AcquireMutable();
 
   // Add cards
-  for (auto& card_config : *phal_config.mutable_cards()) {
+  for (auto& card_config : *phal_config->mutable_cards()) {
     ASSIGN_OR_RETURN(auto card, mutable_root->AddRepeatedChildGroup("cards"));
     std::unique_ptr<MutableAttributeGroup> mutable_card =
         card->AcquireMutable();
@@ -130,7 +130,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
     // Use chassis cache policy if we have no card policy
     if (!card_config.has_cache_policy()) {
       card_config.set_allocated_cache_policy(
-          new CachePolicyConfig(phal_config.cache_policy()));
+          new CachePolicyConfig(phal_config->cache_policy()));
     }
 
     // Add ports per card
@@ -148,7 +148,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
   }
 
   // Add Fans
-  for (auto& fan_tray_config : *phal_config.mutable_fan_trays()) {
+  for (auto& fan_tray_config : *phal_config->mutable_fan_trays()) {
     // Add Fan Tray to attribute DB
     ASSIGN_OR_RETURN(auto fan_tray,
                      mutable_root->AddRepeatedChildGroup("fan_trays"));
@@ -157,7 +157,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
     // Use chassis cache policy if we have no fan tray policy
     if (!fan_tray_config.has_cache_policy()) {
       fan_tray_config.set_allocated_cache_policy(
-          new CachePolicyConfig(phal_config.cache_policy()));
+          new CachePolicyConfig(phal_config->cache_policy()));
     }
 
     // Add Fans per tray
@@ -174,7 +174,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
   }
 
   // Add PSUs
-  for (auto& psu_tray_config : *phal_config.mutable_psu_trays()) {
+  for (auto& psu_tray_config : *phal_config->mutable_psu_trays()) {
     // Add PSU Tray to attribute DB
     ASSIGN_OR_RETURN(auto psu_tray,
                      mutable_root->AddRepeatedChildGroup("psu_trays"));
@@ -183,7 +183,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
     // Use chassis cache policy if we have no psu tray policy
     if (!psu_tray_config.has_cache_policy()) {
       psu_tray_config.set_allocated_cache_policy(
-          new CachePolicyConfig(phal_config.cache_policy()));
+          new CachePolicyConfig(phal_config->cache_policy()));
     }
 
     // Add PSUs per tray
@@ -200,7 +200,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
   }
 
   // Add LEDs
-  for (auto led_group_config : *phal_config.mutable_led_groups()) {
+  for (auto led_group_config : *phal_config->mutable_led_groups()) {
     // Add LED Group to attribute DB
     ASSIGN_OR_RETURN(auto group,
                      mutable_root->AddRepeatedChildGroup("led_groups"));
@@ -209,7 +209,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
     // Use chassis cache policy if we have no led group policy
     if (!led_group_config.has_cache_policy()) {
       led_group_config.set_allocated_cache_policy(
-          new CachePolicyConfig(phal_config.cache_policy()));
+          new CachePolicyConfig(phal_config->cache_policy()));
     }
 
     // Add LEDs
@@ -226,7 +226,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
   }
 
   // Add Thermals
-  for (auto thermal_group_config : *phal_config.mutable_thermal_groups()) {
+  for (auto thermal_group_config : *phal_config->mutable_thermal_groups()) {
     // Add Thermal Group to attribute DB
     ASSIGN_OR_RETURN(auto group,
                      mutable_root->AddRepeatedChildGroup("thermal_groups"));
@@ -235,7 +235,7 @@ OnlpSwitchConfigurator::Make(PhalInterface* phal_interface,
     // Use chassis cache policy if we have no thermal group policy
     if (!thermal_group_config.has_cache_policy()) {
       thermal_group_config.set_allocated_cache_policy(
-          new CachePolicyConfig(phal_config.cache_policy()));
+          new CachePolicyConfig(phal_config->cache_policy()));
     }
 
     // Add Thermals

--- a/stratum/hal/lib/phal/onlp/switch_configurator.h
+++ b/stratum/hal/lib/phal/onlp/switch_configurator.h
@@ -43,7 +43,7 @@ class OnlpSwitchConfigurator : public SwitchConfigurator {
   ::util::Status CreateDefaultConfig(PhalInitConfig* config) const override;
 
   // Configure the Phal DB
-  ::util::Status ConfigurePhalDB(const PhalInitConfig& config,
+  ::util::Status ConfigurePhalDB(PhalInitConfig* config,
                                  AttributeGroup* root) override;
 
  private:

--- a/stratum/hal/lib/phal/onlp/switch_configurator.h
+++ b/stratum/hal/lib/phal/onlp/switch_configurator.h
@@ -43,7 +43,7 @@ class OnlpSwitchConfigurator : public SwitchConfigurator {
   ::util::Status CreateDefaultConfig(PhalInitConfig* config) const override;
 
   // Configure the Phal DB
-  ::util::Status ConfigurePhalDB(PhalInitConfig& config,
+  ::util::Status ConfigurePhalDB(const PhalInitConfig& config,
                                  AttributeGroup* root) override;
 
  private:

--- a/stratum/hal/lib/phal/onlp/switch_configurator_test.cc
+++ b/stratum/hal/lib/phal/onlp/switch_configurator_test.cc
@@ -206,7 +206,7 @@ TEST_F(OnlpSwitchConfiguratorTest, CanConfigurePhalDB) {
   }
 
   ASSERT_OK(configurator_->ConfigurePhalDB(
-      config_,
+      &config_,
       (AttributeGroup*)root_group_.get()));  // NOLINT
 }
 

--- a/stratum/hal/lib/phal/switch_configurator.h
+++ b/stratum/hal/lib/phal/switch_configurator.h
@@ -36,7 +36,7 @@ class SwitchConfigurator {
 
   // Virtual function implemented by each derived class to
   // read the phal_init_config file and configure the Phal DB
-  virtual ::util::Status ConfigurePhalDB(const PhalInitConfig& config,
+  virtual ::util::Status ConfigurePhalDB(PhalInitConfig* config,
                                          AttributeGroup* root) = 0;
 };
 

--- a/stratum/hal/lib/phal/switch_configurator.h
+++ b/stratum/hal/lib/phal/switch_configurator.h
@@ -36,8 +36,8 @@ class SwitchConfigurator {
 
   // Virtual function implemented by each derived class to
   // read the phal_init_config file and configure the Phal DB
-  virtual ::util::Status ConfigurePhalDB(  // NOLINTNEXTLINE
-    PhalInitConfig& config, AttributeGroup* root) = 0;
+  virtual ::util::Status ConfigurePhalDB(const PhalInitConfig& config,
+                                         AttributeGroup* root) = 0;
 };
 
 }  // namespace phal

--- a/stratum/hal/stub/embedded/main.cc
+++ b/stratum/hal/stub/embedded/main.cc
@@ -13,35 +13,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // This file contains the code for a version of Stratum stub intended to be
 // used on the embedded switches. Therefore the code here does not use any
 // non-portable google3 code (e.g. no use of //net/grpc). Note that although
 // this is intended to run on embedded switches, we still build a host version
 // of this binary as well for cases when we run this stub on local desktops.
+
 #include <arpa/inet.h>
-#include "grpcpp/grpcpp.h"
 #include <linux/filter.h>
 #include <linux/if_ether.h>
 #include <net/ethernet.h>
 #include <sstream>
 #include <string>
 
-#include "gflags/gflags.h"
-#include "google/protobuf/any.pb.h"
-#include "google/rpc/code.pb.h"
-#include "stratum/glue/integral_types.h"
 #include "absl/base/macros.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/memory/memory.h"
 #include "absl/numeric/int128.h"
 #include "absl/synchronization/mutex.h"
+#include "gflags/gflags.h"
 #include "gnmi/gnmi.grpc.pb.h"
+#include "google/protobuf/any.pb.h"
+#include "google/rpc/code.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "openconfig/openconfig.pb.h"
 #include "p4/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
+#include "stratum/glue/gtl/map_util.h"
 #include "stratum/glue/init_google.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
-#include "openconfig/openconfig.pb.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/openconfig_converter.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
@@ -49,7 +50,6 @@
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
-#include "stratum/glue/gtl/map_util.h"
 
 DEFINE_string(url, stratum::kLocalStratumUrl,
               "URL for Stratum server to connect to.");

--- a/stratum/hal/stub/embedded/main.cc
+++ b/stratum/hal/stub/embedded/main.cc
@@ -20,7 +20,7 @@
 // this is intended to run on embedded switches, we still build a host version
 // of this binary as well for cases when we run this stub on local desktops.
 #include <arpa/inet.h>
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <linux/filter.h>
 #include <linux/if_ether.h>
 #include <net/ethernet.h>

--- a/stratum/lib/channel/channel_test.cc
+++ b/stratum/lib/channel/channel_test.cc
@@ -232,8 +232,9 @@ TEST(ChannelTest, TestBlockingWrite) {
 
 namespace {
 
-ABSL_CONST_INIT absl::Mutex arr_dst_lock(absl::kConstInit);  // NOLINTNEXTLINE
- // Opensource version of absl::CondVar has takes no arguments: https://github.com/abseil/abseil-cpp/blob/master/absl/synchronization/mutex.h#L777
+ABSL_CONST_INIT absl::Mutex arr_dst_lock(absl::kConstInit);
+// Opensource version of absl::CondVar has takes no arguments:
+// https://github.com/abseil/abseil-cpp/blob/master/absl/synchronization/mutex.h#L777
 absl::CondVar arr_dst_done /*(base::LINKER_INITIALIZED)*/;
 constexpr size_t kArrTestSize = 5;
 int test_arr_src[kArrTestSize];

--- a/stratum/lib/utils.cc
+++ b/stratum/lib/utils.cc
@@ -222,7 +222,7 @@ std::string BaseName(const std::string& path) {
 }
    END GOOGLE ONLY */
 
-// TODO: At the moment this function will not work well for
+// TODO(unknown): At the moment this function will not work well for
 // complex messages with repeated fields or maps. Find a better way.
 bool ProtoLess(const google::protobuf::Message& m1,
                const google::protobuf::Message& m2) {
@@ -238,7 +238,7 @@ bool ProtoEqual(const google::protobuf::Message& m1, const google::protobuf::Mes
 }
    END GOOGLE ONLY */
 
-// TODO: At the moment this function will not work well for
+// TODO(unknown): At the moment this function will not work well for
 // complex messages with repeated fields or maps. Find a better way.
 size_t ProtoHash(const google::protobuf::Message& m) {
   std::hash<std::string> string_hasher;

--- a/stratum/lib/utils.h
+++ b/stratum/lib/utils.h
@@ -18,7 +18,7 @@
 #ifndef STRATUM_LIB_UTILS_H_
 #define STRATUM_LIB_UTILS_H_
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 #include <libgen.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/stratum/lib/utils.h
+++ b/stratum/lib/utils.h
@@ -18,7 +18,6 @@
 #ifndef STRATUM_LIB_UTILS_H_
 #define STRATUM_LIB_UTILS_H_
 
-#include "grpcpp/grpcpp.h"
 #include <libgen.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -38,8 +37,9 @@
 #include "google/protobuf/util/message_differencer.h"
 #include "google/rpc/code.pb.h"
 #include "google/rpc/status.pb.h"
-#include "stratum/glue/status/status.h"
+#include "grpcpp/grpcpp.h"
 #include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 
 namespace stratum {
 

--- a/stratum/p4c_backends/fpm/annotation_mapper.cc
+++ b/stratum/p4c_backends/fpm/annotation_mapper.cc
@@ -229,8 +229,8 @@ bool AnnotationMapper::HandleActionAnnotations(const std::string& action_name,
   return name_ok;
 }
 
-bool AnnotationMapper::MapActionAnnotation(const std::string& annotation,
-                          hal::P4ActionDescriptor* action_descriptor) {
+bool AnnotationMapper::MapActionAnnotation(
+    const std::string& annotation, hal::P4ActionDescriptor* action_descriptor) {
   const auto& iter = annotation_map_.action_addenda_map().find(annotation);
   if (iter == annotation_map_.action_addenda_map().end())
     return true;  // It is OK not to have a matching annotation.
@@ -242,8 +242,8 @@ bool AnnotationMapper::MapActionAnnotation(const std::string& annotation,
   for (const auto& addenda_name : map_value.addenda_names()) {
     auto action_addendum = action_lookup_.FindAddenda(addenda_name);
     if (action_addendum == nullptr) {
-      LOG(ERROR) << "Unable to find action addenda named "
-                 << addenda_name << " for annotation " << annotation;
+      LOG(ERROR) << "Unable to find action addenda named " << addenda_name
+                 << " for annotation " << annotation;
       return false;
     }
 
@@ -259,10 +259,12 @@ bool AnnotationMapper::MapActionAnnotation(const std::string& annotation,
     }
 
     if (action_addendum->has_assignments_addenda()) {
-      *action_descriptor->add_assignments() = action_addendum->assignments_addenda();
+      *action_descriptor->add_assignments() =
+          action_addendum->assignments_addenda();
     }
     if (action_addendum->primitive_ops_addenda() != P4_ACTION_TYPE_UNKNOWN) {
-      action_descriptor->add_primitive_ops(action_addendum->primitive_ops_addenda());
+      action_descriptor->add_primitive_ops(
+          action_addendum->primitive_ops_addenda());
     }
   }
 

--- a/stratum/p4c_backends/fpm/annotation_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/annotation_mapper_test.cc
@@ -259,7 +259,8 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionType) {
 // In this test, test_pipeline_cfg_ has an action descriptor that gets custom
 // replacement assignments and device data from the action descriptor name
 // annotation. The tested action is in the test annotation files.
-TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionAssignmentsReplace) {
+TEST_F(AnnotationMapperTest,
+       TestProcessAnnotationsMapActionAssignmentsReplace) {
   SetUpAnnotationFileList();
   EXPECT_TRUE(mapper_.Init());
 
@@ -267,9 +268,12 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionAssignmentsReplace) 
   const std::string kActionParameterName = "action-parameter-name-1";
   const std::string kActionDestinationFieldName = "action-destination-name-1";
   hal::P4TableMapValue table_map_value;
-  table_map_value.mutable_action_descriptor()->set_type(P4_ACTION_TYPE_FUNCTION);
-  auto assignment = table_map_value.mutable_action_descriptor()->add_assignments();
-  assignment->mutable_assigned_value()->set_parameter_name(kActionParameterName);
+  table_map_value.mutable_action_descriptor()->set_type(
+      P4_ACTION_TYPE_FUNCTION);
+  auto assignment =
+      table_map_value.mutable_action_descriptor()->add_assignments();
+  assignment->mutable_assigned_value()->set_parameter_name(
+      kActionParameterName);
   assignment->set_destination_field_name(kActionDestinationFieldName);
   (*test_pipeline_cfg_.mutable_table_map())[kActionName] = table_map_value;
 
@@ -282,7 +286,8 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionAssignmentsReplace) 
   EXPECT_FALSE(annotated_descriptor.device_data(0).name().empty());
   EXPECT_FALSE(annotated_descriptor.device_data(0).data().empty());
   ASSERT_EQ(1, annotated_descriptor.assignments().size());
-  EXPECT_FALSE(annotated_descriptor.assignments(0).destination_field_name().empty());
+  EXPECT_FALSE(
+      annotated_descriptor.assignments(0).destination_field_name().empty());
   EXPECT_TRUE(annotated_descriptor.assignments(0).has_assigned_value());
 }
 
@@ -297,8 +302,10 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionAssignmentsAdd) {
   const std::string kActionParameterName = "action-parameter-name-1";
   const std::string kActionDestinationFieldName = "action-destination-name-1";
   hal::P4TableMapValue table_map_value;
-  table_map_value.mutable_action_descriptor()->set_type(P4_ACTION_TYPE_FUNCTION);
-  auto assignment = table_map_value.mutable_action_descriptor()->add_assignments();
+  table_map_value.mutable_action_descriptor()->set_type(
+      P4_ACTION_TYPE_FUNCTION);
+  auto assignment =
+      table_map_value.mutable_action_descriptor()->add_assignments();
   assignment->mutable_assigned_value()->set_constant_param(1);
   assignment->set_destination_field_name(kActionDestinationFieldName);
   (*test_pipeline_cfg_.mutable_table_map())[kActionName] = table_map_value;
@@ -312,16 +319,20 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionAssignmentsAdd) {
   EXPECT_FALSE(annotated_descriptor.device_data(0).name().empty());
   EXPECT_FALSE(annotated_descriptor.device_data(0).data().empty());
   ASSERT_EQ(2, annotated_descriptor.assignments().size());
-  EXPECT_FALSE(annotated_descriptor.assignments(0).destination_field_name().empty());
+  EXPECT_FALSE(
+      annotated_descriptor.assignments(0).destination_field_name().empty());
   EXPECT_TRUE(annotated_descriptor.assignments(0).has_assigned_value());
-  EXPECT_FALSE(annotated_descriptor.assignments(1).destination_field_name().empty());
+  EXPECT_FALSE(
+      annotated_descriptor.assignments(1).destination_field_name().empty());
   EXPECT_TRUE(annotated_descriptor.assignments(1).has_assigned_value());
   EXPECT_NE(annotated_descriptor.assignments(0).destination_field_name(),
             annotated_descriptor.assignments(1).destination_field_name());
-  EXPECT_NE(annotated_descriptor.assignments(0).assigned_value().constant_param(),
-            annotated_descriptor.assignments(1).assigned_value().constant_param());
-  EXPECT_NE(annotated_descriptor.assignments(0).assigned_value().parameter_name(),
-            annotated_descriptor.assignments(1).assigned_value().parameter_name());
+  EXPECT_NE(
+      annotated_descriptor.assignments(0).assigned_value().constant_param(),
+      annotated_descriptor.assignments(1).assigned_value().constant_param());
+  EXPECT_NE(
+      annotated_descriptor.assignments(0).assigned_value().parameter_name(),
+      annotated_descriptor.assignments(1).assigned_value().parameter_name());
 }
 
 // In this test, test_pipeline_cfg_ has an action descriptor that gets multiple
@@ -352,16 +363,20 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsMapActionMulti) {
             annotated_descriptor.device_data(1).data());
 
   ASSERT_EQ(2, annotated_descriptor.assignments().size());
-  EXPECT_FALSE(annotated_descriptor.assignments(0).destination_field_name().empty());
+  EXPECT_FALSE(
+      annotated_descriptor.assignments(0).destination_field_name().empty());
   EXPECT_TRUE(annotated_descriptor.assignments(0).has_assigned_value());
-  EXPECT_FALSE(annotated_descriptor.assignments(1).destination_field_name().empty());
+  EXPECT_FALSE(
+      annotated_descriptor.assignments(1).destination_field_name().empty());
   EXPECT_TRUE(annotated_descriptor.assignments(1).has_assigned_value());
   EXPECT_NE(annotated_descriptor.assignments(0).destination_field_name(),
             annotated_descriptor.assignments(1).destination_field_name());
-  EXPECT_NE(annotated_descriptor.assignments(0).assigned_value().constant_param(),
-            annotated_descriptor.assignments(1).assigned_value().constant_param());
-  EXPECT_NE(annotated_descriptor.assignments(0).assigned_value().parameter_name(),
-            annotated_descriptor.assignments(1).assigned_value().parameter_name());
+  EXPECT_NE(
+      annotated_descriptor.assignments(0).assigned_value().constant_param(),
+      annotated_descriptor.assignments(1).assigned_value().constant_param());
+  EXPECT_NE(
+      annotated_descriptor.assignments(0).assigned_value().parameter_name(),
+      annotated_descriptor.assignments(1).assigned_value().parameter_name());
 }
 
 // In this test, test_pipeline_cfg_ has a action descriptor that has no
@@ -372,13 +387,14 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsUnmappedAction) {
   const std::string kActionName = "match-action-unmapped";
 
   hal::P4TableMapValue table_map_value;
-  table_map_value.mutable_action_descriptor()->set_type(P4_ACTION_TYPE_FUNCTION);
+  table_map_value.mutable_action_descriptor()->set_type(
+      P4_ACTION_TYPE_FUNCTION);
   (*test_pipeline_cfg_.mutable_table_map())[kActionName] = table_map_value;
   hal::P4PipelineConfig orig_pipeline_cfg = test_pipeline_cfg_;
   EXPECT_TRUE(mapper_.ProcessAnnotations(mock_p4_info_, &test_pipeline_cfg_));
   test_pipeline_cfg_.clear_idle_pipeline_stages();
-  EXPECT_TRUE(MessageDifferencer::Equals(
-      orig_pipeline_cfg, test_pipeline_cfg_));
+  EXPECT_TRUE(
+      MessageDifferencer::Equals(orig_pipeline_cfg, test_pipeline_cfg_));
 }
 
 // In this test, the action name has an annotation map entry, but an improperly
@@ -394,7 +410,8 @@ TEST_F(AnnotationMapperTest, TestProcessAnnotationsUndefinedActionAddenda) {
   EXPECT_TRUE(mapper_.InitFromP4AnnotationMap(test_map));
 
   hal::P4TableMapValue table_map_value;
-  table_map_value.mutable_action_descriptor()->set_type(P4_ACTION_TYPE_FUNCTION);
+  table_map_value.mutable_action_descriptor()->set_type(
+      P4_ACTION_TYPE_FUNCTION);
   (*test_pipeline_cfg_.mutable_table_map())[kActionWithMissingAddenda] =
       table_map_value;
   EXPECT_FALSE(mapper_.ProcessAnnotations(mock_p4_info_, &test_pipeline_cfg_));

--- a/stratum/p4c_backends/fpm/bcm/bcm_tunnel_optimizer.cc
+++ b/stratum/p4c_backends/fpm/bcm/bcm_tunnel_optimizer.cc
@@ -26,8 +26,9 @@
 namespace stratum {
 namespace p4c_backends {
 
-BcmTunnelOptimizer::BcmTunnelOptimizer()  // NOLINTNEXTLINE
-    : encap_or_decap_(hal::P4ActionDescriptor::P4TunnelProperties::ENCAP_OR_DECAP_NOT_SET) {
+BcmTunnelOptimizer::BcmTunnelOptimizer()
+    : encap_or_decap_(
+          hal::P4ActionDescriptor::P4TunnelProperties::ENCAP_OR_DECAP_NOT_SET) {
 }
 
 bool BcmTunnelOptimizer::Optimize(
@@ -58,8 +59,9 @@ bool BcmTunnelOptimizer::MergeAndOptimize(
 }
 
 void BcmTunnelOptimizer::InitInternalState() {
-  internal_descriptor_.Clear();  // NOLINTNEXTLINE
-  encap_or_decap_ = hal::P4ActionDescriptor::P4TunnelProperties::ENCAP_OR_DECAP_NOT_SET;
+  internal_descriptor_.Clear();
+  encap_or_decap_ =
+      hal::P4ActionDescriptor::P4TunnelProperties::ENCAP_OR_DECAP_NOT_SET;
 }
 
 // If there is ever a non-BCM target, this might belong in a common base class.
@@ -89,8 +91,9 @@ bool BcmTunnelOptimizer::IsValidTunnelAction(
 
 bool BcmTunnelOptimizer::MergeTunnelActions(
     const hal::P4ActionDescriptor& input_action1,
-    const hal::P4ActionDescriptor& input_action2) {  // NOLINTNEXTLINE
-  DCHECK_NE(hal::P4ActionDescriptor::P4TunnelProperties::ENCAP_OR_DECAP_NOT_SET, encap_or_decap_);
+    const hal::P4ActionDescriptor& input_action2) {
+  DCHECK_NE(hal::P4ActionDescriptor::P4TunnelProperties::ENCAP_OR_DECAP_NOT_SET,
+            encap_or_decap_);
 
   // The inner headers can be different in the merged actions.  Differences
   // will be handled during P4Runtime action processing. GRE, ECN, DSCP, and

--- a/stratum/procmon/procmon_main.cc
+++ b/stratum/procmon/procmon_main.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 #include <memory>
 
 #include "gflags/gflags.h"

--- a/stratum/procmon/procmon_main.cc
+++ b/stratum/procmon/procmon_main.cc
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "grpcpp/grpcpp.h"
 #include <memory>
 
 #include "gflags/gflags.h"
+#include "grpcpp/grpcpp.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/logging.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 #include "stratum/procmon/procmon.h"
 #include "stratum/procmon/procmon.pb.h"
 #include "stratum/procmon/procmon_service_impl.h"
-#include "stratum/glue/status/status.h"
 
 DEFINE_string(procmon_config_file, "",
               "Path to Procmon configuration proto file.");

--- a/stratum/procmon/procmon_service_impl.cc
+++ b/stratum/procmon/procmon_service_impl.cc
@@ -25,7 +25,7 @@ ProcmonServiceImpl::~ProcmonServiceImpl() {}
 ::grpc::Status ProcmonServiceImpl::Checkin(::grpc::ServerContext* context,
                                            const CheckinRequest* req,
                                            CheckinResponse* resp) {
-  // TODO: Implement this RPC.
+  // TODO(unknown): Implement this RPC.
   return ::grpc::Status::OK;
 }
 

--- a/stratum/procmon/procmon_service_impl.h
+++ b/stratum/procmon/procmon_service_impl.h
@@ -29,7 +29,7 @@ namespace procmon {
 // checkin) from the rest of the processes.
 class ProcmonServiceImpl final : public ProcmonService::Service {
  public:
-  // TODO: Pass a pointer to Procmon class instance to this class.
+  // TODO(unknown): Pass a pointer to Procmon class instance to this class.
   ProcmonServiceImpl();
   ~ProcmonServiceImpl() override;
 

--- a/stratum/procmon/procmon_service_impl.h
+++ b/stratum/procmon/procmon_service_impl.h
@@ -17,7 +17,7 @@
 #ifndef STRATUM_PROCMON_PROCMON_SERVICE_IMPL_H_
 #define STRATUM_PROCMON_PROCMON_SERVICE_IMPL_H_
 
-#include <grpc++/grpc++.h>
+#include "grpcpp/grpcpp.h"
 
 #include "stratum/procmon/procmon.grpc.pb.h"
 

--- a/stratum/public/lib/error_test.cc
+++ b/stratum/public/lib/error_test.cc
@@ -13,21 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "grpcpp/grpcpp.h"
-
 #include <string>
 #include <vector>
 
 #include "stratum/public/lib/error.h"
 
+#include "gmock/gmock.h"
+#include "google/rpc/code.pb.h"
+#include "google/rpc/status.pb.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/test_utils/matchers.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "google/rpc/code.pb.h"
-#include "google/rpc/status.pb.h"
 
 namespace stratum {
 

--- a/stratum/public/lib/error_test.cc
+++ b/stratum/public/lib/error_test.cc
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <grpcpp/grpcpp.h>
+#include "grpcpp/grpcpp.h"
 
 #include <string>
 #include <vector>

--- a/stratum/public/proto/tv.proto
+++ b/stratum/public/proto/tv.proto
@@ -15,8 +15,8 @@
 
 // This file includes the proto definitions for test vectors used for blackbox
 // testing. For more details see go/blackbox-sw-qual.
-// TODO: This is still WIP. Expect changes etc.
-// TODO: The location of this file is not fixed yet. We need to find
+// TODO(unknown): This is still WIP. Expect changes etc.
+// TODO(unknown): The location of this file is not fixed yet. We need to find
 // a better more permanent location for this proto file.
 syntax = "proto3";
 
@@ -209,7 +209,7 @@ message PortStimulus {
 // Signal to a possibly external device to simulate an alarm situation.
 message AlarmStimulus {
   gnmi.Path alarm = 1;
-  // TODO: Complete the proto.
+  // TODO(unknown): Complete the proto.
 }
 
 message ConfigExpectation {
@@ -245,7 +245,7 @@ message TelemetryExpectation {
   //    passes. Otherwise it fails.
   message Requirement {
     // timing requirements, etc for actions.
-    // TODO: add
+    // TODO(unknown): add
   }
   Requirement requirement = 1;
   // The single gNMI write request to send over the stream.
@@ -303,7 +303,7 @@ message ManagementOperation {
 message Action {
   message Requirement {
     // timing requirements, etc for actions.
-    // TODO: add
+    // TODO(unknown): add
   }
   Requirement requirement = 1;
   oneof actions {
@@ -337,7 +337,7 @@ message SequentialActionGroup {
 message ParallelActionGroup {
   message Options {
     // defines the parallelism options.
-    // TODO: Add this
+    // TODO(unknown): Add this
   }
   Options options = 1;
   repeated Action actions = 2;
@@ -347,7 +347,7 @@ message ParallelActionGroup {
 message RandomizedActionGroup {
   message Options {
     // defines the randomization options.
-    // TODO: Add this
+    // TODO(unknown): Add this
   }
   Options options = 1;
   repeated Action actions = 2;

--- a/stratum/testing/tests/bcm_sim_test_fixture.cc
+++ b/stratum/testing/tests/bcm_sim_test_fixture.cc
@@ -53,8 +53,8 @@ namespace {
 constexpr char kBcmSimBin[] =
     "google3/platforms/networking/stratum/hal/bin/bcm/sim/bcm_pcid_sim";
 
-// File path to the only chassis config used for testing. We use a test Generic Trident2
-// chassis config.
+// File path to the only chassis config used for testing. We use a test Generic
+// Trident2 chassis config.
 constexpr char kTestChassisConfigFile[] =
     "platforms/networking/stratum/testing/protos/"
     "test_chassis_config_generic_trident2_40g_stratum.pb.txt";

--- a/tools/onos-cfg-to-chassis-cfg.py
+++ b/tools/onos-cfg-to-chassis-cfg.py
@@ -39,7 +39,7 @@ def generateChassisConfig(deviceId, deviceCfg):
     return None
   chassisConfig = common_pb2.ChassisConfig()
   chassisConfig.description = "Stratum device %s" % deviceId
-  # TODO: Sets correct platform based on device config
+  # TODO(unknown): Sets correct platform based on device config
   chassisConfig.chassis.platform = common_pb2.PLT_P4_SOFT_SWITCH
   chassisConfig.chassis.name = deviceId
   node = chassisConfig.nodes.add()


### PR DESCRIPTION
Headers and c++ code should match all rules from cpplint (which based on Google C++ style guide).

Depends on #81 
Minimal subset from #48 
Closes #48 