### PR TITLE
Check bash scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,15 @@ jobs:
           name: Run cpplint
           command: cpplint --recursive --exclude=stratum/hal/lib/bcm/bcm_sdk_wrapper.cc stratum
 
+  shell-check:
+    docker:
+      - image: koalaman/shellcheck-alpine:stable
+    steps:
+      - checkout
+      - run:
+          name: Check Scripts
+          command: find . -type f -name '*.sh' | xargs shellcheck --external-sources
+
 workflows:
   version: 2
   build_and_test:
@@ -193,6 +202,7 @@ workflows:
       - cdlang_tests
       - coverage
       - cpp-style-check
+      - shell-check
   docker-publish:
     jobs:
       - publish-docker-build:


### PR DESCRIPTION
[Shellcheck](https://www.shellcheck.net/) checks for common errors and mistakes in bash scripts. Ours are not exactly security critical or handle untrusted input, but we could still make sure they follow best practices.

@ccascone you're a fan of having scripts for common tasks, any opinion on this?