### PR TITLE
Transform inline BUILD files of external deps to real files

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -1,0 +1,84 @@
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# trick to export headers in a convenient way
+cc_library(
+    name = "bf_headers",
+    hdrs = glob([
+        "barefoot-bin/include/bf_switchd/*.h",
+        "barefoot-bin/include/bfsys/**/*.h",
+        "barefoot-bin/include/bfutils/**/*.h",
+        "barefoot-bin/include/bf_types/*.h",
+        "barefoot-bin/include/dvm/*.h",
+        "barefoot-bin/include/mc_mgr/*.h",
+        "barefoot-bin/include/port_mgr/*.h",
+        "barefoot-bin/include/tofino/bf_pal/*.h",
+    ]),
+    includes = ["barefoot-bin/include"],
+)
+
+cc_import(
+    name = "bf_switchd",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "barefoot-bin/lib/libbf_switchd_lib.so",
+    # If alwayslink is turned on, libbf_switchd_lib.so will be forcely linked
+    # into any binary that depends on it.
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "bf_drivers",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "barefoot-bin/lib/libdriver.so",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "bf_sys",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "barefoot-bin/lib/libbfsys.so",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "bf_utils",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "barefoot-bin/lib/libbfutils.so",
+    alwayslink = 1,
+)
+
+pkg_tar(
+    name = "bf_library_files",
+    srcs = glob(["barefoot-bin/lib/*.so"]),
+    mode = "0644",
+    package_dir = "/usr",
+    strip_prefix = "barefoot-bin",
+)
+
+pkg_tar_with_symlinks(
+    name = "bf_shareable_files",
+    srcs = glob(["barefoot-bin/share/microp_fw/**"]) + glob([
+        "barefoot-bin/share/bfsys/**",
+    ]) + glob([
+        "barefoot-bin/share/tofino_sds_fw/**",
+    ]),
+    mode = "0644",
+    package_dir = "/usr",
+    strip_prefix = "barefoot-bin",
+)
+
+pkg_tar(
+    name = "kernel_module",
+    srcs = glob(["barefoot-bin/lib/modules/*.ko"]),
+    mode = "0644",
+    package_dir = "/usr",
+    strip_prefix = "barefoot-bin",
+)

--- a/bazel/external/bmv2.BUILD
+++ b/bazel/external/bmv2.BUILD
@@ -1,0 +1,34 @@
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# trick to export headers in a convenient way
+cc_library(
+    name = "bmv2_headers",
+    hdrs = glob([
+        "bmv2-bin/include/bm/**/*.h",
+        "bmv2-bin/include/bm/**/*.cc",
+    ]),
+    includes = ["bmv2-bin/include"],
+)
+
+cc_import(
+    name = "bmv2_simple_switch",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "bmv2-bin/lib/libsimpleswitch_runner.so",
+    # If alwayslink is turned on, libsimpleswitch_runner.so will be forcely linked
+    # into any binary that depends on it.
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "bmv2_pi",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "bmv2-bin/lib/libbmpi.so",
+    alwayslink = 1,
+)

--- a/bazel/external/np4intel.BUILD
+++ b/bazel/external/np4intel.BUILD
@@ -1,0 +1,24 @@
+# Copyright 2020-present Dell EMC
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# trick to export headers in a convenient way
+cc_library(
+    name = "np4_headers",
+    hdrs = glob([
+        "netcope-bin/include/np4/*.hpp",
+        "netcope-bin/include/np4/p4*.h",
+    ]),
+    includes = ["netcope-bin/include"],
+)
+
+cc_import(
+    name = "np4_atom",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "netcope-bin/lib/libnp4atom.so",
+)

--- a/bazel/external/onlp.BUILD
+++ b/bazel/external/onlp.BUILD
@@ -1,0 +1,44 @@
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "onlp_headers",
+    hdrs = glob([
+        "onlp-bin/include/**/*.h",
+        "onlp-bin/include/**/*.x",
+    ]),
+    includes = ["onlp-bin/include"],
+)
+
+cc_library(
+    name = "onlp",
+    srcs = [
+        "onlp-bin/lib/libonlp.so",
+        "onlp-bin/lib/libonlp.so.1",
+    ],
+    hdrs = [],  # see cc_library rule above
+)
+
+cc_library(
+    name = "onlp_platform",
+    srcs = [
+        "onlp-bin/lib/libonlp-platform.so",
+        "onlp-bin/lib/libonlp-platform.so.1",
+    ],
+    hdrs = [],  # see cc_library rule above
+)
+
+cc_library(
+    name = "onlp_platform_defaults",
+    srcs = [
+        "onlp-bin/lib/libonlp-platform-defaults.so",
+        "onlp-bin/lib/libonlp-platform-defaults.so.1",
+    ],
+    hdrs = [],  # see cc_library rule above
+)

