### PR TITLE
Add optical-related paths

### DIFF
--- a/stratum/hal/bin/dummy/chassis_config
+++ b/stratum/hal/bin/dummy/chassis_config
@@ -51,3 +51,15 @@ singleton_ports {
     mac_address: 0x222222222222
   }
 }
+optical_ports {
+  id: 3
+  name: "card-1"
+  slot: 1
+  port: 3
+  channel: 1
+  node: 1
+  frequency: 193500000000000
+  target_output_power: 0
+  operational_mode: 2
+  line_port: "oe-17"
+}

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -741,6 +741,7 @@ stratum_cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/public/lib:error",

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -235,6 +235,7 @@ stratum_cc_library(
         ":switch_interface",
         ":writer_interface",
         ":utils",
+        ":constants",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -250,70 +250,6 @@ enum FecMode {
   FEC_MODE_AUTO = 3;
 }
 
-// The input optical power of this port in units of 0.01 decibel-milliwatt.
-// If the port is an aggregate of multiple physical channels, this attribute
-// is the total power or sum of all channels.
-//
-// The time-based values are the timestamps in nanoseconds relative to the
-// Unix Epoch (Jan 1, 1970 00:00:00 UTC)."
-message InputPower {
-  // The instantaneous value of the statistic.
-  float instant = 1;
-  // The arithmetic mean value of the statistic over the time interval.
-  float avg = 2;
-  // The time interval over which the statistics are computed.
-  uint64 interval = 3;
-  // The maximum value of the statistic over the time interval.
-  float max = 4;
-  // The absolute time at which the maximum value occurred.
-  uint64 max_time = 5;
-  // The minimum value of the statistic over the time interval.
-  float min = 6;
-  // The absolute time at which the minimum value occurred.
-  uint64 min_time = 7;
-}
-
-// Current output optical power level of the optical channel, expressed in
-// increments of 0.01 decibel-milliwats.
-//
-// The time-based values are the timestamps in nanoseconds relative to the
-// Unix Epoch (Jan 1, 1970 00:00:00 UTC)."
-message OutputPower {
-  // The instantaneous value of the statistic.
-  float instant = 1;
-  // The arithmetic mean value of the statistic over the time interval.
-  float avg = 2;
-  // The time interval over which the statistics are computed.
-  uint64 interval = 3;
-  // The maximum value of the statistic over the time interval.
-  float max = 4;
-  // The absolute time at which the maximum value occurred.
-  uint64 max_time = 5;
-  // The minimum value of the statistic over the time interval.
-  float min = 6;
-  // The absolute time at which the minimum value occurred.
-  uint64 min_time = 7;
-}
-
-// Target output optical power level of the optical channel, expressed in
-// increments of 0.01 decibel-milliwats.
-message TargetOutputPower {
-  float value = 1;
-}
-
-// NOTE. The name 'LaserFrequency' was chosen to avoid the conflict with
-// 'gnmi_publisher.cc:Frequency'.
-//
-// Optical channel frequency in MHz.
-message LaserFrequency {
-  uint64 value = 1;
-}
-
-// Optical channel operational mode.
-message OperationalMode {
-  uint64 value = 1;
-}
-
 // Config-related parameters for the ports (singleton and trunk ports).
 message PortConfigParams {
   // Per port hash config. Most of the hash configuration is given per node.
@@ -1094,9 +1030,48 @@ message FrontPanelPortInfo {
 
 // Optical channel configuration
 message OpticalChannelInfo {
-  LaserFrequency laser_frequency = 1;
-  InputPower input_power = 2;
-  OutputPower output_power = 3;
+  // The input/output optical power of this port in units of 0.01 decibel-milliwatt.
+  // If the port is an aggregate of multiple physical channels, this attribute
+  // is the total power or sum of all channels.
+  //
+  // The time-based values are the timestamps in nanoseconds relative to the
+  // Unix Epoch (Jan 1, 1970 00:00:00 UTC)."
+  message Power {
+    // The instantaneous value of the statistic.
+    float instant = 1;
+    // The arithmetic mean value of the statistic over the time interval.
+    float avg = 2;
+    // The time interval over which the statistics are computed.
+    uint64 interval = 3;
+    // The maximum value of the statistic over the time interval.
+    float max = 4;
+    // The absolute time at which the maximum value occurred.
+    uint64 max_time = 5;
+    // The minimum value of the statistic over the time interval.
+    float min = 6;
+    // The absolute time at which the minimum value occurred.
+    uint64 min_time = 7;
+  }
+
+  // Target output optical power level of the optical channel, expressed in
+  // increments of 0.01 decibel-milliwats.
+  message TargetOutputPower {
+    float value = 1;
+  }
+
+  // Optical channel frequency in MHz.
+  message Frequency {
+    uint64 value = 1;
+  }
+
+  // Optical channel operational mode.
+  message OperationalMode {
+    uint64 value = 1;
+  }
+
+  Frequency frequency = 1;
+  Power input_power = 2;
+  Power output_power = 3;
   TargetOutputPower target_output_power = 4;
   OperationalMode operational_mode = 5;
 }

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1053,27 +1053,15 @@ message OpticalChannelInfo {
     uint64 min_time = 7;
   }
 
-  // Target output optical power level of the optical channel, expressed in
-  // increments of 0.01 decibel-milliwats.
-  message TargetOutputPower {
-    float value = 1;
-  }
-
   // Optical channel frequency in MHz.
-  message Frequency {
-    uint64 value = 1;
-  }
-
-  // Optical channel operational mode.
-  message OperationalMode {
-    uint64 value = 1;
-  }
-
-  Frequency frequency = 1;
+  uint64 frequency = 1;
   Power input_power = 2;
   Power output_power = 3;
-  TargetOutputPower target_output_power = 4;
-  OperationalMode operational_mode = 5;
+  // Target output optical power level of the optical channel, expressed in
+  // increments of 0.01 decibel-milliwats.
+  float target_output_power = 4;
+  // Vendor-specific optical channel operational mode.
+  uint64 operational_mode = 5;
 }
 
 //------------------------------------------------------------------------------

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1030,12 +1030,6 @@ message FrontPanelPortInfo {
 
 // Optical channel configuration
 message OpticalChannelInfo {
-  // The input/output optical power of this port in units of 0.01 decibel-milliwatt.
-  // If the port is an aggregate of multiple physical channels, this attribute
-  // is the total power or sum of all channels.
-  //
-  // The time-based values are the timestamps in nanoseconds relative to the
-  // Unix Epoch (Jan 1, 1970 00:00:00 UTC)."
   message Power {
     // The instantaneous value of the statistic.
     float instant = 1;
@@ -1055,6 +1049,9 @@ message OpticalChannelInfo {
 
   // Optical channel frequency in MHz.
   uint64 frequency = 1;
+  // The input/output optical power of this port in units of 0.01 decibel-milliwatt.
+  // If the port is an aggregate of multiple physical channels, this attribute
+  // is the total power or sum of all channels.
   Power input_power = 2;
   Power output_power = 3;
   // Target output optical power level of the optical channel, expressed in

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -250,6 +250,70 @@ enum FecMode {
   FEC_MODE_AUTO = 3;
 }
 
+// The input optical power of this port in units of 0.01 decibel-milliwatt.
+// If the port is an aggregate of multiple physical channels, this attribute
+// is the total power or sum of all channels.
+//
+// The time-based values are the timestamps in nanoseconds relative to the
+// Unix Epoch (Jan 1, 1970 00:00:00 UTC)."
+message InputPower {
+  // The instantaneous value of the statistic.
+  float instant = 1;
+  // The arithmetic mean value of the statistic over the time interval.
+  float avg = 2;
+  // The time interval over which the statistics are computed.
+  uint64 interval = 3;
+  // The maximum value of the statistic over the time interval.
+  float max = 4;
+  // The absolute time at which the maximum value occurred.
+  uint64 max_time = 5;
+  // The minimum value of the statistic over the time interval.
+  float min = 6;
+  // The absolute time at which the minimum value occurred.
+  uint64 min_time = 7;
+}
+
+// Current output optical power level of the optical channel, expressed in
+// increments of 0.01 decibel-milliwats.
+//
+// The time-based values are the timestamps in nanoseconds relative to the
+// Unix Epoch (Jan 1, 1970 00:00:00 UTC)."
+message OutputPower {
+  // The instantaneous value of the statistic.
+  float instant = 1;
+  // The arithmetic mean value of the statistic over the time interval.
+  float avg = 2;
+  // The time interval over which the statistics are computed.
+  uint64 interval = 3;
+  // The maximum value of the statistic over the time interval.
+  float max = 4;
+  // The absolute time at which the maximum value occurred.
+  uint64 max_time = 5;
+  // The minimum value of the statistic over the time interval.
+  float min = 6;
+  // The absolute time at which the minimum value occurred.
+  uint64 min_time = 7;
+}
+
+// Target output optical power level of the optical channel, expressed in
+// increments of 0.01 decibel-milliwats.
+message TargetOutputPower {
+  float value = 1;
+}
+
+// NOTE. The name 'LaserFrequency' was chosen to avoid the conflict with
+// 'gnmi_publisher.cc:Frequency'.
+//
+// Optical channel frequency in MHz.
+message LaserFrequency {
+  uint64 value = 1;
+}
+
+// Optical channel operational mode.
+message OperationalMode {
+  uint64 value = 1;
+}
+
 // Config-related parameters for the ports (singleton and trunk ports).
 message PortConfigParams {
   // Per port hash config. Most of the hash configuration is given per node.
@@ -362,6 +426,38 @@ message SingletonPort {
   // Parameters configured for each singleton port when config is pushed to the
   // the switch.
   PortConfigParams config_params = 8;
+}
+
+// OpticalPort uniquely identifies a single physical optical port on a single
+// chassis and all its flow-related and config-related parameters (As
+// SingletonPort).
+message OpticalPort {
+  // The unique optical port ID.
+  uint32 id = 1;
+  // An optional arbitrary name for the optical port. WILL NOT BE PARSED.
+  string name = 2;
+  // The 1-base index of the slot (aka linecard) of the port.
+  int32 slot = 3;
+  // The 1-base index of the optical port on the slot.
+  int32 port = 4;
+  // The 1-base channel index (only if the port is channelized). Absence or zero
+  // means non-channelized.
+  int32 channel = 5;
+  // The id of the corresponding node that the port belongs to.
+  uint64 node = 6;
+  // The module location corresponding to module that the port belongs to.
+  uint32 module_location = 7; // required
+  // The unique netif location that represents the optical port on the module.
+  uint32 netif_location = 8; // required
+  // Optical channel frequency in MHz.
+  uint64 frequency = 9;
+  // Target output optical power level of the optical channel, expressed in
+  // increments of 0.01 decibel-milliwats.
+  float target_output_power = 10;
+  // Optical channel operational mode.
+  uint64 operational_mode = 11;
+  // Optical channel line port value.
+  string line_port = 12;
 }
 
 // TrunkPort uniquely identifies a single trunk port on a single chassis and
@@ -665,6 +761,7 @@ message ChassisConfig {
   repeated TrunkPort trunk_ports = 5;
   repeated PortGroup port_groups = 6;
   VendorConfig vendor_config = 7;
+  repeated OpticalPort optical_ports = 8;
 }
 
 //------------------------------------------------------------------------------
@@ -995,6 +1092,15 @@ message FrontPanelPortInfo {
   HwState hw_state = 6;
 }
 
+// Optical channel configuration
+message OpticalChannelInfo {
+  LaserFrequency laser_frequency = 1;
+  InputPower input_power = 2;
+  OutputPower output_power = 3;
+  TargetOutputPower target_output_power = 4;
+  OperationalMode operational_mode = 5;
+}
+
 //------------------------------------------------------------------------------
 // Monitoring related messages.
 //------------------------------------------------------------------------------
@@ -1140,6 +1246,7 @@ message DataRequest {
       Port front_panel_port_info = 16;
       Port hardware_port = 17;
       Port fec_status = 18;
+      Port optical_channel_info = 19;
     }
   }
   repeated Request requests = 1;
@@ -1169,6 +1276,7 @@ message DataResponse {
     FrontPanelPortInfo front_panel_port_info = 16;
     HardwarePort hardware_port = 17;
     FecStatus fec_status = 18;
+    OpticalChannelInfo optical_channel_info = 19;
   }
 }
 
@@ -1196,6 +1304,8 @@ message SetRequest {
         AutonegotiationStatus autoneg_status = 9;
         // The new forwarding viability of the port.
         ForwardingViability forwarding_viability = 10;
+        // The new optical channel configurable values.
+        OpticalChannelInfo optical_channel_info = 11;
       }
     }
     // Data required to set info for a specific node.

--- a/stratum/hal/lib/common/constants.h
+++ b/stratum/hal/lib/common/constants.h
@@ -78,6 +78,9 @@ constexpr uint8 kIpProtoTcp = 6;
 constexpr uint8 kIpProtoUdp = 17;
 constexpr uint8 kIpProtoGre = 47;
 
+// Precision for converting floating point to ::gnmi::Decimal64
+constexpr uint32 kDefaultPrecision = 2;
+
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/hal/lib/common/gnmi_events.h
+++ b/stratum/hal/lib/common/gnmi_events.h
@@ -387,23 +387,15 @@ class PortInputPowerChangedEvent
     : public PerPortGnmiEvent<PortInputPowerChangedEvent> {
  public:
   PortInputPowerChangedEvent(uint64 node_id, uint32 port_id,
-                             const InputPower new_input_power)
+                             const OpticalChannelInfo::Power new_input_power)
       : PerPortGnmiEvent(node_id, port_id), new_input_power_(new_input_power) {}
   ~PortInputPowerChangedEvent() override {}
 
   // Actual power values.
-  float GetInstant() const {
-    return new_input_power_.instant();
-  }
-  float GetAvg() const {
-    return new_input_power_.avg();
-  }
-  float GetMin() const {
-    return new_input_power_.min();
-  }
-  float GetMax() const {
-    return new_input_power_.max();
-  }
+  float GetInstant() const { return new_input_power_.instant(); }
+  float GetAvg() const { return new_input_power_.avg(); }
+  float GetMin() const { return new_input_power_.min(); }
+  float GetMax() const { return new_input_power_.max(); }
 
   // Time values.
   uint64 GetInterval() const { return new_input_power_.interval(); }
@@ -411,7 +403,7 @@ class PortInputPowerChangedEvent
   uint64 GetMaxTime() const { return new_input_power_.max_time(); }
 
  private:
-  const InputPower new_input_power_;
+  const OpticalChannelInfo::Power new_input_power_;
 };
 
 // Port target output power changed event.
@@ -435,24 +427,16 @@ class PortOutputPowerChangedEvent
     : public PerPortGnmiEvent<PortOutputPowerChangedEvent> {
  public:
   PortOutputPowerChangedEvent(uint64 node_id, uint32 port_id,
-                             const OutputPower new_output_power)
+                              const OpticalChannelInfo::Power new_output_power)
       : PerPortGnmiEvent(node_id, port_id),
         new_output_power_(new_output_power) {}
   ~PortOutputPowerChangedEvent() override {}
 
   // Actual power values.
-  float GetInstant() const {
-    return new_output_power_.instant();
-  }
-  float GetAvg() const {
-    return new_output_power_.avg();
-  }
-  float GetMin() const {
-    return new_output_power_.min();
-  }
-  float GetMax() const {
-    return new_output_power_.max();
-  }
+  float GetInstant() const { return new_output_power_.instant(); }
+  float GetAvg() const { return new_output_power_.avg(); }
+  float GetMin() const { return new_output_power_.min(); }
+  float GetMax() const { return new_output_power_.max(); }
 
   // Time values.
   uint64 GetInterval() const { return new_output_power_.interval(); }
@@ -460,7 +444,7 @@ class PortOutputPowerChangedEvent
   uint64 GetMaxTime() const { return new_output_power_.max_time(); }
 
  private:
-  const OutputPower new_output_power_;
+  const OpticalChannelInfo::Power new_output_power_;
 };
 
 // Port operational mode changed event.

--- a/stratum/hal/lib/common/gnmi_events.h
+++ b/stratum/hal/lib/common/gnmi_events.h
@@ -367,6 +367,133 @@ class PortAutonegChangedEvent
   const TriState new_state_;
 };
 
+// Port frequency changed event.
+class PortFrequencyChangedEvent
+    : public PerPortGnmiEvent<PortFrequencyChangedEvent> {
+ public:
+  PortFrequencyChangedEvent(uint64 node_id, uint32 port_id,
+                            uint64 new_frequency)
+      : PerPortGnmiEvent(node_id, port_id), new_frequency_(new_frequency) {}
+  ~PortFrequencyChangedEvent() override {}
+
+  uint64 GetFrequency() const { return new_frequency_; }
+
+ private:
+  const uint64 new_frequency_;
+};
+
+// Port input power changed event.
+class PortInputPowerChangedEvent
+    : public PerPortGnmiEvent<PortInputPowerChangedEvent> {
+ public:
+  PortInputPowerChangedEvent(uint64 node_id, uint32 port_id,
+                             const InputPower new_input_power)
+      : PerPortGnmiEvent(node_id, port_id), new_input_power_(new_input_power) {}
+  ~PortInputPowerChangedEvent() override {}
+
+  // Actual power values.
+  float GetInstant() const {
+    return new_input_power_.instant();
+  }
+  float GetAvg() const {
+    return new_input_power_.avg();
+  }
+  float GetMin() const {
+    return new_input_power_.min();
+  }
+  float GetMax() const {
+    return new_input_power_.max();
+  }
+
+  // Time values.
+  uint64 GetInterval() const { return new_input_power_.interval(); }
+  uint64 GetMinTime() const { return new_input_power_.min_time(); }
+  uint64 GetMaxTime() const { return new_input_power_.max_time(); }
+
+ private:
+  const InputPower new_input_power_;
+};
+
+// Port target output power changed event.
+class PortTargetOutputPowerChangedEvent
+    : public PerPortGnmiEvent<PortTargetOutputPowerChangedEvent> {
+ public:
+  PortTargetOutputPowerChangedEvent(uint64 node_id, uint32 port_id,
+                                    float new_target_output_power)
+      : PerPortGnmiEvent(node_id, port_id),
+        new_target_output_power_(new_target_output_power) {}
+  ~PortTargetOutputPowerChangedEvent() override {}
+
+  float GetPower() const { return new_target_output_power_; }
+
+ private:
+  const float new_target_output_power_;
+};
+
+// Port output power changed event.
+class PortOutputPowerChangedEvent
+    : public PerPortGnmiEvent<PortOutputPowerChangedEvent> {
+ public:
+  PortOutputPowerChangedEvent(uint64 node_id, uint32 port_id,
+                             const OutputPower new_output_power)
+      : PerPortGnmiEvent(node_id, port_id),
+        new_output_power_(new_output_power) {}
+  ~PortOutputPowerChangedEvent() override {}
+
+  // Actual power values.
+  float GetInstant() const {
+    return new_output_power_.instant();
+  }
+  float GetAvg() const {
+    return new_output_power_.avg();
+  }
+  float GetMin() const {
+    return new_output_power_.min();
+  }
+  float GetMax() const {
+    return new_output_power_.max();
+  }
+
+  // Time values.
+  uint64 GetInterval() const { return new_output_power_.interval(); }
+  uint64 GetMinTime() const { return new_output_power_.min_time(); }
+  uint64 GetMaxTime() const { return new_output_power_.max_time(); }
+
+ private:
+  const OutputPower new_output_power_;
+};
+
+// Port operational mode changed event.
+class PortOperationalModeChangedEvent
+    : public PerPortGnmiEvent<PortOperationalModeChangedEvent> {
+ public:
+  PortOperationalModeChangedEvent(uint64 node_id, uint32 port_id,
+                                  uint64 new_operational_mode)
+      : PerPortGnmiEvent(node_id, port_id),
+        new_operational_mode_(new_operational_mode) {}
+  ~PortOperationalModeChangedEvent() override {}
+
+  uint64 GetOperationalMode() const { return new_operational_mode_; }
+
+ private:
+  const uint64 new_operational_mode_;
+};
+
+// Port "line port" changed event.
+class PortLinePortChangedEvent
+    : public PerPortGnmiEvent<PortLinePortChangedEvent> {
+ public:
+  PortLinePortChangedEvent(uint64 node_id, uint32 port_id,
+                           const std::string& new_line_port)
+      : PerPortGnmiEvent(node_id, port_id), new_line_port_(new_line_port) {}
+  ~PortLinePortChangedEvent() override {}
+
+  const std::string& GetLinePort() const { return new_line_port_; }
+
+ private:
+  const std::string new_line_port_;
+};
+
 // Configuration Has Been Pushed event.
 class ConfigHasBeenPushedEvent
     : public GnmiEventProcess<ConfigHasBeenPushedEvent> {

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -16,6 +16,7 @@
 
 #include "stratum/hal/lib/common/utils.h"
 
+#include <cfenv>  // NOLINT
 #include <cmath>
 #include <sstream>  // IWYU pragma: keep
 #include <regex>  // NOLINT
@@ -23,6 +24,7 @@
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/public/lib/error.h"
+#include "stratum/public/proto/error.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -397,16 +399,32 @@ std::string ConvertHwStateToPresentString(const HwState& hw_state) {
   }
 }
 
