### PR TITLE
Bump BMv2 commit to fix to zero-valued timestamps

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@
 
 ARG BAZEL_VERSION=3.2.0
 ARG PI_COMMIT=0fbdac256151eb1537cd5ebf19101d5df60767fa
-ARG BMV2_COMMIT=5bb6075d090e7cc9bbe2df36cf85a2f2635beb59
+ARG BMV2_COMMIT=498202d98d83a6c580aa86a3497b9b496bcd43b2
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch main"
 


### PR DESCRIPTION
The issue is described here:
https://github.com/p4lang/behavioral-model/issues/905

@sundararajan20 was experiencing this issue while trying INT support in fabric.p4.