--- a/bazel/external/onlp_local.BUILD
+++ b/bazel/external/onlp_local.BUILD
@@ -1,0 +1,40 @@
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "onlp_headers",
+    hdrs = glob([
+        "onlp-bin/include/**/*.h",
+        "onlp-bin/include/**/*.x",
+    ]),
+    includes = ["onlp-bin/include"],
+)
+
+cc_import(
+    name = "onlp",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "onlp-bin/lib/libonlp.so",
+    # If alwayslink is turned on, libonlp.so will be forcely linked
+    # into any binary that depends on it.
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "onlp_platform",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "onlp-bin/lib/libonlp-platform.so",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "onlp_platform_defaults",
+    hdrs = [],  # see cc_library rule above
+    shared_library = "onlp-bin/lib/libonlp-platform-defaults.so",
+    alwayslink = 1,
+)

--- a/stratum/hal/bin/bmv2/bmv2.bzl
+++ b/stratum/hal/bin/bmv2/bmv2.bzl
@@ -8,38 +8,14 @@
 
 def _impl(repository_ctx):
     if "BMV2_INSTALL" not in repository_ctx.os.environ:
-        repository_ctx.file("BUILD", """
-""")
+        repository_ctx.file("BUILD", "")
         return
     bmv2_path = repository_ctx.os.environ["BMV2_INSTALL"]
     repository_ctx.symlink(bmv2_path, "bmv2-bin")
-    repository_ctx.file("BUILD", """
-package(
-    default_visibility = ["//visibility:public"],
-)
-# trick to export headers in a convenient way
-cc_library(
-    name = "bmv2_headers",
-    hdrs = glob(["bmv2-bin/include/bm/**/*.h", "bmv2-bin/include/bm/**/*.cc"]),
-    includes = ["bmv2-bin/include"],
-)
-cc_import(
-  name = "bmv2_simple_switch",
-  hdrs = [],  # see cc_library rule above
-  shared_library = "bmv2-bin/lib/libsimpleswitch_runner.so",
-  # If alwayslink is turned on, libsimpleswitch_runner.so will be forcely linked
-  # into any binary that depends on it.
-  alwayslink = 1,
-)
-cc_import(
-  name = "bmv2_pi",
-  hdrs = [],  # see cc_library rule above
-  shared_library = "bmv2-bin/lib/libbmpi.so",
-  alwayslink = 1,
-)
-""")
+    repository_ctx.symlink(Label("@//bazel:external/bmv2.BUILD"), "BUILD")
 
 bmv2_configure = repository_rule(
-    implementation=_impl,
+    implementation = _impl,
     local = True,
-    environ = ["BMV2_INSTALL"])
+    environ = ["BMV2_INSTALL"],
+)

--- a/stratum/hal/bin/np4intel/np4intel.bzl
+++ b/stratum/hal/bin/np4intel/np4intel.bzl
@@ -10,30 +10,11 @@
 
 def _impl(repository_ctx):
     if "NP4_INSTALL" not in repository_ctx.os.environ:
-        repository_ctx.file("BUILD", """
-""")
+        repository_ctx.file("BUILD", "")
         return
     netcope_path = repository_ctx.os.environ["NP4_INSTALL"]
     repository_ctx.symlink(netcope_path, "netcope-bin")
