### PR TITLE
Bump BMv2, PI, and P4Runtime to fix action profile crash in stratum_bmv2

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BAZEL_VERSION=3.0.0
-ARG PI_COMMIT=1539ecd8a50c159b011d9c5a9c0eba99f122a845
-ARG BMV2_COMMIT=9ef324838b29419040b4f677a3ff65bc72405c44
+ARG PI_COMMIT=0fbdac256151eb1537cd5ebf19101d5df60767fa
+ARG BMV2_COMMIT=5bb6075d090e7cc9bbe2df36cf85a2f2635beb59
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch main"
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -10,8 +10,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
      "new_git_repository")
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
-P4RUNTIME_VER = "1.1.0-rc.1"
-P4RUNTIME_SHA = "fb4eb0767ea9e9697b2359be6979942c54abf64187a2d0f5ff61f227500ec195"
+P4RUNTIME_VER = "fb437abd13dc2a3177256149582cc85c0c39f956" # 1.2.0-dev
+P4RUNTIME_SHA = "2c01f5dff0c84efc3ef6bf33a9d18b3ddc07de4a86da55636b709abed79c36fc"
 
 GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a";
 GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108"
@@ -70,7 +70,7 @@ def stratum_deps():
     if "com_github_p4lang_p4runtime" not in native.existing_rules():
         http_archive(
             name = "com_github_p4lang_p4runtime",
-            urls = ["https://github.com/p4lang/p4runtime/archive/v%s.zip" % P4RUNTIME_VER],
+            urls = ["https://github.com/p4lang/p4runtime/archive/%s.zip" % P4RUNTIME_VER],
             sha256 = P4RUNTIME_SHA,
             strip_prefix = "p4runtime-%s/proto" % P4RUNTIME_VER,
             build_file = "@//bazel:external/p4runtime.BUILD",
@@ -88,7 +88,7 @@ def stratum_deps():
         remote_workspace(
             name = "com_github_p4lang_PI",
             remote = "https://github.com/p4lang/PI.git",
-            commit = "1539ecd8a50c159b011d9c5a9c0eba99f122a845",
+            commit = "0fbdac256151eb1537cd5ebf19101d5df60767fa",
         )
 
     for sde_ver in BF_SDE_PI_VER:


### PR DESCRIPTION
A bug in BMv2 caused the stratum_bmv2 process to crash when packets were processed by an action selector left in an inconsistent state. The issue is described here:
https://github.com/p4lang/behavioral-model/issues/893

This was causing PTF tests for fabric.p4 to fail:
https://github.com/opennetworkinglab/fabric-p4test/issues/72

To fix stratum_bmv2, this change bumps the bmv2 commit, which requires bumping PI and P4Runtime as well. P4Runtime is updated from 1.1.0-rc1 to backward-compatible 1.2.0-dev.