### PR TITLE
Add docker CLI to build container for CI builds

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -101,4 +101,4 @@ RUN add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/debian \
    $(lsb_release -cs) \
    stable"
-RUN apt-get update && apt-get install docker-ce-cli
+RUN apt-get update && apt-get install -y --no-install-recommends docker-ce-cli

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -94,3 +94,11 @@ RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
 # Tools for style checking
 RUN pip install setuptools wheel && \
     pip install cpplint
+
+# Docker CLI for CI builds
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+RUN apt-get update && apt-get install docker-ce-cli


### PR DESCRIPTION
This allows using the [remote docker environment](https://circleci.com/docs/2.0/building-docker-images/) on CircleCi.