### PR TITLE
Add `m` utility to mn-stratum image

### DIFF
--- a/tools/mininet/Dockerfile
+++ b/tools/mininet/Dockerfile
@@ -38,6 +38,8 @@ RUN curl -L https://github.com/mininet/mininet/tarball/master | \
 RUN mkdir -p /output
 RUN PREFIX=/output make install-mnexec install-manpages
 RUN python setup.py install --root /output
+# Install `m` utility so user can attach to a mininet host directly
+RUN cp util/m /output/bin/m && sed -i 's#sudo##g' /output/bin/m
 
 # Build stratum_bmv2
 COPY . /tmp/stratum

--- a/tools/mininet/examples/trellis/Makefile
+++ b/tools/mininet/examples/trellis/Makefile
@@ -27,6 +27,9 @@ mn-cli:
 mn-log:
 	docker-compose logs -f mininet
 
+mn-host:
+	docker-compose exec mininet m $@
+
 netcfg:
 	${onos_post} ${onos_url}/v1/network/configuration/ -d@./topo/netcfg.json
 

--- a/tools/mininet/examples/trellis/README.md
+++ b/tools/mininet/examples/trellis/README.md
@@ -378,6 +378,16 @@ PING 10.0.3.1 (10.0.3.1) 56(84) bytes of data.
 ^C
 ```
 
+#### Run a command on a Mininet host
+
+Use `make mn-host` to run a command on a Mininet host, for example:
+
+```bash
+make mn-host h1 ip a # Run `ip a` command on h1
+make mn-host h1 bash # Run `bash` command on h1, which allows you to attach the shell
+make mn-host h1 # Same as below, the default command is `bash`
+```
+
 ### Congratulations!
 
 You have completed all the steps of this example.

--- a/tools/mininet/examples/trellis/README.md
+++ b/tools/mininet/examples/trellis/README.md
@@ -54,6 +54,7 @@ reference:
 | `make mn-log`       | Show the Mininet log (i.e., the CLI output)            |
 | `make netcfg`       | Push netcfg.json file (network config) to ONOS         |
 | `make reset`        | Reset the tutorial environment                         |
+| `make mn-host`      | Run a command in a Mininet host.                       |
 
 ## Walktrough
 
@@ -295,11 +296,11 @@ information on how to use the ONOS web UI please refer to this guide:
 
 To show or hide switch labels, press `L` on your keyboard.
 
-To show or hide link stats, press `A` on your keyboard multiple times until you see 
+To show or hide link stats, press `A` on your keyboard multiple times until you see
 (pkt/second or bit/second).
 
 #### Check forwarding
-      
+
 It is finally time to test connectivity between the hosts of our Mininet
 network. To access the Mininet CLI (Ctrl-A Ctrl-D to exit):
 


### PR DESCRIPTION
`m` utility allows user to attach to a mininet host or execute a specific
command in a host without using mininet CLI.