### PR TITLE
Strip invalid vlan tags from PacketIns

### DIFF
--- a/stratum/hal/lib/bcm/bcm_packetio_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.cc
@@ -1241,7 +1241,7 @@ std::string BcmPacketioManager::GetKnetIntfNameTemplate(
     auto* pid = reinterpret_cast<uint16*>(payload_buffer.get() +
                                           sizeof(struct ether_header));
     uint16 vlan = ntohs(*pid) & kVlanIdMask;
-    if (vlan == kDefaultVlan || vlan == kArpVlan) {
+    if (vlan == kDefaultVlan || vlan == kArpVlan || vlan == 0) {
       tagged = true;
     }
   }


### PR DESCRIPTION
This is a simple fix to remove empty VLAN tags on PacketIns to the CPU. This can occur on SDKLT with ports configured in loopback mode.

I believe there is a flag for this in SDK6, but vlan id 0 is not valid anyway, so we could always strip it.