### PR TITLE
Fix invalid free() in OnlpWrapper

### DIFF
--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
@@ -221,18 +221,19 @@ OnlpWrapper::~OnlpWrapper() {
 }
 
 ::util::StatusOr<std::vector<OnlpOid>> OnlpWrapper::GetOidList(
-      onlp_oid_type_flag_t type) const {
+    onlp_oid_type_flag_t type) const {
   std::vector<OnlpOid> oid_list;
-  biglist_t* oid_hdr_list;
+  biglist_t* oid_hdr_list = nullptr;
 
   OnlpOid root_oid = ONLP_CHASSIS_ID_CREATE(1);
-  onlp_oid_hdr_get_all(root_oid, type, 0, &oid_hdr_list);
+  CHECK_RETURN_IF_FALSE(
+      ONLP_SUCCESS(onlp_oid_hdr_get_all(root_oid, type, 0, &oid_hdr_list)));
 
   // Iterate though the returned list and add the OIDs to oid_list
   biglist_t* curr_node = oid_hdr_list;
   while (curr_node != nullptr) {
     onlp_oid_hdr_t* oid_hdr =
-                    reinterpret_cast<onlp_oid_hdr_t*>(curr_node->data);
+        reinterpret_cast<onlp_oid_hdr_t*>(curr_node->data);
     oid_list.emplace_back(oid_hdr->id);
     curr_node = curr_node->next;
   }
@@ -244,15 +245,13 @@ OnlpWrapper::~OnlpWrapper() {
 ::util::StatusOr<OnlpPortNumber> OnlpWrapper::GetSfpMaxPortNumber() const {
   SfpBitmap bitmap;
   onlp_sfp_bitmap_t_init(&bitmap);
-  int result = onlp_sfp_bitmap_get(&bitmap);
-  if (result < 0) {
-    LOG(ERROR) << "Failed to get valid SFP port bitmap from ONLP.";
-  }
+  CHECK_RETURN_IF_FALSE(ONLP_SUCCESS(onlp_sfp_bitmap_get(&bitmap)))
+      << "Failed to get valid SFP port bitmap from ONLP.";
 
   OnlpPortNumber port_num = ONLP_MAX_FRONT_PORT_NUM;
   int i, j;
-  for (i = 0; i < kOnlpBitmapWordCount; i ++) {
-    for (j = 0; j < kOnlpBitmapBitsPerWord; j ++) {
+  for (i = 0; i < kOnlpBitmapWordCount; ++i) {
+    for (j = 0; j < kOnlpBitmapBitsPerWord; ++j) {
       if (bitmap.words[i] & (1 << j)) {
         port_num = i * kOnlpBitmapBitsPerWord + j + 1;
         // Note: return here only if the valid port numbers start from


### PR DESCRIPTION
This fixes the following error:

```
==9037==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x00000827a6e0 in thread T0
    #0 0x50b4b8 in __interceptor_cfree.localalias.0 (/root/stratum_bcm6.grpc+0x50b4b8)
    #1 0x7f2a94b69fb6 in aim_free (/lib/x86_64-linux-gnu/libonlp.so.1+0x1cfb6)
    #2 0x7f2a94b9599d in biglist_free_all (/lib/x86_64-linux-gnu/libonlp.so.1+0x4899d)
    #3 0x7f2a94b7ee05 in onlp_oid_get_all_free (/lib/x86_64-linux-gnu/libonlp.so.1+0x31e05)
    #4 0x2b1fbb0 in stratum::hal::phal::onlp::OnlpWrapper::GetOidList(onlp_oid_type_flag_e) const /proc/self/cwd/stratum/hal/lib/phal/onlp/onlp_wrapper.cc:239:3
    #5 0x2ab7878 in stratum::hal::phal::onlp::OnlpSwitchConfigurator::CreateDefaultConfig(stratum::hal::PhalInitConfig*) const /proc/self/cwd/stratum/hal/lib/phal/onlp/onlp_switch_configurator.cc:86:3
    #6 0x2aada0a in stratum::hal::phal::Phal::PushChassisConfig(stratum::hal::ChassisConfig const&) /proc/self/cwd/stratum/hal/lib/phal/phal.cc:109:9
    #7 0x1edf02c in stratum::hal::bcm::BcmSwitch::PushChassisConfig(stratum::hal::ChassisConfig const&) /proc/self/cwd/stratum/hal/lib/bcm/bcm_switch.cc:63:3
    #8 0x23b5592 in stratum::hal::ConfigMonitoringService::PushChassisConfig(bool, std::unique_ptr<stratum::hal::ChassisConfig, std::default_delete<stratum::hal::ChassisConfig> >) /proc/self/cwd/stratum/hal/lib/common/config_monitoring_service.cc:142:48
    #9 0x23b4d64 in stratum::hal::ConfigMonitoringService::PushSavedChassisConfig(bool) /proc/self/cwd/stratum/hal/lib/common/config_monitoring_service.cc:134:10
    #10 0x23b4980 in stratum::hal::ConfigMonitoringService::Setup(bool) /proc/self/cwd/stratum/hal/lib/common/config_monitoring_service.cc:98:10
    #11 0x223c531 in stratum::hal::Hal::Setup() /proc/self/cwd/stratum/hal/lib/common/hal.cc:147:3
    #12 0x5435c2 in stratum::hal::bcm::Main(int, char**) /proc/self/cwd/stratum/hal/bin/bcm/standalone/main.cc:129:17
    #13 0x7f2a930802e0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202e0)
    #14 0x447438 in _start (/root/stratum_bcm6.grpc+0x447438)

0x00000827a6e0 is located 0 bytes inside of global variable 'google::protobuf::internal::fixed_address_empty_string' defined in 'external/com_google_protobuf/src/google/protobuf/generated_message_util.cc:67:38' (0x827a6e0) of size 32
SUMMARY: AddressSanitizer: bad-free (/root/stratum_bcm6.grpc+0x50b4b8) in __interceptor_cfree.localalias.0
==9037==ABORTING
```