### PR TITLE
Add LTO option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,11 @@ build --cxxopt='-std=gnu++11'
 build --copt -Wall
 build --copt -Wno-sign-compare
 
+# LTO on clang
+build:lto --copt -Wno-unused-command-line-argument
+build:lto --copt -flto
+build:lto --linkopt -flto
+
 # Address sanitizer
 build:asan --strip=never
 build:asan --copt -fsanitize=address


### PR DESCRIPTION
[Link time optimization](https://llvm.org/docs/LinkTimeOptimization.html) can reduce binary size.

Needs to be enabled manually for now.