### PR TITLE
Add loopback mode to the Stratum model

### DIFF
--- a/stratum/docs/gnmi/supported-paths.md
+++ b/stratum/docs/gnmi/supported-paths.md
@@ -112,6 +112,12 @@ Supported gNMI paths
  - Get type: ALL, STATE
  - Set mode: REPLACE, UPDATE
 
+`/interfaces/interface[name=port name]/config/loopback-mode`
+
+ - Subscription mode: ONCE, POLL, SAMPLE
+ - Get type: ALL, STATE
+ - Set mode: REPLACE, UPDATE
+
 `/interfaces/interface[name=port name]/ethernet/config/forwarding-viable`
 
  - Subscription mode: ONCE, POLL, SAMPLE
@@ -180,6 +186,12 @@ Supported gNMI paths
  - Get type: ALL, STATE
  - Set mode: Not valid
 
+`/interfaces/interface[name=port name]/state/loopback-mode`
+
+ - Subscription mode: ONCE, POLL, SAMPLE, ON_CHANGE
+ - Get type: ALL, STATE
+ - Set mode: Not valid
+
 `/interfaces/interface[name=port name]/state/ifindex`
 
  - Subscription mode: ONCE, POLL, SAMPLE
@@ -221,31 +233,31 @@ Supported gNMI paths
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-  
+
 `/interfaces/interface[name=port name]/state/counters/in-discards`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-    
+
 `/interfaces/interface[name=port name]/state/counters/in-errors`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-  
+
 `/interfaces/interface[name=port name]/state/counters/in-fcs-errors`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-  
+
 `/interfaces/interface[name=port name]/state/counters/in-multicast-pkts`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-  
+
 `/interfaces/interface[name=port name]/state/counters/in-octets`
 
  - Subscription mode: ONCE, POLL, SAMPLE
@@ -257,43 +269,43 @@ Supported gNMI paths
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-    
+
 `/interfaces/interface[name=port name]/state/counters/in-unknown-protos`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-  
+
 `/interfaces/interface[name=port name]/state/counters/out-broadcast-pkts`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
- 
+
 `/interfaces/interface[name=port name]/state/counters/out-discards`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
-   
+
 `/interfaces/interface[name=port name]/state/counters/out-errors`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
- 
+
 `/interfaces/interface[name=port name]/state/counters/out-multicast-pkts`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
- 
+
 `/interfaces/interface[name=port name]/state/counters/out-octets`
 
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
- 
+
 `/interfaces/interface[name=port name]/state/counters/out-unicast-pkts`
 
  - Subscription mode: ONCE, POLL, SAMPLE

--- a/stratum/hal/lib/common/openconfig_converter.cc
+++ b/stratum/hal/lib/common/openconfig_converter.cc
@@ -312,6 +312,13 @@ SingletonPortToInterfaces(const SingletonPort &in) {
   interface->mutable_ethernet()->mutable_auto_negotiate()->set_value(
       IsPortAutonegEnabled(in.config_params().autoneg()));
 
+  // SingletonPort.config_params.loopback_mode
+  // -> /interfaces/interface/config/loopback-mode
+  if (in.config_params().loopback_mode() != LOOPBACK_STATE_UNKNOWN) {
+    interface->mutable_loopback_mode()->set_value(
+        IsLoopbackStateEnabled(in.config_params().loopback_mode()));
+  }
+
   // FIXME(Yi Tseng): Should we use other field to store interface channel?
   interface->add_physical_channel()->set_value(in.channel());
 
@@ -702,6 +709,12 @@ TrunkPortToInterfaces(const ChassisConfig &root, const TrunkPort &in) {
     case OPENCONFIGPLATFORMTYPESFECMODETYPE_FEC_AUTO:
       config_params->set_fec_mode(FEC_MODE_AUTO);
       break;
+  }
+
+  if (interface.has_loopback_mode()) {
+    LoopbackState lpbk_mode = interface.loopback_mode().value() ?
+        LOOPBACK_STATE_MAC : LOOPBACK_STATE_NONE;
+    config_params->set_loopback_mode(lpbk_mode);
   }
 
   // FIXME(Yi Tseng): Should we use other field to store interface channel?

--- a/stratum/hal/lib/common/testdata/port_config_params_chassis.pb.txt
+++ b/stratum/hal/lib/common/testdata/port_config_params_chassis.pb.txt
@@ -25,5 +25,6 @@ singleton_ports {
     autoneg: TRI_STATE_TRUE
     fec_mode: FEC_MODE_ON
     admin_state: ADMIN_STATE_ENABLED
+    loopback_mode: LOOPBACK_STATE_MAC
   }
 }

--- a/stratum/hal/lib/common/testdata/port_config_params_oc_device.pb.txt
+++ b/stratum/hal/lib/common/testdata/port_config_params_oc_device.pb.txt
@@ -63,6 +63,9 @@ interface {
         value: true
       }
     }
+    loopback_mode: {
+      value: true
+    }
     id {
       value: 1
     }

--- a/stratum/public/yang/openconfig-interfaces-stratum.yang
+++ b/stratum/public/yang/openconfig-interfaces-stratum.yang
@@ -36,11 +36,6 @@ module openconfig-interfaces-stratum {
         deviate not-supported;
     }
 
-    deviation "/oc-if:interfaces/oc-if:interface/oc-if:config/oc-if:loopback-mode" {
-        description "Stratum does not support interface/config/loopback-mode";
-        deviate not-supported;
-    }
-
     deviation "/oc-if:interfaces/oc-if:interface/oc-if:config/oc-if:description" {
         description "Stratum does not support interface/config/description";
         deviate not-supported;


### PR DESCRIPTION
 - Remove `deviate` from the Stratum OpenConfig interface yang file.
 - Add new logic to OpenConfig convertor to support loopback mode
 - Add unit OpenConfig convertor test case for loopback mode 