-    repository_ctx.file("BUILD", """
-package(
-    default_visibility = ["//visibility:public"],
-)
-# trick to export headers in a convenient way
-cc_library(
-    name = "np4_headers",
-    hdrs = glob(["netcope-bin/include/np4/*.hpp", 
-                 "netcope-bin/include/np4/p4*.h"]),
-    includes = ["netcope-bin/include"],
-)
-
-cc_import(
-  name = "np4_atom",
-  hdrs = [], # see cc_library rule above 
-  shared_library = "netcope-bin/lib/libnp4atom.so",
-)
-
-""")
+    repository_ctx.symlink(Label("@//bazel:external/np4intel.BUILD"), "BUILD")
 
 np4intel_configure = repository_rule(
     implementation = _impl,

--- a/stratum/hal/lib/barefoot/barefoot.bzl
+++ b/stratum/hal/lib/barefoot/barefoot.bzl
@@ -7,83 +7,14 @@
 
 def _impl(repository_ctx):
     if "BF_SDE_INSTALL" not in repository_ctx.os.environ:
-        repository_ctx.file("BUILD", """
-""")
+        repository_ctx.file("BUILD", "")
         return
     bf_sde_path = repository_ctx.os.environ["BF_SDE_INSTALL"]
     repository_ctx.symlink(bf_sde_path, "barefoot-bin")
-    repository_ctx.file("BUILD", """
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
-
-package(
-    default_visibility = ["//visibility:public"],
-)
-# trick to export headers in a convenient way
-cc_library(
-    name = "bf_headers",
-    hdrs = glob(["barefoot-bin/include/bf_switchd/*.h",
-                 "barefoot-bin/include/bfsys/**/*.h",
-                 "barefoot-bin/include/bfutils/**/*.h",
-                 "barefoot-bin/include/bf_types/*.h",
-                 "barefoot-bin/include/dvm/*.h",
-                 "barefoot-bin/include/mc_mgr/*.h",
-                 "barefoot-bin/include/port_mgr/*.h",
-                 "barefoot-bin/include/tofino/bf_pal/*.h"]),
-    includes = ["barefoot-bin/include"],
-)
-cc_import(
-  name = "bf_switchd",
-  hdrs = [],  # see cc_library rule above
-  shared_library = "barefoot-bin/lib/libbf_switchd_lib.so",
-  # If alwayslink is turned on, libbf_switchd_lib.so will be forcely linked
-  # into any binary that depends on it.
-  alwayslink = 1,
-)
-cc_import(
-  name = "bf_drivers",
-  hdrs = [],  # see cc_library rule above
-  shared_library = "barefoot-bin/lib/libdriver.so",
-  alwayslink = 1,
-)
-cc_import(
-  name = "bf_sys",
-  hdrs = [],  # see cc_library rule above
-  shared_library = "barefoot-bin/lib/libbfsys.so",
-  alwayslink = 1,
-)
-cc_import(
-  name = "bf_utils",
-  hdrs = [],  # see cc_library rule above
-  shared_library = "barefoot-bin/lib/libbfutils.so",
-  alwayslink = 1,
-)
-pkg_tar(
-  name = "bf_library_files",
-  srcs = glob(["barefoot-bin/lib/*.so"]),
-  mode = "0644",
-  package_dir = "/usr",
-  strip_prefix = "barefoot-bin",
-)
-pkg_tar_with_symlinks(
-  name = "bf_shareable_files",
-  srcs = glob(["barefoot-bin/share/microp_fw/**"]) +
-         glob(["barefoot-bin/share/bfsys/**"]) +
-         glob(["barefoot-bin/share/tofino_sds_fw/**"]),
-  mode = "0644",
-  package_dir = "/usr",
-  strip_prefix = "barefoot-bin",
-)
-pkg_tar(
-  name = "kernel_module",
-  srcs = glob(["barefoot-bin/lib/modules/*.ko"]),
-  mode = "0644",
-  package_dir = "/usr",
-  strip_prefix = "barefoot-bin",
-)
-""")
+    repository_ctx.symlink(Label("@//bazel:external/bfsde.BUILD"), "BUILD")
 
 barefoot_configure = repository_rule(
-    implementation=_impl,
+    implementation = _impl,
     local = True,
-    environ = ["BF_SDE_INSTALL"])
+    environ = ["BF_SDE_INSTALL"],
+)

--- a/stratum/hal/lib/phal/onlp/onlp.bzl
+++ b/stratum/hal/lib/phal/onlp/onlp.bzl
@@ -5,7 +5,6 @@
 # The ONLP_INSTALL environment variable needs to be set
 # otherwise will download the prebuit libraries
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 ONLP_URL = "https://github.com/opennetworkinglab/OpenNetworkLinux/releases/download/onlpv2-dev-1.1.0/onlp-dev_1.1.0_amd64.tar.gz"
 SHA = "bd359f2429368e5645b4d4a77fe7c95fb0702e753f04fee48690adad653c6503"
 
@@ -20,81 +19,33 @@ SHA = "bd359f2429368e5645b4d4a77fe7c95fb0702e753f04fee48690adad653c6503"
 def _impl(repository_ctx):
     if "ONLP_INSTALL" not in repository_ctx.os.environ:
         # Download prebuild version of ONLP library if ONLP_INSTALL not defined