-float Decimal64ValueToFloat(const ::gnmi::Decimal64 &value) {
-  return value.digits() / std::pow(10, value.precision());
+::util::StatusOr<float> Decimal64ValueToFloat(const ::gnmi::Decimal64 &value) {
+  std::feclearexcept(FE_ALL_EXCEPT);
+  float result = value.digits() / std::pow(10, value.precision());
+  if (std::feclearexcept(FE_INVALID)) {
+    return MAKE_ERROR(ERR_OUT_OF_RANGE)
+      << "can not convert decimal"
+      << " with digits " << value.digits()
+      << " and precision " << value.precision()
+      << " to a float value.";
+  }
+  return result;
 }
 
-::gnmi::Decimal64 FloatToDecimal64Value(
-  float value, ::google::protobuf::uint32 precision) {
+::util::StatusOr<::gnmi::Decimal64>
+FloatToDecimal64Value(float value, uint32 precision) {
+  std::feclearexcept(FE_ALL_EXCEPT);
   ::gnmi::Decimal64 decimal;
   decimal.set_digits(
-      static_cast<::google::protobuf::int64>(value * std::pow(10, precision)));
+      std::llround(value * std::pow(10, precision)));
   decimal.set_precision(precision);
+  if (std::fetestexcept(FE_INVALID)) {
+    return MAKE_ERROR(ERR_OUT_OF_RANGE)
+      << "can not convert number " << value
+      << " with precision " << precision
+      << " to a Decimal64 value";
+  }
   return decimal;
 }
 

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -399,31 +399,28 @@ std::string ConvertHwStateToPresentString(const HwState& hw_state) {
   }
 }
 
