### PR TITLE
Fix handling of @name table annotations.

### DIFF
--- a/stratum/p4c_backends/fpm/switch_p4c_backend.cc
+++ b/stratum/p4c_backends/fpm/switch_p4c_backend.cc
@@ -294,7 +294,7 @@ void SwitchP4cBackend::ConvertTables(
   for (auto table : ir_tables) {
     if (IsHidden(*table))
       continue;
-    const std::string p4_table_name = std::string(table->externalName());
+    const std::string p4_table_name = std::string(table->controlPlaneName());
     VLOG(1) << "Processing table " << p4_table_name;
     table_mapper_->AddTable(p4_table_name);
     if (table->getEntries() != nullptr) {

--- a/stratum/p4c_backends/fpm/utils.cc
+++ b/stratum/p4c_backends/fpm/utils.cc
@@ -156,8 +156,8 @@ void FillTableRefByName(const std::string& table_name,
 void FillTableRefFromIR(const IR::P4Table& ir_table,
                         const hal::P4InfoManager& p4_info_manager,
                         hal::P4ControlTableRef* table_ref) {
-  FillTableRefByName(std::string(
-      ir_table.externalName()), p4_info_manager, table_ref);
+  FillTableRefByName(std::string(ir_table.controlPlaneName()), p4_info_manager,
+                     table_ref);
   table_ref->set_pipeline_stage(GetAnnotatedPipelineStage(ir_table));
 }
 

--- a/stratum/p4c_backends/fpm/utils_test.cc
+++ b/stratum/p4c_backends/fpm/utils_test.cc
@@ -393,6 +393,23 @@ TEST_F(P4cUtilsTest, TestFillTableRefFromIRAnnotated) {
   EXPECT_EQ(0, ::errorCount());  // Errors from p4c's internal error reporter.
 }
 
+// Tests FillTableRefFromIR with table @name annotation.
+// See P4 Spec 18.2.3 Control-plane API annotations
+TEST_F(P4cUtilsTest, TestFillTableRefFromIRNameAnnotated) {
+  const std::string kOverrideTableName = "tableName";
+  // Override with fully-qualified name (starts with ".").
+  AddStringAnnotation("name", "." + kOverrideTableName);
+  SetUpIRTable();
+  EXPECT_CALL(mock_p4_info_manager_, FindTableByName(_))
+      .WillOnce(Return(test_p4_table_));
+  FillTableRefFromIR(*ir_table_, mock_p4_info_manager_, &table_ref_);
+  // Make sure the leading dot is stripped.
+  EXPECT_EQ(kOverrideTableName, table_ref_.table_name());
+  EXPECT_EQ(test_p4_table_.preamble().id(), table_ref_.table_id());
+  EXPECT_EQ(P4Annotation::DEFAULT_STAGE, table_ref_.pipeline_stage());
+  EXPECT_EQ(0, ::errorCount());  // Errors from p4c's internal error reporter.
+}
+
 // Tests a node that doesn't support annotations.
 TEST_F(P4cUtilsTest, TestUnannotatedNode) {
   // IR::BoolLiteral is not an IAnnotated subclass.


### PR DESCRIPTION
Leading "." was not stripped on fully-qualified names.