### PR TITLE
Improve Barefoot conatiner image build script 

### DIFF
--- a/stratum/hal/bin/barefoot/docker/Dockerfile.builder
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.builder
@@ -24,8 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libelf-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# COPY SDE_TAR
 ARG SDE_TAR
-COPY build-kdrv.sh /build-kdrv.sh
+COPY $SDE_TAR /stratum/
 
 ENV SDE /bf-sde
 ENV SDE_INSTALL /$SDE/install

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.builder
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.builder
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libelf-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# COPY SDE_TAR
 ARG SDE_TAR
 COPY $SDE_TAR /stratum/
 

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.builder
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.builder
@@ -25,10 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 ARG SDE_TAR
-ARG KERNEL_HEADERS_TAR
-# Copy SDE and Linux headers tarball
-COPY $SDE_TAR /stratum/
-COPY $KERNEL_HEADERS_TAR /stratum/
 COPY build-kdrv.sh /build-kdrv.sh
 
 ENV SDE /bf-sde
@@ -42,11 +38,6 @@ ARG JOBS=4
 RUN sed -i.bak '/package_dependencies/d; /thrift/d' profiles/stratum_profile.yaml
 RUN ./p4studio_build.py -up stratum_profile -wk -j$JOBS -shc && \
     rm -rf /var/lib/apt/lists/*
-
-# Build Barefoot Tofino kernel module
-ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers
-ENV KDRV_DIR=/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv
-RUN /build-kdrv.sh
 
 # Prepare all SDE libraries
 ENV OUTPUT_BASE /output/usr/local

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
@@ -25,6 +25,16 @@ ADD . /stratum
 ENV BF_SDE_INSTALL $SDE_INSTALL
 WORKDIR /stratum
 
+# Build Barefoot Kernel module if needed
+ARG KERNEL_HEADERS_TAR
+# Copy SDE and Linux headers tarball
+COPY $SDE_TAR /stratum/
+COPY $KERNEL_HEADERS_TAR /stratum/
+
+ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers
+ENV KDRV_DIR=/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv
+RUN /build-kdrv.sh
+
 # Without ONLP
 RUN bazel build //stratum/hal/bin/barefoot:stratum_bf \
     --define sde_ver=$(cat $SDE_INSTALL/share/VERSION) \

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
@@ -27,9 +27,9 @@ WORKDIR /stratum
 
 # Build Barefoot Kernel module if needed
 ARG KERNEL_HEADERS_TAR
-# Copy SDE and Linux headers tarball
-COPY $SDE_TAR /stratum/
+# Copy Linux headers tarball and build script
 COPY $KERNEL_HEADERS_TAR /stratum/
+COPY /stratum/stratum/hal/bin/barefoot/docker/build-kdrv.sh /build-kdrv.sh
 
 ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers
 ENV KDRV_DIR=/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
@@ -29,7 +29,7 @@ WORKDIR /stratum
 ARG KERNEL_HEADERS_TAR
 # Copy Linux headers tarball and build script
 COPY $KERNEL_HEADERS_TAR /stratum/
-COPY /stratum/stratum/hal/bin/barefoot/docker/build-kdrv.sh /build-kdrv.sh
+COPY /stratum/hal/bin/barefoot/docker/build-kdrv.sh /build-kdrv.sh
 
 ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers
 ENV KDRV_DIR=/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv

--- a/stratum/hal/bin/barefoot/docker/build-kdrv.sh
+++ b/stratum/hal/bin/barefoot/docker/build-kdrv.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 if [ -n "$KERNEL_HEADERS_TAR" ]; then
-  mkdir -p /usr/src/kernel-headers && \
-  tar xf /stratum/$KERNEL_HEADERS_TAR -C $KERNEL_HEADERS_PATH --strip-components 1 && \
-  mkdir -p $SDE_INSTALL/lib/modules && \
-  make -C $KERNEL_HEADERS_PATH M=$KDRV_DIR src=$KDRV_DIR modules && \
+  echo "Building kernel module..."
+  mkdir -p /usr/src/kernel-headers
+  tar xf /stratum/$KERNEL_HEADERS_TAR -C $KERNEL_HEADERS_PATH --strip-components 1
+  mkdir -p $SDE_INSTALL/lib/modules
+  make -C $KERNEL_HEADERS_PATH M=$KDRV_DIR src=$KDRV_DIR modules
   mkdir -p /output/usr/local/modules
-  mv $KDRV_DIR/bf_kdrv.ko /output/usr/local/modules/
+  mv $KDRV_DIR/bf_kdrv.ko /output/usr/local/lib/modules/
 else
   echo "No Kernel headers found, skip"
   exit 0

--- a/stratum/hal/bin/barefoot/docker/build-kdrv.sh
+++ b/stratum/hal/bin/barefoot/docker/build-kdrv.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+KERNEL_HEADERS_PATH=${KERNEL_HEADERS_PATH:-/usr/src/kernel-headers}
+KDRV_DIR=${KDRV_DIR:-/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv}
+
 if [ -n "$KERNEL_HEADERS_TAR" ]; then
-  echo "Building kernel module..."
-  mkdir -p /usr/src/kernel-headers
+  mkdir -p "$KERNEL_HEADERS_PATH"
   tar xf /stratum/$KERNEL_HEADERS_TAR -C $KERNEL_HEADERS_PATH --strip-components 1
-  mkdir -p $SDE_INSTALL/lib/modules
+  mkdir -p "$SDE_INSTALL/lib/modules"
+  KERNEL_VERSION="$(cat $KERNEL_HEADERS_PATH/include/config/kernel.release)"
+  echo "Building kernel module for $KERNEL_VERSION"
   make -C $KERNEL_HEADERS_PATH M=$KDRV_DIR src=$KDRV_DIR modules
   mkdir -p /output/usr/local/modules
   mv $KDRV_DIR/bf_kdrv.ko /output/usr/local/lib/modules/

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -75,11 +75,11 @@ docker build -t "$BUILDER_IMAGE" \
 
 # Build runtime image
 echo "Building $RUNTIME_IMAGE"
-TMP_TMG_TAG="$RANDOM"
+TMP_IMG_TAG="$RANDOM"
 docker build -t "$RUNTIME_IMAGE" \
              --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
              --build-arg KERNEL_HEADERS_TAR="$KERNEL_HEADERS_TAR" \
-             --label stratum-tmp-img-tag="$TMP_TMG_TAG" \
+             --label stratum-tmp-img-tag="$TMP_IMG_TAG" \
              -f "$DOCKERFILE_DIR/Dockerfile.runtime" "$STRATUM_ROOT"
 
 # Remove copied tarballs
@@ -91,7 +91,7 @@ if [ -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR" ]; then
 fi
 
 # Remove temporary image
-TMP_IMGS=$(docker images --filter "label=stratum-tmp-img-tag=$TMP_TMG_TAG" -q)
+TMP_IMGS=$(docker images --filter "label=stratum-tmp-img-tag=$TMP_IMG_TAG" -q)
 
 if [ -n $TMP_IMGS ]; then
     docker rmi $TMP_IMGS

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -75,9 +75,11 @@ docker build -t "$BUILDER_IMAGE" \
 
 # Build runtime image
 echo "Building $RUNTIME_IMAGE"
+TMP_TMG_TAG="$RANDOM"
 docker build -t "$RUNTIME_IMAGE" \
              --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
              --build-arg KERNEL_HEADERS_TAR="$KERNEL_HEADERS_TAR" \
+             --label stratum-tmp-img-tag="$TMP_TMG_TAG" \
              -f "$DOCKERFILE_DIR/Dockerfile.runtime" "$STRATUM_ROOT"
 
 # Remove copied tarballs
@@ -86,4 +88,11 @@ if [ -f "$DOCKERFILE_DIR/$SDE_TAR" ]; then
 fi
 if [ -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR" ]; then
     rm -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR"
+fi
+
+# Remove temporary image
+TMP_IMGS=$(docker images --filter "label=stratum-tmp-img-tag=$TMP_TMG_TAG" -q)
+
+if [ -n $TMP_IMGS ]; then
+    docker rmi $TMP_IMGS
 fi

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -71,7 +71,7 @@ echo "Building $BUILDER_IMAGE"
 docker build -t "$BUILDER_IMAGE" \
      --build-arg JOBS="$JOBS" \
      --build-arg SDE_TAR="$SDE_TAR" \
-	 -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
+     -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
 
 # Build runtime image
 echo "Building $RUNTIME_IMAGE"

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -52,15 +52,15 @@ NOTE: Copied tarballs will be DELETED after the build
 EOF
 
 if [ -n "$1" ]; then
-    SDE_TAR=$(basename "$1")
+    SDE_TAR=$(basename $1)
     IMG_TAG=${SDE_TAR%.tgz}
     RUNTIME_IMG_TAG="$IMG_TAG"
     cp -f "$1" "$DOCKERFILE_DIR"
 fi
 if [ -n "$2" ]; then
-    KERNEL_HEADERS_TAR=$(basename "$2")
+    KERNEL_HEADERS_TAR=$(basename $2)
     RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}"
-    cp -f "$2" "$DOCKERFILE_DIR"
+    cp -f "$2" "$STRATUM_ROOT"
 fi
 
 BUILDER_IMAGE=stratumproject/stratum-bf-builder:$IMG_TAG

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -39,6 +39,8 @@ EOF
 BUILD_ARGS="--build-arg JOBS=$JOBS"
 SDE_TAR=""
 KERNEL_HEADERS_TAR=""
+RUNTIME_BUILD_ARGS=""
+RUNTIME_IMG_TAG=""
 
 if [ "$#" -eq 0 ]; then
     print_help
@@ -46,40 +48,44 @@ if [ "$#" -eq 0 ]; then
 fi
 
 # Copy tarballs to Stratum root
-echo """Copying SDE and header tarballs to $DOCKERFILE_DIR/
-NOTE: Copied tarballs will be DELETED after the build"""
+cat << EOF
+Copying SDE and Kernel header tarballs to $DOCKERFILE_DIR/
+NOTE: Copied tarballs will be DELETED after the build
+EOF
 
 if [ -n "$1" ]; then
-    SDE_TAR=$(basename $1)
-    BUILD_ARGS="$BUILD_ARGS --build-arg SDE_TAR=$SDE_TAR"
+    SDE_TAR=$(basename "$1")
     IMG_TAG=${SDE_TAR%.tgz}
-    cp -f $1 $DOCKERFILE_DIR
+    RUNTIME_IMG_TAG="$IMG_TAG"
+    cp -f "$1" "$DOCKERFILE_DIR"
 fi
 if [ -n "$2" ]; then
-    KERNEL_HEADERS_TAR=$(basename $2)
-    BUILD_ARGS="$BUILD_ARGS --build-arg KERNEL_HEADERS_TAR=$KERNEL_HEADERS_TAR"
-    IMG_TAG=$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}
-    cp -f $2 $DOCKERFILE_DIR
+    KERNEL_HEADERS_TAR=$(basename "$2")
+    RUNTIME_BUILD_ARGS="--build-arg KERNEL_HEADERS_TAR=$KERNEL_HEADERS_TAR"
+    RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}"
+    cp -f "$2" "$DOCKERFILE_DIR"
 fi
 
 BUILDER_IMAGE=stratumproject/stratum-bf-builder:$IMG_TAG
-RUNTIME_IMAGE=stratumproject/stratum-bf:$IMG_TAG
+RUNTIME_IMAGE=stratumproject/stratum-bf:$RUNTIME_IMG_TAG
 
 # Build base builder image
 echo "Building $BUILDER_IMAGE"
-docker build -t $BUILDER_IMAGE $BUILD_ARGS \
-	 -f $DOCKERFILE_DIR/Dockerfile.builder $DOCKERFILE_DIR
-
-# Remove copied tarballs
-if [ -f "$DOCKERFILE_DIR/$SDE_TAR" ]; then
-    rm -f $DOCKERFILE_DIR/$SDE_TAR
-fi
-if [ -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR" ]; then
-    rm -f $DOCKERFILE_DIR/$KERNEL_HEADERS_TAR
-fi
+docker build -t "$BUILDER_IMAGE" "$BUILD_ARGS" \
+     --build-arg SDE_TAR="$SDE_TAR" \
+	 -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
 
 # Build runtime image
 echo "Building $RUNTIME_IMAGE"
-docker build -t $RUNTIME_IMAGE \
-             --build-arg BUILDER_IMAGE=$BUILDER_IMAGE \
-             -f $DOCKERFILE_DIR/Dockerfile.runtime $STRATUM_ROOT
+docker build -t "$RUNTIME_IMAGE" \
+             --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
+             "$RUNTIME_BUILD_ARGS" \
+             -f "$DOCKERFILE_DIR/Dockerfile.runtime" "$STRATUM_ROOT"
+
+# Remove copied tarballs
+if [ -f "$DOCKERFILE_DIR/$SDE_TAR" ]; then
+    rm -f "$DOCKERFILE_DIR/$SDE_TAR"
+fi
+if [ -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR" ]; then
+    rm -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR"
+fi

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -36,10 +36,8 @@ Example:
 EOF
 }
 
-BUILD_ARGS="--build-arg JOBS=$JOBS"
 SDE_TAR=""
 KERNEL_HEADERS_TAR=""
-RUNTIME_BUILD_ARGS=""
 RUNTIME_IMG_TAG=""
 
 if [ "$#" -eq 0 ]; then
@@ -61,7 +59,6 @@ if [ -n "$1" ]; then
 fi
 if [ -n "$2" ]; then
     KERNEL_HEADERS_TAR=$(basename "$2")
-    RUNTIME_BUILD_ARGS="--build-arg KERNEL_HEADERS_TAR=$KERNEL_HEADERS_TAR"
     RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}"
     cp -f "$2" "$DOCKERFILE_DIR"
 fi
@@ -71,7 +68,8 @@ RUNTIME_IMAGE=stratumproject/stratum-bf:$RUNTIME_IMG_TAG
 
 # Build base builder image
 echo "Building $BUILDER_IMAGE"
-docker build -t "$BUILDER_IMAGE" "$BUILD_ARGS" \
+docker build -t "$BUILDER_IMAGE" \
+     --build-arg JOBS="$JOBS" \
      --build-arg SDE_TAR="$SDE_TAR" \
 	 -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
 
@@ -79,7 +77,7 @@ docker build -t "$BUILDER_IMAGE" "$BUILD_ARGS" \
 echo "Building $RUNTIME_IMAGE"
 docker build -t "$RUNTIME_IMAGE" \
              --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
-             "$RUNTIME_BUILD_ARGS" \
+             --build-arg KERNEL_HEADERS_TAR="$KERNEL_HEADERS_TAR" \
              -f "$DOCKERFILE_DIR/Dockerfile.runtime" "$STRATUM_ROOT"
 
 # Remove copied tarballs


### PR DESCRIPTION
Move kernel module build to runtime builder since we don't need to rebuild entire SDE for different Kernel version