-::util::StatusOr<float> Decimal64ValueToFloat(const ::gnmi::Decimal64 &value) {
+::util::StatusOr<float> Decimal64ValueToFloat(const ::gnmi::Decimal64& value) {
   std::feclearexcept(FE_ALL_EXCEPT);
   float result = value.digits() / std::pow(10, value.precision());
   if (std::feclearexcept(FE_INVALID)) {
     return MAKE_ERROR(ERR_OUT_OF_RANGE)
-      << "can not convert decimal"
-      << " with digits " << value.digits()
-      << " and precision " << value.precision()
-      << " to a float value.";
+           << "can not convert decimal"
+           << " with digits " << value.digits() << " and precision "
+           << value.precision() << " to a float value.";
   }
   return result;
 }
 
-::util::StatusOr<::gnmi::Decimal64>
-FloatToDecimal64Value(float value, uint32 precision) {
+::util::StatusOr<::gnmi::Decimal64> FloatToDecimal64Value(float value,
+                                                          uint32 precision) {
   std::feclearexcept(FE_ALL_EXCEPT);
   ::gnmi::Decimal64 decimal;
-  decimal.set_digits(
-      std::llround(value * std::pow(10, precision)));
+  decimal.set_digits(std::llround(value * std::pow(10, precision)));
   decimal.set_precision(precision);
   if (std::fetestexcept(FE_INVALID)) {
     return MAKE_ERROR(ERR_OUT_OF_RANGE)
-      << "can not convert number " << value
-      << " with precision " << precision
-      << " to a Decimal64 value";
+           << "can not convert number " << value << " with precision "
+           << precision << " to a Decimal64 value";
   }
   return decimal;
 }

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -398,9 +398,7 @@ std::string ConvertHwStateToPresentString(const HwState& hw_state) {
 }
 
 float Decimal64ValueToFloat(const ::gnmi::Decimal64 &value) {
-  float result = value.digits();
-  result /= std::pow(10, value.precision());
-  return result;
+  return value.digits() / std::pow(10, value.precision());
 }
 
 ::gnmi::Decimal64 FloatToDecimal64Value(

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -16,6 +16,7 @@
 
 #include "stratum/hal/lib/common/utils.h"
 
+#include <cmath>
 #include <sstream>  // IWYU pragma: keep
 #include <regex>  // NOLINT
 
@@ -394,6 +395,21 @@ std::string ConvertHwStateToPresentString(const HwState& hw_state) {
     default:
       return "UNKNOWN";
   }
+}
+
+float Decimal64ValueToFloat(const ::gnmi::Decimal64 &value) {
+  float result = value.digits();
+  result /= std::pow(10, value.precision());
+  return result;
+}
+
+::gnmi::Decimal64 FloatToDecimal64Value(
+  float value, ::google::protobuf::uint32 precision) {
+  ::gnmi::Decimal64 decimal;
+  decimal.set_digits(
+      static_cast<::google::protobuf::int64>(value * std::pow(10, precision)));
+  decimal.set_precision(precision);
+  return decimal;
 }
 
 }  // namespace hal

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -28,6 +28,7 @@
 #include "stratum/glue/integral_types.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "gnmi/gnmi.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -227,6 +228,14 @@ std::string ConvertMediaTypeToString(const MediaType& type);
 // A helper function taht convert Stratum HwState to OpenConfig present
 // state string (PRESENT, NOT_PRESENT)
 std::string ConvertHwStateToPresentString(const HwState& hw_state);
+
+// Converts ::gnmi::Decimal64 to float type.
+float Decimal64ValueToFloat(const ::gnmi::Decimal64 &value);
+
+// Converts float to ::gnmi::Decimal64 type.
+::gnmi::Decimal64
+FloatToDecimal64Value(float value, ::google::protobuf::uint32 precision);
+
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -231,12 +231,11 @@ std::string ConvertMediaTypeToString(const MediaType& type);
 std::string ConvertHwStateToPresentString(const HwState& hw_state);
 
 // Converts ::gnmi::Decimal64 to float type.
-::util::StatusOr<float>
-Decimal64ValueToFloat(const ::gnmi::Decimal64 &value);
+::util::StatusOr<float> Decimal64ValueToFloat(const ::gnmi::Decimal64& value);
 
 // Converts float to ::gnmi::Decimal64 type.
-::util::StatusOr<::gnmi::Decimal64>
-FloatToDecimal64Value(float value, uint32 precision);
+::util::StatusOr<::gnmi::Decimal64> FloatToDecimal64Value(float value,
+                                                          uint32 precision);
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -26,6 +26,7 @@
 
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "gnmi/gnmi.pb.h"
@@ -230,11 +231,12 @@ std::string ConvertMediaTypeToString(const MediaType& type);
 std::string ConvertHwStateToPresentString(const HwState& hw_state);
 
 // Converts ::gnmi::Decimal64 to float type.
-float Decimal64ValueToFloat(const ::gnmi::Decimal64 &value);
+::util::StatusOr<float>
+Decimal64ValueToFloat(const ::gnmi::Decimal64 &value);
 
 // Converts float to ::gnmi::Decimal64 type.
-::gnmi::Decimal64
-FloatToDecimal64Value(float value, ::google::protobuf::uint32 precision);
+::util::StatusOr<::gnmi::Decimal64>
+FloatToDecimal64Value(float value, uint32 precision);
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/yang_parse_tree.cc
+++ b/stratum/hal/lib/common/yang_parse_tree.cc
@@ -172,6 +172,17 @@ void YangParseTree::SendNotification(const GnmiEventPtr& event) {
     port_id_to_node_id[singleton.id()] = singleton.node();
     singleton_names.insert(singleton.name());
   }
+
+  std::unordered_set<std::string> optical_names;
+  for (const auto& optical : change.new_config_.optical_ports()) {
+    if (optical_names.count(optical.name())) {
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Duplicate optical port name: "
+          << optical.name();
+    }
+    AddSubtreeInterfaceFromOptical(optical);
+    optical_names.insert(optical.name());
+  }
+
   std::unordered_set<std::string> trunk_names;
   for (const auto& trunk : change.new_config_.trunk_ports()) {
     // Find out on which node the trunk is created.
@@ -248,6 +259,7 @@ YangParseTree::YangParseTree(SwitchInterface* switch_interface)
   // The rest of nodes will be added once the config is pushed.
   absl::WriterMutexLock l(&root_access_lock_);
   AddSubtreeAllInterfaces();
+  AddSubtreeAllComponents();
   AddRoot();
 }
 
@@ -331,6 +343,10 @@ void YangParseTree::AddSubtreeInterfaceFromSingleton(
                                                        this);
 }
 
+void YangParseTree::AddSubtreeInterfaceFromOptical(const OpticalPort& optical) {
+  YangParseTreePaths::AddSubtreeInterfaceFromOptical(optical, this);
+}
+
 void YangParseTree::AddSubtreeNode(const Node& node) {
   YangParseTreePaths::AddSubtreeNode(node, this);
 }
