### PR TITLE
Passthrough CLI args from start-*.sh scripts to Stratum

### DIFF
--- a/stratum/hal/bin/barefoot/deb/stratum-entrypoint
+++ b/stratum/hal/bin/barefoot/deb/stratum-entrypoint
@@ -39,4 +39,4 @@ else
     echo "Cannot find $KDRV_PATH, skip installing the Kernel module."
 fi
 
-exec /usr/bin/stratum_bf -flagfile=$FLAG_FILE
+exec /usr/bin/stratum_bf -flagfile=$FLAG_FILE $@

--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -31,4 +31,5 @@ docker run -it --privileged \
     -p 9339:9339 \
     -v $CONFIG_DIR:/etc/stratum \
     -v $LOG_DIR:/var/log/stratum \
-    $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    $DOCKER_IMAGE:$DOCKER_IMAGE_TAG \
+    $@

--- a/stratum/hal/bin/bcm/standalone/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/bcm/standalone/docker/start-stratum-container.sh
@@ -23,4 +23,5 @@ docker run -it --privileged --cap-add ALL --shm-size=512m --network host \
     -v /etc/onl:/etc/onl \
     -v $CONFIG_DIR:/etc/stratum/stratum_configs \
     -v $LOG_DIR:/var/log/stratum \
-    $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    $DOCKER_IMAGE:$DOCKER_IMAGE_TAG \
+    $@


### PR DESCRIPTION
This allows quick and easy configuration changes on the fly. It also can remove the need for ad-hoc flag parsing in scripts.