### PR TITLE
Add libdru_sim.so for runs against tofino model

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -45,6 +45,7 @@ pkg_tar(
         "barefoot-bin/lib/libavago.so",
         "barefoot-bin/lib/libbfsys.so",
         "barefoot-bin/lib/libdriver.so",
+        "barefoot-bin/lib/libdru_sim.so",
         "barefoot-bin/lib/libpython3.4m.so",
     ],
     mode = "0644",


### PR DESCRIPTION
It is `dlopen`'d when using the tofino model as a backend.