### PR TITLE
Add buildifier and run as non-mandatory CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,14 @@ jobs:
       - run:
           name: Run reuse
           command: reuse lint
+  bazel-style-check:
+    docker:
+      - image: stratumproject/build:build
+    steps:
+      - checkout
+      - run:
+          name: Run buildifier
+          command: buildifier --lint=warn -r ./ || true
 
 workflows:
   version: 2
@@ -235,6 +243,7 @@ workflows:
       - coverage
       - cpp-style-check
       - license-check
+      - bazel-style-check
   docker-publish:
     jobs:
       - publish-docker-build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Some additional points:
 
 3. Pass all unit tests locally. Create new tests for new code and **add the targets to the [build-targets.txt](.circleci/build-targets.txt) and [test-targets.txt](.circleci/test-targets.txt) files** in the same PR, so CI can pick them up! Execute the following command in the Stratum root directory to run all currently enabled tests: `xargs -a .circleci/test-targets.txt bazel test`
 
-4. Check code style compliance with `cpplint` and `clang-format` (pre-installed in development docker container). If you're editing Bazel files, consider [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier).
+4. Check code style compliance with `cpplint` and `clang-format` (pre-installed in development docker container). If you're editing Bazel files, consider [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier) as well (also pre-installed).
 
 5. Create a [Pull Request](https://github.com/stratum/stratum/compare). Consider [allowing maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make changes if you want direct assistance from maintainers.
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -83,6 +83,7 @@ RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
 # Tools for style and license checking
 RUN pip install setuptools wheel && \
     pip install 'cpplint==1.*'
+RUN wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/3.2.1/buildifier
 
 # Docker CLI for CI builds
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -


### PR DESCRIPTION
[buildifier](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md) is a linter and formatter for Bazel related files.

We could also set it up inside [Bazel](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#setup-and-usage-via-bazel).