@@ -344,6 +360,17 @@ void YangParseTree::AddSubtreeAllInterfaces() {
 
   // Add all nodes defined in YangParseTreePaths class.
   YangParseTreePaths::AddSubtreeAllInterfaces(this);
+}
+
+void YangParseTree::AddSubtreeAllComponents() {
+  // No need to lock the mutex - it is locked by method calling this one.
+
+  // Setup
+  // * the /components/component[name="*"]/name path to make possible all
+  //   components' names retrieval.
+  // * the /components/component/* path to retrieve all the nodes for the
+  //   specific component.
+  YangParseTreePaths::AddSubtreeAllComponents(this);
 }
 
 void YangParseTree::AddRoot() {

--- a/stratum/hal/lib/common/yang_parse_tree.cc
+++ b/stratum/hal/lib/common/yang_parse_tree.cc
@@ -362,14 +362,13 @@ void YangParseTree::AddSubtreeAllInterfaces() {
   YangParseTreePaths::AddSubtreeAllInterfaces(this);
 }
 
-void YangParseTree::AddSubtreeAllComponents() {
-  // No need to lock the mutex - it is locked by method calling this one.
-
   // Setup
   // * the /components/component[name="*"]/name path to make possible all
   //   components' names retrieval.
   // * the /components/component/* path to retrieve all the nodes for the
   //   specific component.
+void YangParseTree::AddSubtreeAllComponents() {
+  // No need to lock the mutex - it is locked by method calling this one.
   YangParseTreePaths::AddSubtreeAllComponents(this);
 }
 

--- a/stratum/hal/lib/common/yang_parse_tree.h
+++ b/stratum/hal/lib/common/yang_parse_tree.h
@@ -415,6 +415,9 @@ class YangParseTree {
                                         const NodeConfigParams& node_config)
       EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
   // Add supported leaf handles for one particular interface like xe-1/1/1.
+  void AddSubtreeInterfaceFromOptical(const OpticalPort& optical)
+      EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
+  // Add supported leaf handles for one particular interface like xe-1/1/1.
   void AddSubtreeInterfaceFromTrunk(const std::string& name, uint64 node_id,
                                     uint32 port_id,
                                     const NodeConfigParams& node_config)
@@ -422,6 +425,11 @@ class YangParseTree {
   // Add supported leaf handles for the case of interfaces[name=*] (all known
   // interfaces).
   void AddSubtreeAllInterfaces() EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
+  // Enable
+  // * /components/component[name=*]/name
+  // * /components/component/*
+  // paths discovering.
+  void AddSubtreeAllComponents() EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
 
   // Add supported leaf handles for a node.
   void AddSubtreeNode(const Node& node)

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "stratum/hal/lib/common/yang_parse_tree_paths.h"
 
@@ -98,28 +98,6 @@ template <class T>
     ->mutable_val()
     ->mutable_decimal_val() = contents;
   return resp;
-}
-
-// Convert ::gnmi::Decimal64 to float type.
-float Decimal64ValueToFloat(const ::gnmi::Decimal64 &value) {
-  float result = value.digits();
-  if (value.precision() > 0) {
-    result /= powf(10, value.precision());
-  }
-  return result;
-}
-
-// Convert float to ::gnmi::Decimal64 type.
-::gnmi::Decimal64 FloatToDecimal64Value(
-  float value, ::google::protobuf::uint32 precision) {
-  ::gnmi::Decimal64 decimal;
-  if (precision <= 0) {
-      precision = 0;
-  }
-  decimal.set_digits(
-      static_cast<::google::protobuf::int64>(value * powf(10, precision)));
-  decimal.set_precision(precision);
-  return decimal;
 }
 
 // A helper method that handles writing a response into the output stream.
@@ -2237,9 +2215,9 @@ void SetUpComponentsComponentTransceiverStateFormFactor(
 void SetUpComponentsComponentOpticalChannelStateFrequency(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
-      &OpticalChannelInfo::laser_frequency,
-      &OpticalChannelInfo::has_laser_frequency,
-      &LaserFrequency::value);
+      &OpticalChannelInfo::frequency,
+      &OpticalChannelInfo::has_frequency,
+      &OpticalChannelInfo::Frequency::value);
 
   auto register_functor = RegisterFunc<PortFrequencyChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2280,8 +2258,8 @@ void SetUpComponentsComponentOpticalChannelConfigFrequency(uint64 initial_value,
     auto status = SetValue(
         node_id, port_id, tree,
         &SetRequest::Request::Port::mutable_optical_channel_info,
-        &OpticalChannelInfo::mutable_laser_frequency,
-        &LaserFrequency::set_value, uint_val);
+        &OpticalChannelInfo::mutable_frequency,
+        &OpticalChannelInfo::Frequency::set_value, uint_val);
     if (status != ::util::OkStatus()) {
       return status;
     }
@@ -2323,7 +2301,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerInstant(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::input_power,
-          &OpticalChannelInfo::has_input_power, &InputPower::instant);
+          &OpticalChannelInfo::has_input_power,
+          &OpticalChannelInfo::Power::instant);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2347,7 +2326,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerAvg(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::input_power,
-          &OpticalChannelInfo::has_input_power, &InputPower::avg);
+          &OpticalChannelInfo::has_input_power,
+          &OpticalChannelInfo::Power::avg);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2369,7 +2349,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerInterval(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::input_power,
-      &OpticalChannelInfo::has_input_power, &InputPower::interval);
+      &OpticalChannelInfo::has_input_power,
+      &OpticalChannelInfo::Power::interval);
   auto register_functor = RegisterFunc<PortInputPowerChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortInputPowerChangedEvent::GetInterval);
@@ -2388,7 +2369,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerMax(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::input_power,
-          &OpticalChannelInfo::has_input_power, &InputPower::max);
+          &OpticalChannelInfo::has_input_power,
+          &OpticalChannelInfo::Power::max);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2410,7 +2392,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerMaxTime(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::input_power,
-      &OpticalChannelInfo::has_input_power, &InputPower::max_time);
+      &OpticalChannelInfo::has_input_power,
+      &OpticalChannelInfo::Power::max_time);
 
   auto register_functor = RegisterFunc<PortInputPowerChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2430,7 +2413,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerMin(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::input_power,
-          &OpticalChannelInfo::has_input_power, &InputPower::min);
+          &OpticalChannelInfo::has_input_power,
+          &OpticalChannelInfo::Power::min);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2452,7 +2436,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerMinTime(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::input_power,
-      &OpticalChannelInfo::has_input_power, &InputPower::min_time);
+      &OpticalChannelInfo::has_input_power,
+      &OpticalChannelInfo::Power::min_time);
 
   auto register_functor = RegisterFunc<PortInputPowerChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2472,7 +2457,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerInstant(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::output_power,
-          &OpticalChannelInfo::has_output_power, &OutputPower::instant);
+          &OpticalChannelInfo::has_output_power,
+          &OpticalChannelInfo::Power::instant);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2496,7 +2482,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerAvg(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::output_power,
-          &OpticalChannelInfo::has_output_power, &OutputPower::avg);
+          &OpticalChannelInfo::has_output_power,
+          &OpticalChannelInfo::Power::avg);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2519,7 +2506,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerInterval(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::output_power,
-      &OpticalChannelInfo::has_output_power, &OutputPower::interval);
+      &OpticalChannelInfo::has_output_power,
+      &OpticalChannelInfo::Power::interval);
 
   auto register_functor = RegisterFunc<PortOutputPowerChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2539,7 +2527,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerMax(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::output_power,
-          &OpticalChannelInfo::has_output_power, &OutputPower::max);
+          &OpticalChannelInfo::has_output_power,
+          &OpticalChannelInfo::Power::max);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2562,7 +2551,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerMaxTime(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::output_power,
-      &OpticalChannelInfo::has_output_power, &OutputPower::max_time);
+      &OpticalChannelInfo::has_output_power,
+      &OpticalChannelInfo::Power::max_time);
 
   auto register_functor = RegisterFunc<PortOutputPowerChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2582,7 +2572,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerMin(
                          GnmiSubscribeStream* stream) {
       float float_value = GetOpticalChannelValue(node_id, port_id, tree,
           &OpticalChannelInfo::output_power,
-          &OpticalChannelInfo::has_output_power, &OutputPower::min);
+          &OpticalChannelInfo::has_output_power,
+          &OpticalChannelInfo::Power::min);
       ::gnmi::Decimal64 decimal_value =
         FloatToDecimal64Value(float_value, kDefaultPrecision);
       return SendResponse(GetResponse(path, decimal_value), stream);
@@ -2605,7 +2596,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerMinTime(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::output_power,
-      &OpticalChannelInfo::has_output_power, &OutputPower::min_time);
+      &OpticalChannelInfo::has_output_power,
+      &OpticalChannelInfo::Power::min_time);
 
   auto register_functor = RegisterFunc<PortOutputPowerChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2651,7 +2643,7 @@ void SetUpComponentsComponentOpticalChannelConfigTargetOutputPower(
     auto status = SetValue(node_id, port_id, tree,
         &SetRequest::Request::Port::mutable_optical_channel_info,
         &OpticalChannelInfo::mutable_target_output_power,
-        &TargetOutputPower::set_value, float_val);
+        &OpticalChannelInfo::TargetOutputPower::set_value, float_val);
     if (status != ::util::OkStatus()) {
       return status;
     }