-        repository_ctx.download_and_extract(url=ONLP_URL,
-                                            output="onlp-bin",
-                                            sha256=SHA,
-                                            stripPrefix="onlp-dev_1.1.0_amd64")
-        repository_ctx.symlink("onlp-bin/lib/libonlp.so",
-                               "onlp-bin/lib/libonlp.so.1")
-        repository_ctx.symlink("onlp-bin/lib/libonlp-platform.so",
-                               "onlp-bin/lib/libonlp-platform.so.1")
-        repository_ctx.symlink("onlp-bin/lib/libonlp-platform-defaults.so",
-                               "onlp-bin/lib/libonlp-platform-defaults.so.1")
-        repository_ctx.file("BUILD", """
-package(
-    default_visibility = ["//visibility:public"],
-)
+        repository_ctx.download_and_extract(
+            url = ONLP_URL,
+            output = "onlp-bin",
+            sha256 = SHA,
+            stripPrefix = "onlp-dev_1.1.0_amd64",
+        )
+        repository_ctx.symlink(
+            "onlp-bin/lib/libonlp.so",
+            "onlp-bin/lib/libonlp.so.1",
+        )
+        repository_ctx.symlink(
+            "onlp-bin/lib/libonlp-platform.so",
+            "onlp-bin/lib/libonlp-platform.so.1",
+        )
+        repository_ctx.symlink(
+            "onlp-bin/lib/libonlp-platform-defaults.so",
+            "onlp-bin/lib/libonlp-platform-defaults.so.1",
+        )
+        repository_ctx.symlink(Label("@//bazel:external/onlp.BUILD"), "BUILD")
 
-cc_library(
-    name = "onlp_headers",
-    hdrs = glob(["onlp-bin/include/**/*.h", "onlp-bin/include/**/*.x"]),
-    includes = ["onlp-bin/include"],
-)
-cc_library(
-    name = "onlp",
-    hdrs = [],  # see cc_library rule above
-    srcs = ["onlp-bin/lib/libonlp.so",
-            "onlp-bin/lib/libonlp.so.1"],
-)
-cc_library(
-    name = "onlp_platform",
-    hdrs = [],  # see cc_library rule above
-    srcs = ["onlp-bin/lib/libonlp-platform.so",
-            "onlp-bin/lib/libonlp-platform.so.1"],
-)
-cc_library(
-    name = "onlp_platform_defaults",
-    hdrs = [],  # see cc_library rule above
-    srcs = ["onlp-bin/lib/libonlp-platform-defaults.so",
-            "onlp-bin/lib/libonlp-platform-defaults.so.1"],
-)
-""")
     else:  # ONLP_INSTALL env variable is defined
         onlp_path = repository_ctx.os.environ["ONLP_INSTALL"]
         repository_ctx.symlink(onlp_path, "onlp-bin")
-        repository_ctx.file("BUILD", """
-package(
-    default_visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "onlp_headers",
-    hdrs = glob(["onlp-bin/include/**/*.h", "onlp-bin/include/**/*.x"]),
-    includes = ["onlp-bin/include"],
-)
-cc_import(
-    name = "onlp",
-    hdrs = [],  # see cc_library rule above
-    shared_library = "onlp-bin/lib/libonlp.so",
-    # If alwayslink is turned on, libonlp.so will be forcely linked
-    # into any binary that depends on it.
-    alwayslink = 1,
-)
-cc_import(
-    name = "onlp_platform",
-    hdrs = [],  # see cc_library rule above
-    shared_library = "onlp-bin/lib/libonlp-platform.so",
-    alwayslink = 1,
-)
-cc_import(
-    name = "onlp_platform_defaults",
-    hdrs = [],  # see cc_library rule above
-    shared_library = "onlp-bin/lib/libonlp-platform-defaults.so",
-    alwayslink = 1,
-)
-""")
+        repository_ctx.symlink(Label("@//bazel:external/onlp_local.BUILD"), "BUILD")
 
 onlp_configure = repository_rule(
-    implementation=_impl,
+    implementation = _impl,
     local = True,
-    environ = ["ONLP_INSTALL"])
+    environ = ["ONLP_INSTALL"],
+)


### PR DESCRIPTION


Pros:
- Facilitates automation by making these files visible to tools like buildifier
- First step to transition from `repository_rule` to `new_local_repository` or `http_archive` with local `file://` url
- Improves visibility of dependencies, not hidden away somewhere

Cons:
- Removes some context: Some rules do some setup (`repository_ctx.symlink(...)`). The paths are now in two files