### PR TITLE
Update cpplint

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -82,7 +82,7 @@ RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
 
 # Tools for style and license checking
 RUN pip install setuptools wheel && \
-    pip install cpplint==1.4.6
+    pip install 'cpplint==1.*'
 
 # Docker CLI for CI builds
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -


### PR DESCRIPTION
Fix landed upstream.

Pinning to major version 1 as a trade-off between updates and stability.