@@ -2691,7 +2683,8 @@ void SetUpComponentsComponentOpticalChannelStateOperationalMode(
     TreeNode* node, YangParseTree* tree, uint64 node_id, uint32 port_id) {
   auto poll_functor = GetOnPollOpticalInfoFunctor(node_id, port_id, tree,
       &OpticalChannelInfo::operational_mode,
-      &OpticalChannelInfo::has_operational_mode, &OperationalMode::value);
+      &OpticalChannelInfo::has_operational_mode,
+      &OpticalChannelInfo::OperationalMode::value);
 
   auto register_functor = RegisterFunc<PortOperationalModeChangedEvent>();
   auto on_change_functor = GetOnChangeFunctor(
@@ -2734,7 +2727,7 @@ void SetUpComponentsComponentOpticalChannelConfigOperationalMode(
         SetValue(node_id, port_id, tree,
                  &SetRequest::Request::Port::mutable_optical_channel_info,
                  &OpticalChannelInfo::mutable_operational_mode,
-                 &OperationalMode::set_value, uint_val);
+                 &OpticalChannelInfo::OperationalMode::set_value, uint_val);
     if (status != ::util::OkStatus()) {
       return status;
     }
@@ -2779,7 +2772,7 @@ void SetUpComponentsComponentOpticalChannelConfigLinePort(
   };
 
   // This /config node represents the component name in the configuration tree,
-  // so it doesn't support OnChange/OnUpdate/OnReplace untill the yang tree
+  // so it doesn't support OnChange/OnUpdate/OnReplace until the yang tree
   // supports nodes renaming.
 
   node->SetOnPollHandler(poll_functor)
@@ -2811,7 +2804,7 @@ void SetUpComponentsComponentConfigName(
   };
 
   // This /config node represents the component name in the configuration tree,
-  // so it doesn't support OnChange/OnUpdate/OnReplace untill the yang tree
+  // so it doesn't support OnChange/OnUpdate/OnReplace until the yang tree
   // supports nodes renaming.
 
   node->SetOnPollHandler(poll_functor)
@@ -2835,7 +2828,7 @@ void SetUpComponentsComponentName(const std::string& name, TreeNode* node) {
 // /components/component[name=<name>]/state/type
 void SetUpComponentsComponentStateType(
     const std::string& name, const std::string& type, TreeNode* node) {
-  auto poll_functor = [name, type](const GnmiEvent& /*event*/,
+  auto poll_functor = [type](const GnmiEvent& /*event*/,
                                    const ::gnmi::Path& path,
                                    GnmiSubscribeStream* stream) {
     return SendResponse(GetResponse(path, type), stream);

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -386,8 +386,8 @@ U GetOpticalChannelValue(
   // Result variable.
   U value{};
 
-  // Worker function for DataResponseWriter.
-  const auto worker = [&value, instance_getter, has_instance_getter,
+  // Writer for retrieving value
+  DataResponseWriter writer([&value, instance_getter, has_instance_getter,
       inner_message_get_field_func](const DataResponse& in) {
       if (!in.has_optical_channel_info())
       return false;
@@ -400,8 +400,7 @@ U GetOpticalChannelValue(
       value = (instance.*inner_message_get_field_func)();
 
       return true;
-  };
-  DataResponseWriter writer(std::move(worker));
+  });
 
   // Retrieve value from the switch.
   tree->GetSwitchInterface()

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -686,9 +686,9 @@ TreeNodeEventHandler GetOnChangeFunctorForOpticalChannelPower(
       return ::util::OkStatus();
 
     // Convert floating-point value to decimal and send the response.
-    float float_val = (change->*get_func_ptr)();
-    ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_val, kDefaultPrecision);
+    float float_value = (change->*get_func_ptr)();
+    ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                     FloatToDecimal64Value(float_value, kDefaultPrecision));
     return SendResponse(GetResponse(path, decimal_value), stream);
   };
 }
@@ -2303,8 +2303,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerInstant(
           &OpticalChannelInfo::input_power,
           &OpticalChannelInfo::has_input_power,
           &OpticalChannelInfo::Power::instant);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2328,8 +2328,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerAvg(
           &OpticalChannelInfo::input_power,
           &OpticalChannelInfo::has_input_power,
           &OpticalChannelInfo::Power::avg);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2371,8 +2371,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerMax(
           &OpticalChannelInfo::input_power,
           &OpticalChannelInfo::has_input_power,
           &OpticalChannelInfo::Power::max);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2415,8 +2415,8 @@ void SetUpComponentsComponentOpticalChannelStateInputPowerMin(
           &OpticalChannelInfo::input_power,
           &OpticalChannelInfo::has_input_power,
           &OpticalChannelInfo::Power::min);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2459,8 +2459,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerInstant(
           &OpticalChannelInfo::output_power,
           &OpticalChannelInfo::has_output_power,
           &OpticalChannelInfo::Power::instant);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2484,8 +2484,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerAvg(
           &OpticalChannelInfo::output_power,
           &OpticalChannelInfo::has_output_power,
           &OpticalChannelInfo::Power::avg);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2529,8 +2529,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerMax(
           &OpticalChannelInfo::output_power,
           &OpticalChannelInfo::has_output_power,
           &OpticalChannelInfo::Power::max);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2574,8 +2574,8 @@ void SetUpComponentsComponentOpticalChannelStateOutputPowerMin(
           &OpticalChannelInfo::output_power,
           &OpticalChannelInfo::has_output_power,
           &OpticalChannelInfo::Power::min);
-      ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(float_value, kDefaultPrecision);
+      ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                       FloatToDecimal64Value(float_value, kDefaultPrecision));
       return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2617,8 +2617,8 @@ void SetUpComponentsComponentOpticalChannelConfigTargetOutputPower(
   auto poll_functor = [initial_value](const GnmiEvent& /*event*/,
                                       const ::gnmi::Path& path,
                                       GnmiSubscribeStream* stream) {
-    ::gnmi::Decimal64 decimal_value =
-        FloatToDecimal64Value(initial_value, kDefaultPrecision);
+    ASSIGN_OR_RETURN(::gnmi::Decimal64 decimal_value,
+                     FloatToDecimal64Value(initial_value, kDefaultPrecision));
     return SendResponse(GetResponse(path, decimal_value), stream);
   };
 
@@ -2638,7 +2638,7 @@ void SetUpComponentsComponentOpticalChannelConfigTargetOutputPower(
       return MAKE_ERROR(ERR_INVALID_PARAM) << "Expects a decimal value!";
     }
     ::gnmi::Decimal64 decimal_val = typed_value->decimal_val();
-    float float_val = Decimal64ValueToFloat(decimal_val);
+    ASSIGN_OR_RETURN(float float_val, Decimal64ValueToFloat(decimal_val));
 
     auto status = SetValue(node_id, port_id, tree,
         &SetRequest::Request::Port::mutable_optical_channel_info,

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -3302,9 +3302,8 @@ void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
 
   node = tree->AddNode(GetPath("components")("component", name)(
       "optical-channel")("config")("frequency")());
-  uint64 initial_frequency{ optical_port.frequency() };
   SetUpComponentsComponentOpticalChannelConfigFrequency(
-      initial_frequency, node, tree, node_id, port_id);
+      optical_port.frequency(), node, tree, node_id, port_id);
 
   node = tree->AddNode(GetPath("components")("component", name)(
       "optical-channel")("state")("input-power")("instant")());
@@ -3378,9 +3377,8 @@ void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
 
   node = tree->AddNode(GetPath("components")("component", name)(
       "optical-channel")("config")("target-output-power")());
-  float initial_output_power{ optical_port.target_output_power() };
   SetUpComponentsComponentOpticalChannelConfigTargetOutputPower(
-      initial_output_power, node, tree, node_id, port_id);
+      optical_port.target_output_power(), node, tree, node_id, port_id);
 
   // Currently, the OpenConfig considers a 16-bit uint type to represent a
   // vendor-specific bitmask for the operational-mode leaves. It might be split
@@ -3395,9 +3393,8 @@ void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
 
   node = tree->AddNode(GetPath("components")("component", name)(
       "optical-channel")("config")("operational-mode")());
-  uint64 initial_operational_mode{ optical_port.operational_mode() };
   SetUpComponentsComponentOpticalChannelConfigOperationalMode(
-      initial_operational_mode, node, tree, node_id, port_id);
+      optical_port.operational_mode(), node, tree, node_id, port_id);
 
   const std::string& line_port = optical_port.line_port();
   node = tree->AddNode(GetPath("components")("component", name)(
@@ -3417,8 +3414,7 @@ void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
 
   node = tree->AddNode(GetPath("components")("component", name)("state")(
       "type")());
-  const std::string component_type = "OPTICAL_CHANNEL";
-  SetUpComponentsComponentStateType(name, component_type, node);
+  SetUpComponentsComponentStateType(name, "OPTICAL_CHANNEL", node);
 }
 
 void YangParseTreePaths::AddSubtreeNode(const Node& node, YangParseTree* tree) {

--- a/stratum/hal/lib/common/yang_parse_tree_paths.h
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.h
@@ -41,7 +41,7 @@ class YangParseTreePaths {
       const SingletonPort& singleton, const NodeConfigParams& node_config,
       YangParseTree* tree) EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
 
-  // Adds all supported paths for the specified singleton interface.
+  // Adds all supported paths for the specified optical interface.
   static void AddSubtreeInterfaceFromOptical(
       const OpticalPort& optical_port, YangParseTree* tree)
       EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
@@ -65,10 +65,7 @@ class YangParseTreePaths {
   static void AddSubtreeAllInterfaces(YangParseTree* tree)
       EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
 
-  // Enable
-  // * /components/component[name=*]/name
-  // * /components/component/*
-  // paths discovering.
+  // Enable all supported wildcard component-related paths.
   static void AddSubtreeAllComponents(YangParseTree* tree)
       EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
 

--- a/stratum/hal/lib/common/yang_parse_tree_paths.h
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.h
@@ -41,6 +41,11 @@ class YangParseTreePaths {
       const SingletonPort& singleton, const NodeConfigParams& node_config,
       YangParseTree* tree) EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
 
+  // Adds all supported paths for the specified singleton interface.
+  static void AddSubtreeInterfaceFromOptical(
+      const OpticalPort& optical_port, YangParseTree* tree)
+      EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
+
   // Adds all supported paths for the specified trunk interface.
   static void AddSubtreeInterfaceFromTrunk(const std::string& name,
                                            uint64 node_id, uint32 port_id,
@@ -58,6 +63,13 @@ class YangParseTreePaths {
 
   // Adds all supported wildcard interface-related paths.
   static void AddSubtreeAllInterfaces(YangParseTree* tree)
+      EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
+
+  // Enable
+  // * /components/component[name=*]/name
+  // * /components/component/*
+  // paths discovering.
+  static void AddSubtreeAllComponents(YangParseTree* tree)
       EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
 
   // Configure the root element.

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -3383,7 +3383,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   ASSERT_THAT(req.requests(), SizeIs(1));
   EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .laser_frequency().value(), expected_value);
+      .frequency().value(), expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/frequency'
@@ -3402,7 +3402,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   ASSERT_THAT(req.requests(), SizeIs(1));
   EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .laser_frequency().value(), expected_value);
+      .frequency().value(), expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/frequency'
@@ -3466,7 +3466,8 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::mutable_laser_frequency, &LaserFrequency::set_value,
+      &OpticalChannelInfo::mutable_frequency,
+      &OpticalChannelInfo::Frequency::set_value,
       expected_value);
 
   // Retrieve the value that has been mocked.
@@ -3490,7 +3491,8 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::mutable_laser_frequency, &LaserFrequency::set_value,
+      &OpticalChannelInfo::mutable_frequency,
+      &OpticalChannelInfo::Frequency::set_value,
       expected_value);
 
   // Retrieve the value that has been mocked.
@@ -3513,7 +3515,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_instant,
+      &OpticalChannelInfo::Power::set_instant,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3537,7 +3539,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_instant,
+      &OpticalChannelInfo::Power::set_instant,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3558,7 +3560,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("input-power")("instant")();
 
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_instant(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3584,7 +3586,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_avg,
+      &OpticalChannelInfo::Power::set_avg,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3606,7 +3608,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_avg,
+      &OpticalChannelInfo::Power::set_avg,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3627,7 +3629,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("input-power")("avg")();
 
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_avg(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3654,7 +3656,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_interval,
+      &OpticalChannelInfo::Power::set_interval,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3676,7 +3678,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_interval,
+      &OpticalChannelInfo::Power::set_interval,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3696,7 +3698,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
       "optical-channel")("state")("input-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_interval(expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3720,7 +3722,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_max,
+      &OpticalChannelInfo::Power::set_max,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3742,7 +3744,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_max,
+      &OpticalChannelInfo::Power::set_max,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3763,7 +3765,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("input-power")("max")();
 
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_max(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3790,7 +3792,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_max_time,
+      &OpticalChannelInfo::Power::set_max_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3812,7 +3814,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_max_time,
+      &OpticalChannelInfo::Power::set_max_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3832,7 +3834,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
       "optical-channel")("state")("input-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_max_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3856,7 +3858,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_min,
+      &OpticalChannelInfo::Power::set_min,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3878,7 +3880,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_min,
+      &OpticalChannelInfo::Power::set_min,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3899,7 +3901,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("input-power")("min")();
 
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_min(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -3926,7 +3928,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_min_time,
+      &OpticalChannelInfo::Power::set_min_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3948,7 +3950,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &InputPower::set_min_time,
+      &OpticalChannelInfo::Power::set_min_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -3968,7 +3970,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
       "optical-channel")("state")("input-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
-  InputPower input_power;
+  OpticalChannelInfo::Power input_power;
   input_power.set_min_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4111,7 +4113,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_instant,
+      &OpticalChannelInfo::Power::set_instant,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4134,7 +4136,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_instant,
+      &OpticalChannelInfo::Power::set_instant,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4155,7 +4157,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("output-power")("instant")();
 
-  OutputPower output_power;
+  OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_instant(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4181,7 +4183,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_avg,
+      &OpticalChannelInfo::Power::set_avg,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4204,7 +4206,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_avg,
+      &OpticalChannelInfo::Power::set_avg,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4225,7 +4227,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("output-power")("avg")();
 
-  OutputPower output_power;
+  OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_avg(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4252,7 +4254,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_interval,
+      &OpticalChannelInfo::Power::set_interval,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4274,7 +4276,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_interval,
+      &OpticalChannelInfo::Power::set_interval,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4294,7 +4296,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
       "optical-channel")("state")("output-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
-  OutputPower output_power;
+  OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_interval(expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4318,7 +4320,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_max,
+      &OpticalChannelInfo::Power::set_max,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4341,7 +4343,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_max,
+      &OpticalChannelInfo::Power::set_max,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4362,7 +4364,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("output-power")("max")();
 
-  OutputPower output_power;
+  OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_max(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4389,7 +4391,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_max_time,
+      &OpticalChannelInfo::Power::set_max_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4411,7 +4413,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_max_time,
+      &OpticalChannelInfo::Power::set_max_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4431,7 +4433,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
       "optical-channel")("state")("output-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
-  OutputPower output_power;
+  OpticalChannelInfo::Power output_power;
   output_power.set_max_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4455,7 +4457,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_min,
+      &OpticalChannelInfo::Power::set_min,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4478,7 +4480,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_min,
+      &OpticalChannelInfo::Power::set_min,
       10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4499,7 +4501,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "dummy-switch-1")(
       "optical-channel")("state")("output-power")("min")();
 
-  OutputPower output_power;
+  OpticalChannelInfo::Power output_power;
   output_power.set_min(10.05);
 
   ::gnmi::SubscribeResponse resp;
@@ -4526,7 +4528,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_min_time,
+      &OpticalChannelInfo::Power::set_min_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4548,7 +4550,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OutputPower::set_min_time,
+      &OpticalChannelInfo::Power::set_min_time,
       expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4568,7 +4570,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
       "optical-channel")("state")("output-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
-  OutputPower output_power;
+  OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_min_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
@@ -4733,7 +4735,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_operational_mode,
-      &OperationalMode::set_value,
+      &OpticalChannelInfo::OperationalMode::set_value,
       expected_value);
 
   // Retrieve the value that has been mocked.
@@ -4759,7 +4761,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_operational_mode,
-      &OperationalMode::set_value,
+      &OpticalChannelInfo::OperationalMode::set_value,
       expected_value);
 
   // Retrieve the value that has been mocked.

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -487,6 +487,22 @@ class YangParseTreeOpticalChannelTest : public YangParseTreeTest {
         WithArg<2>(Invoke(mockedRetrieve)),
         Return(::util::OkStatus())));
   }
+
+  // Mock switch::RetrieveValue to return the desired value.
+  template <typename TOption, typename TSetterValue, typename TValue>
+  void SubstituteOpticalChannelRetrieveValue(
+      void (TOption::*value_setter)(TSetterValue), const TValue& value) {
+    const auto mockedRetrieve = [=](WriterInterface<DataResponse>* w) {
+      DataResponse resp;
+      OpticalChannelInfo* oc_info = resp.mutable_optical_channel_info();
+      (oc_info->*value_setter)(value);
+      w->Write(resp);
+    };
+
+    EXPECT_CALL(switch_, RetrieveValue(_, _, _, _)).WillOnce(DoAll(
+        WithArg<2>(Invoke(mockedRetrieve)),
+        Return(::util::OkStatus())));
+  }
 };
 
 constexpr char YangParseTreeTest::kInterface1QueueName[];
@@ -3383,7 +3399,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   ASSERT_THAT(req.requests(), SizeIs(1));
   EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .frequency().value(), expected_value);
+      .frequency(), expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/frequency'
@@ -3402,7 +3418,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   ASSERT_THAT(req.requests(), SizeIs(1));
   EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .frequency().value(), expected_value);
+      .frequency(), expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/frequency'
@@ -3466,8 +3482,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::mutable_frequency,
-      &OpticalChannelInfo::Frequency::set_value,
+      &OpticalChannelInfo::set_frequency,
       expected_value);
 
   // Retrieve the value that has been mocked.
@@ -3491,8 +3506,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::mutable_frequency,
-      &OpticalChannelInfo::Frequency::set_value,
+      &OpticalChannelInfo::set_frequency,
       expected_value);
 
   // Retrieve the value that has been mocked.
@@ -4001,7 +4015,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_THAT(req.requests(), SizeIs(1));
 
   float result = req.requests(0).port().optical_channel_info()
-      .target_output_power().value();
+      .target_output_power();
   EXPECT_FLOAT_EQ(result, 10.05);
 }
 
@@ -4023,7 +4037,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_THAT(req.requests(), SizeIs(1));
 
   float result = req.requests(0).port().optical_channel_info()
-      .target_output_power().value();
+      .target_output_power();
   EXPECT_FLOAT_EQ(result, 10.05);
 }
 
@@ -4647,7 +4661,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   ASSERT_THAT(req.requests(), SizeIs(1));
   EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .operational_mode().value(), expected_value);
+      .operational_mode(), expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/operational-mode'
@@ -4667,7 +4681,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   ASSERT_THAT(req.requests(), SizeIs(1));
   EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .operational_mode().value(), expected_value);
+      .operational_mode(), expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/operational-mode'
@@ -4734,8 +4748,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::mutable_operational_mode,
-      &OpticalChannelInfo::OperationalMode::set_value,
+      &OpticalChannelInfo::set_operational_mode,
       expected_value);
 
   // Retrieve the value that has been mocked.
@@ -4760,8 +4773,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::mutable_operational_mode,
-      &OpticalChannelInfo::OperationalMode::set_value,
+      &OpticalChannelInfo::set_operational_mode,
       expected_value);
 
   // Retrieve the value that has been mocked.

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -53,6 +53,9 @@ class YangParseTreeTest : public ::testing::Test {
   static constexpr int kInterface1PortId = 3;
   static constexpr uint32 kInterface1QueueId = 0;
   static constexpr char kInterface1QueueName[] = "BE1";
+  static constexpr int kOpticalInterface1NodeId = 5;
+  static constexpr int kOpticalInterface1PortId = 5;
+  static constexpr uint64 kOpticalInterface1Frequency = 10050;
   static constexpr char kAlarmDescription[] = "alarm";
   static constexpr char kAlarmSeverityText[] = "CRITICAL";
   static constexpr Alarm::Severity kAlarmSeverityEnum = Alarm::CRITICAL;
@@ -139,16 +142,17 @@ class YangParseTreeTest : public ::testing::Test {
     parse_tree_.AddSubtreeInterfaceFromSingleton(*singleton_ptr, node_config);
   }
 
-  // Create /components/conponent[name]/optical-channel subtree from the
+  // Create /components/component[name]/optical-channel subtree from the
   // default OpticalPort instance.
-  void AddOpticalInterface(const std::string& name) {
+  void AddSubtreeOpticalInterface(const std::string& name) {
     absl::WriterMutexLock l(&parse_tree_.root_access_lock_);
 
     OpticalPort optical_port;
     optical_port.set_name(name);
     optical_port.set_line_port("line-port-1");
-    optical_port.set_node(kInterface1NodeId);
-    optical_port.set_id(kInterface1PortId);
+    optical_port.set_node(kOpticalInterface1NodeId);
+    optical_port.set_id(kOpticalInterface1PortId);
+    optical_port.set_frequency(kOpticalInterface1Frequency);
     parse_tree_.AddSubtreeInterfaceFromOptical(optical_port);
   }
 
@@ -3344,18 +3348,18 @@ TEST_F(YangParseTreeTest, DebugNodesNodePacketIoDebugStringOnPollSuccess) {
 // Check if the '/components/component/optical-channel/config/frequency'
 // OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigFrequencyOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("frequency")();
+       ComponentsComponentOpticalChannelConfigFrequencyOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("frequency")();
 
   const uint64 frequency = 10245;
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortFrequencyChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, frequency),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortFrequencyChangedEvent(kOpticalInterface1NodeId,
+                                kOpticalInterface1PortId, frequency),
+      &resp));
 
   // Check that the result of the call is what is expected.
   ASSERT_EQ(resp.update().update_size(), 1);
@@ -3365,18 +3369,18 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/frequency'
 // OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateFrequencyOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("state")("frequency")();
+       ComponentsComponentOpticalChannelStateFrequencyOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("state")("frequency")();
 
   const uint64 frequency = 10245;
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortFrequencyChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, frequency),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortFrequencyChangedEvent(kOpticalInterface1NodeId,
+                                kOpticalInterface1PortId, frequency),
+      &resp));
 
   // Check that the result of the call is what is expected.
   ASSERT_EQ(resp.update().update_size(), 1);
@@ -3386,10 +3390,10 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/config/frequency'
 // OnUpdate action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigFrequencyOnUpdateSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("frequency")();
+       ComponentsComponentOpticalChannelConfigFrequencyOnUpdateSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("frequency")();
 
   const uint expected_value = 100500;
   ::gnmi::TypedValue typed_value = GetTypedValue(expected_value);
@@ -3398,17 +3402,17 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_OK(ExecuteOnUpdate(path, typed_value, &req, nullptr));
 
   ASSERT_THAT(req.requests(), SizeIs(1));
-  EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .frequency(), expected_value);
+  EXPECT_EQ(req.requests(0).port().optical_channel_info().frequency(),
+            expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/frequency'
 // OnReplace action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigFrequencyOnReplaceSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("frequency")();
+       ComponentsComponentOpticalChannelConfigFrequencyOnReplaceSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("frequency")();
 
   const uint expected_value = 100500;
   ::gnmi::TypedValue typed_value = GetTypedValue(expected_value);
@@ -3417,17 +3421,17 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_OK(ExecuteOnReplace(path, typed_value, &req, nullptr));
 
   ASSERT_THAT(req.requests(), SizeIs(1));
-  EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .frequency(), expected_value);
+  EXPECT_EQ(req.requests(0).port().optical_channel_info().frequency(),
+            expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/frequency'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigFrequencyOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("frequency")();
+       ComponentsComponentOpticalChannelConfigFrequencyOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("frequency")();
 
   // Set some value to config/ node.
 
@@ -3449,10 +3453,10 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/config/frequency'
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigFrequencyOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("frequency")();
+       ComponentsComponentOpticalChannelConfigFrequencyOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("frequency")();
 
   const uint expected_value = 100500;
   ::gnmi::TypedValue typed_value = GetTypedValue(expected_value);
@@ -3473,17 +3477,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/frequency'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateFrequencyOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("state")("frequency")();
+       ComponentsComponentOpticalChannelStateFrequencyOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("state")("frequency")();
 
   const uint expected_value = 100500;
 
   // Mock switch->RetrieveValue() call.
-  SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::set_frequency,
-      expected_value);
+  SubstituteOpticalChannelRetrieveValue(&OpticalChannelInfo::set_frequency,
+                                        expected_value);
 
   // Retrieve the value that has been mocked.
   ::gnmi::SubscribeResponse resp;
@@ -3497,17 +3500,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/frequency'
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateFrequencyOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("state")("frequency")();
+       ComponentsComponentOpticalChannelStateFrequencyOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("state")("frequency")();
 
   const uint expected_value = 100500;
 
   // Mock switch->RetrieveValue() call.
-  SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::set_frequency,
-      expected_value);
+  SubstituteOpticalChannelRetrieveValue(&OpticalChannelInfo::set_frequency,
+                                        expected_value);
 
   // Retrieve the value that has been mocked.
   ::gnmi::SubscribeResponse resp;
@@ -3522,15 +3524,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /instant' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerInstantOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerInstantOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("instant")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_instant,
-      10.05);
+      &OpticalChannelInfo::Power::set_instant, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3546,15 +3547,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /instant' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerInstantOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerInstantOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("instant")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_instant,
-      10.05);
+      &OpticalChannelInfo::Power::set_instant, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3569,20 +3569,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /instant' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerInstantOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerInstantOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("instant")();
 
   OpticalChannelInfo::Power input_power;
   input_power.set_instant(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -3593,15 +3593,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /avg' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateInputPowerAvgOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateInputPowerAvgOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("avg")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_avg,
-      10.05);
+      &OpticalChannelInfo::Power::set_avg, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3615,15 +3614,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /avg' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateInputPowerAvgOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerAvgOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("avg")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_avg,
-      10.05);
+      &OpticalChannelInfo::Power::set_avg, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3638,20 +3636,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /avg' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerAvgOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerAvgOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("avg")();
 
   OpticalChannelInfo::Power input_power;
   input_power.set_avg(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -3662,16 +3660,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /interval' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateInputPowerIntervalOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateInputPowerIntervalOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_interval,
-      expected_value);
+      &OpticalChannelInfo::Power::set_interval, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3684,16 +3681,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /interval' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerIntervalOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerIntervalOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_interval,
-      expected_value);
+      &OpticalChannelInfo::Power::set_interval, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3704,11 +3700,12 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/state/input-power
 // /interval' OnChange action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerIntervalOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelStateInputPowerIntervalOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
@@ -3716,11 +3713,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
   input_power.set_interval(expected_value);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
 
   ASSERT_THAT(resp.update().update(), SizeIs(1));
   EXPECT_EQ(resp.update().update(0).val().uint_val(), expected_value);
@@ -3729,15 +3726,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /max' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateInputPowerMaxOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateInputPowerMaxOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_max,
-      10.05);
+      &OpticalChannelInfo::Power::set_max, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3751,15 +3747,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /max' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateInputPowerMaxOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMaxOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_max,
-      10.05);
+      &OpticalChannelInfo::Power::set_max, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3774,20 +3769,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /max' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerMaxOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMaxOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max")();
 
   OpticalChannelInfo::Power input_power;
   input_power.set_max(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -3798,16 +3793,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/config/input-power
 // /max-time' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateInputPowerMaxTimeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateInputPowerMaxTimeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_max_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_max_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3820,16 +3814,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /max-time' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerMaxTimeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMaxTimeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_max_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_max_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3842,9 +3835,9 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /max-time' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerMaxTimeOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMaxTimeOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
@@ -3852,11 +3845,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
   input_power.set_max_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
 
   ASSERT_THAT(resp.update().update(), SizeIs(1));
   EXPECT_EQ(resp.update().update(0).val().uint_val(), expected_value);
@@ -3865,15 +3858,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /min' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateInputPowerMinOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateInputPowerMinOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_min,
-      10.05);
+      &OpticalChannelInfo::Power::set_min, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3887,15 +3879,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /min' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateInputPowerMinOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMinOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_min,
-      10.05);
+      &OpticalChannelInfo::Power::set_min, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3910,20 +3901,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /min' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerMinOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMinOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min")();
 
   OpticalChannelInfo::Power input_power;
   input_power.set_min(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -3934,16 +3925,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/input-power
 // /min-time' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateInputPowerMinTimeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateInputPowerMinTimeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_min_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_min_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -3956,16 +3946,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /min-time' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerMinTimeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMinTimeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_input_power,
-      &OpticalChannelInfo::Power::set_min_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_min_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -3978,9 +3967,9 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /min-time' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateInputPowerMinTimeOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateInputPowerMinTimeOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
@@ -3988,11 +3977,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
   input_power.set_min_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortInputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, input_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortInputPowerChangedEvent(kOpticalInterface1NodeId,
+                                 kOpticalInterface1PortId, input_power),
+      &resp));
 
   ASSERT_THAT(resp.update().update(), SizeIs(1));
   EXPECT_EQ(resp.update().update(0).val().uint_val(), expected_value);
@@ -4001,9 +3990,9 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/config/output-power'
 // OnUpdate action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCConfigOutputPowerOnUpdateSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCConfigOutputPowerOnUpdateSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("config")("target-output-power")();
 
   ::gnmi::TypedValue value;
@@ -4014,8 +4003,8 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_OK(ExecuteOnUpdate(path, value, &req, nullptr));
   ASSERT_THAT(req.requests(), SizeIs(1));
 
-  float result = req.requests(0).port().optical_channel_info()
-      .target_output_power();
+  float result =
+      req.requests(0).port().optical_channel_info().target_output_power();
   EXPECT_FLOAT_EQ(result, 10.05);
 }
 
@@ -4023,9 +4012,9 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnReplace action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigOutputPowerOnReplaceSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelConfigOutputPowerOnReplaceSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("config")("target-output-power")();
 
   ::gnmi::TypedValue value;
@@ -4036,17 +4025,17 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_OK(ExecuteOnReplace(path, value, &req, nullptr));
   ASSERT_THAT(req.requests(), SizeIs(1));
 
-  float result = req.requests(0).port().optical_channel_info()
-      .target_output_power();
+  float result =
+      req.requests(0).port().optical_channel_info().target_output_power();
   EXPECT_FLOAT_EQ(result, 10.05);
 }
 
 // Check if the '/components/component/optical-channel/config
 // /target-output-power' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCConfigOutputPowerOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCConfigOutputPowerOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("config")("target-output-power")();
   // Set some value to config/ node.
 
@@ -4071,9 +4060,9 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /target-output-power' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigTargetOutputPowerOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelConfigTargetOutputPowerOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("config")("target-output-power")();
   // Set some value to config/ node.
 
@@ -4096,19 +4085,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/config
 // /target-output-power' OnChange action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigTargetOutputPowerOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("target-output-power")();
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelConfigTargetOutputPowerOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("target-output-power")();
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortTargetOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, 10.05),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortTargetOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                        kOpticalInterface1PortId, 10.05),
+      &resp));
   ASSERT_EQ(resp.update().update_size(), 1);
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -4120,15 +4110,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /instant' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerInstantOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerInstantOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("instant")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_instant,
-      10.05);
+      &OpticalChannelInfo::Power::set_instant, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4143,15 +4132,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /instant' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerInstantOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerInstantOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("instant")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_instant,
-      10.05);
+      &OpticalChannelInfo::Power::set_instant, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4164,22 +4152,23 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/state/output-power
 // /instant' OnChange action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerInstantOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelStateOutputPowerInstantOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("instant")();
 
   OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_instant(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -4190,15 +4179,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/output-power
 // /avg' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateOutputPowerAvgOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateOutputPowerAvgOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("avg")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_avg,
-      10.05);
+      &OpticalChannelInfo::Power::set_avg, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4213,15 +4201,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /avg' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerAvgOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerAvgOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("avg")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_avg,
-      10.05);
+      &OpticalChannelInfo::Power::set_avg, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4236,20 +4223,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /avg' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerAvgOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerAvgOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("avg")();
 
   OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_avg(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -4260,16 +4247,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/output-power
 // /interval' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateOutputPowerIntervalOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateOutputPowerIntervalOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_interval,
-      expected_value);
+      &OpticalChannelInfo::Power::set_interval, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4280,18 +4266,18 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/state/output-power
 // /interval' OnTimer action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerIntervalOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelStateOutputPowerIntervalOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_interval,
-      expected_value);
+      &OpticalChannelInfo::Power::set_interval, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4302,11 +4288,12 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/state/output-power
 // /interval' OnChange action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerIntervalOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelStateOutputPowerIntervalOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("interval")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
@@ -4314,11 +4301,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
   output_power.set_interval(expected_value);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
 
   ASSERT_THAT(resp.update().update(), SizeIs(1));
   EXPECT_EQ(resp.update().update(0).val().uint_val(), expected_value);
@@ -4327,15 +4314,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/output-power
 // /max' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateOutputPowerMaxOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateOutputPowerMaxOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_max,
-      10.05);
+      &OpticalChannelInfo::Power::set_max, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4350,15 +4336,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /max' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMaxOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerMaxOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_max,
-      10.05);
+      &OpticalChannelInfo::Power::set_max, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4373,20 +4358,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /max' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMaxOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerMaxOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max")();
 
   OpticalChannelInfo::OpticalChannelInfo::Power output_power;
   output_power.set_max(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -4397,16 +4382,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/output-power
 // /max-time' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateOutputPowerMaxTimeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateOutputPowerMaxTimeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_max_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_max_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4419,16 +4403,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /max-time' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMaxTimeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerMaxTimeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_max_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_max_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4439,11 +4422,12 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/state/output-power
 // /max-time' OnChange action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMaxTimeOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelStateOutputPowerMaxTimeOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
@@ -4451,11 +4435,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
   output_power.set_max_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
 
   ASSERT_THAT(resp.update().update(), SizeIs(1));
   EXPECT_EQ(resp.update().update(0).val().uint_val(), expected_value);
@@ -4464,15 +4448,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/output-power
 // /min' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateOutputPowerMinOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateOutputPowerMinOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_min,
-      10.05);
+      &OpticalChannelInfo::Power::set_min, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4487,15 +4470,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /min' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMinOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerMinOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min")();
 
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_min,
-      10.05);
+      &OpticalChannelInfo::Power::set_min, 10.05);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4510,20 +4492,20 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /min' OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMinOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerMinOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min")();
 
   OpticalChannelInfo::Power output_power;
   output_power.set_min(10.05);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
   ASSERT_THAT(resp.update().update(), SizeIs(1));
 
   ::gnmi::Decimal64 result = resp.update().update(0).val().decimal_val();
@@ -4534,16 +4516,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/output-power
 // /min-time' OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOCStateOutputPowerMinTimeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOCStateOutputPowerMinTimeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_min_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_min_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnPoll(path, &resp));
@@ -4556,16 +4537,15 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // /min-time' OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMinTimeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateOutputPowerMinTimeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalChannelInfo::mutable_output_power,
-      &OpticalChannelInfo::Power::set_min_time,
-      expected_value);
+      &OpticalChannelInfo::Power::set_min_time, expected_value);
 
   ::gnmi::SubscribeResponse resp;
   ASSERT_OK(ExecuteOnTimer(path, &resp));
@@ -4576,11 +4556,12 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
 // Check if the '/components/component/optical-channel/state/output-power
 // /min-time' OnChange action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOutputPowerMinTimeOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+TEST_F(
+    YangParseTreeOpticalChannelTest,
+    // NOLINTNEXTLINE(whitespace/line_length)
+    ComponentsComponentOpticalChannelStateOutputPowerMinTimeOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min-time")();
 
   const ::google::protobuf::uint64 expected_value = 100500;
@@ -4588,11 +4569,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
   output_power.set_min_time(expected_value);
 
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOutputPowerChangedEvent(
-                          kInterface1NodeId, kInterface1PortId, output_power),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOutputPowerChangedEvent(kOpticalInterface1NodeId,
+                                  kOpticalInterface1PortId, output_power),
+      &resp));
 
   ASSERT_THAT(resp.update().update(), SizeIs(1));
   EXPECT_EQ(resp.update().update(0).val().uint_val(), expected_value);
@@ -4602,19 +4583,18 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigOperationalModeOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("operational-mode")();
+       ComponentsComponentOpticalChannelConfigOperationalModeOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("operational-mode")();
 
   const uint64 operational_mode = 10245;
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOperationalModeChangedEvent(
-                          kInterface1NodeId, kInterface1PortId,
-                          operational_mode),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOperationalModeChangedEvent(
+          kOpticalInterface1NodeId, kOpticalInterface1PortId, operational_mode),
+      &resp));
 
   // Check that the result of the call is what is expected.
   ASSERT_EQ(resp.update().update_size(), 1);
@@ -4625,19 +4605,18 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnChange action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOperationalModeOnChangeSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("state")("operational-mode")();
+       ComponentsComponentOpticalChannelStateOperationalModeOnChangeSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("state")("operational-mode")();
 
   const uint64 operational_mode = 10245;
   ::gnmi::SubscribeResponse resp;
-  EXPECT_OK(
-      ExecuteOnChange(path,
-                      PortOperationalModeChangedEvent(
-                          kInterface1NodeId, kInterface1PortId,
-                          operational_mode),
-                      &resp));
+  EXPECT_OK(ExecuteOnChange(
+      path,
+      PortOperationalModeChangedEvent(
+          kOpticalInterface1NodeId, kOpticalInterface1PortId, operational_mode),
+      &resp));
 
   // Check that the result of the call is what is expected.
   ASSERT_EQ(resp.update().update_size(), 1);
@@ -4648,10 +4627,10 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnUpdate action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigOperationalModeOnUpdateSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("operational-mode")();
+       ComponentsComponentOpticalChannelConfigOperationalModeOnUpdateSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("operational-mode")();
 
   const uint expected_value = 100500;
   ::gnmi::TypedValue typed_value = GetTypedValue(expected_value);
@@ -4660,18 +4639,18 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_OK(ExecuteOnUpdate(path, typed_value, &req, nullptr));
 
   ASSERT_THAT(req.requests(), SizeIs(1));
-  EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .operational_mode(), expected_value);
+  EXPECT_EQ(req.requests(0).port().optical_channel_info().operational_mode(),
+            expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/operational-mode'
 // OnReplace action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigOperationalOnReplaceSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("operational-mode")();
+       ComponentsComponentOpticalChannelConfigOperationalOnReplaceSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("operational-mode")();
 
   const uint expected_value = 100500;
   ::gnmi::TypedValue typed_value = GetTypedValue(expected_value);
@@ -4680,18 +4659,18 @@ TEST_F(YangParseTreeOpticalChannelTest,
   ASSERT_OK(ExecuteOnReplace(path, typed_value, &req, nullptr));
 
   ASSERT_THAT(req.requests(), SizeIs(1));
-  EXPECT_EQ(req.requests(0).port().optical_channel_info()
-      .operational_mode(), expected_value);
+  EXPECT_EQ(req.requests(0).port().optical_channel_info().operational_mode(),
+            expected_value);
 }
 
 // Check if the '/components/component/optical-channel/config/operational-mode'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigOperationalModeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("operational-mode")();
+       ComponentsComponentOpticalChannelConfigOperationalModeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("operational-mode")();
 
   // Set some value to config/ node.
 
@@ -4714,10 +4693,10 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelConfigOperationalModeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("config")("operational-mode")();
+       ComponentsComponentOpticalChannelConfigOperationalModeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("config")("operational-mode")();
 
   const uint expected_value = 100500;
   ::gnmi::TypedValue typed_value = GetTypedValue(expected_value);
@@ -4739,17 +4718,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOperationalModeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("state")("operational-mode")();
+       ComponentsComponentOpticalChannelStateOperationalModeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("state")("operational-mode")();
 
   const uint expected_value = 100500;
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::set_operational_mode,
-      expected_value);
+      &OpticalChannelInfo::set_operational_mode, expected_value);
 
   // Retrieve the value that has been mocked.
   ::gnmi::SubscribeResponse resp;
@@ -4764,17 +4742,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
        // NOLINTNEXTLINE(whitespace/line_length)
-       ComponentsComponentOpticalChannelStateOperationalModeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component",
-      "dummy-switch-1")("optical-channel")("state")("operational-mode")();
+       ComponentsComponentOpticalChannelStateOperationalModeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
+      "optical-channel")("state")("operational-mode")();
 
   const uint expected_value = 100500;
 
   // Mock switch->RetrieveValue() call.
   SubstituteOpticalChannelRetrieveValue(
-      &OpticalChannelInfo::set_operational_mode,
-      expected_value);
+      &OpticalChannelInfo::set_operational_mode, expected_value);
 
   // Retrieve the value that has been mocked.
   ::gnmi::SubscribeResponse resp;
@@ -4788,10 +4765,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/line-port'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateLinePortOnPollSuccess_Test) {
-  // Set "dummy-switch-1" subtree with the hardcoded line-port = "line-port-1".
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateLinePortOnPollSuccess) {
+  // Set "optical-interface-1" subtree with the hardcoded line-port =
+  // "line-port-1".
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("line-port")();
 
   // Retrieve the value from the tree.
@@ -4806,10 +4784,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/state/line-port'
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelStateLinePortOnTimerSuccess_Test) {
-  // Set "dummy-switch-1" subtree with the hardcoded line-port = "line-port-1".
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelStateLinePortOnTimerSuccess) {
+  // Set "optical-interface-1" subtree with the hardcoded line-port =
+  // "line-port-1".
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("line-port")();
 
   // Retrieve the value from the tree.
@@ -4824,10 +4803,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/config/line-port'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigLinePortOnPollSuccess_Test) {
-  // Set "dummy-switch-1" subtree with the hardcoded line-port = "line-port-1".
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelConfigLinePortOnPollSuccess) {
+  // Set "optical-interface-1" subtree with the hardcoded line-port =
+  // "line-port-1".
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("config")("line-port")();
 
   // Retrieve the value from the tree.
@@ -4842,10 +4822,11 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/optical-channel/config/line-port'
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentOpticalChannelConfigLinePortOnTimerSuccess_Test) {
-  // Set "dummy-switch-1" subtree with the hardcoded line-port = "line-port-1".
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")(
+       ComponentsComponentOpticalChannelConfigLinePortOnTimerSuccess) {
+  // Set "optical-interface-1" subtree with the hardcoded line-port =
+  // "line-port-1".
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("config")("line-port")();
 
   // Retrieve the value from the tree.
@@ -4858,10 +4839,10 @@ TEST_F(YangParseTreeOpticalChannelTest,
 }
 
 // Check if the '/components/component/name' OnPoll action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentNameOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")("name")();
+TEST_F(YangParseTreeOpticalChannelTest, ComponentsComponentNameOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path =
+      GetPath("components")("component", "optical-interface-1")("name")();
 
   // Retrieve the value from the tree.
   ::gnmi::SubscribeResponse resp;
@@ -4869,14 +4850,14 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Check that we retrieve the component name.
   ASSERT_THAT(resp.update().update(), SizeIs(1));
-  EXPECT_EQ(resp.update().update(0).val().string_val(), "dummy-switch-1");
+  EXPECT_EQ(resp.update().update(0).val().string_val(), "optical-interface-1");
 }
 
 // Check if the '/components/component/name' OnTimer action works correctly.
-TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentNameOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")("name")();
+TEST_F(YangParseTreeOpticalChannelTest, ComponentsComponentNameOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path =
+      GetPath("components")("component", "optical-interface-1")("name")();
 
   // Retrieve the value from the tree.
   ::gnmi::SubscribeResponse resp;
@@ -4884,16 +4865,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Check that we retrieve the component name.
   ASSERT_THAT(resp.update().update(), SizeIs(1));
-  EXPECT_EQ(resp.update().update(0).val().string_val(), "dummy-switch-1");
+  EXPECT_EQ(resp.update().update(0).val().string_val(), "optical-interface-1");
 }
 
 // Check if the '/components/component/config/name'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentConfigNameOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")("config")(
-      "name")();
+       ComponentsComponentConfigNameOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component",
+                                    "optical-interface-1")("config")("name")();
 
   // Retrieve the value from the tree.
   ::gnmi::SubscribeResponse resp;
@@ -4901,16 +4882,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Check that we retrieve the component name.
   ASSERT_THAT(resp.update().update(), SizeIs(1));
-  EXPECT_EQ(resp.update().update(0).val().string_val(), "dummy-switch-1");
+  EXPECT_EQ(resp.update().update(0).val().string_val(), "optical-interface-1");
 }
 
 // Check if the '/components/component/config/name'
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentConfigNameOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")("config")(
-      "name")();
+       ComponentsComponentConfigNameOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component",
+                                    "optical-interface-1")("config")("name")();
 
   // Retrieve the value from the tree.
   ::gnmi::SubscribeResponse resp;
@@ -4918,16 +4899,16 @@ TEST_F(YangParseTreeOpticalChannelTest,
 
   // Check that we retrieve the component name.
   ASSERT_THAT(resp.update().update(), SizeIs(1));
-  EXPECT_EQ(resp.update().update(0).val().string_val(), "dummy-switch-1");
+  EXPECT_EQ(resp.update().update(0).val().string_val(), "optical-interface-1");
 }
 
 // Check if the '/components/component/state/type'
 // OnPoll action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentStateTypeOnPollSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")("state")(
-      "type")();
+       ComponentsComponentStateTypeOnPollSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component",
+                                    "optical-interface-1")("state")("type")();
 
   // Retrieve the value from the tree.
   ::gnmi::SubscribeResponse resp;
@@ -4941,10 +4922,10 @@ TEST_F(YangParseTreeOpticalChannelTest,
 // Check if the '/components/component/state/type'
 // OnTimer action works correctly.
 TEST_F(YangParseTreeOpticalChannelTest,
-       ComponentsComponentStateTypeOnTimerSuccess_Test) {
-  AddOpticalInterface("dummy-switch-1");
-  auto path = GetPath("components")("component", "dummy-switch-1")("state")(
-      "type")();
+       ComponentsComponentStateTypeOnTimerSuccess) {
+  AddSubtreeOpticalInterface("optical-interface-1");
+  auto path = GetPath("components")("component",
+                                    "optical-interface-1")("state")("type")();
 
   // Retrieve the value from the tree.
   ::gnmi::SubscribeResponse resp;


### PR DESCRIPTION
This is the first part from #72 

@maksym-tropets-plvision we will break PR #72 to four smaller PR so we can merge it faster.

The first one is to add new paths and internal message structure(common.proto) to the Stratum to support optical device.
The second part will be TAI PHAL backend, TaiSwitchConfigurator, TaiDataSource, and OpticalAdapter.
<del>The third part will be TaiSwitchConfigurator, TaiDataSource, and OpticalAdapter</del>
The final part will be TaiManager/Wrapper

I put you and Bohdan as the author of the commit.
Let me know if there is any issue

Co-authored-by: Bohdan Oheruk <bohdan.oheruk@plvision.eu>
Co-authored-by: Yi Tseng <yi@opennetworking.org>