### PR TITLE
Reject ChassisConfig changes that modify the port layout

### DIFF
--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -88,9 +88,9 @@ BFSwitch::~BFSwitch() {}
     for (const auto& entry : node_id_to_unit) {
       uint64 node_id = entry.first;
       int unit = entry.second;
-      ASSIGN_OR_RETURN(auto* bfrt_node, GetPINodeFromUnit(unit));
+      ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromUnit(unit));
       APPEND_STATUS_IF_ERROR(status,
-                             bfrt_node->VerifyChassisConfig(config, node_id));
+                             pi_node->VerifyChassisConfig(config, node_id));
     }
   }
 

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -43,6 +43,9 @@ BFSwitch::BFSwitch(PhalInterface* phal_interface,
 BFSwitch::~BFSwitch() {}
 
 ::util::Status BFSwitch::PushChassisConfig(const ChassisConfig& config) {
+  // Verify the config first. No need to continue if verification is not OK.
+  // Push config to PHAL first and then the rest of the managers.
+  RETURN_IF_ERROR(VerifyChassisConfig(config));
   absl::WriterMutexLock l(&chassis_lock);
   RETURN_IF_ERROR(phal_interface_->PushChassisConfig(config));
   RETURN_IF_ERROR(bf_chassis_manager_->PushChassisConfig(config));
@@ -63,8 +66,39 @@ BFSwitch::~BFSwitch() {}
 }
 
 ::util::Status BFSwitch::VerifyChassisConfig(const ChassisConfig& config) {
-  (void)config;
-  return ::util::OkStatus();
+  // First make sure PHAL is happy with the config then continue with the rest
+  // of the managers and nodes.
+  absl::ReaderMutexLock l(&chassis_lock);
+  ::util::Status status = ::util::OkStatus();
+  APPEND_STATUS_IF_ERROR(status, phal_interface_->VerifyChassisConfig(config));
+  APPEND_STATUS_IF_ERROR(status,
+                         bf_chassis_manager_->VerifyChassisConfig(config));
+
+  // Get the current copy of the node_id_to_unit from chassis manager. If this
+  // fails with ERR_NOT_INITIALIZED, do not verify anything at the node level.
+  // Note that we do not expect any change in node_id_to_unit. Any change in
+  // this map will be detected in bcm_chassis_manager_->VerifyChassisConfig.
+  auto ret = bf_chassis_manager_->GetNodeIdToUnitMap();
+  if (!ret.ok()) {
+    if (ret.status().error_code() != ERR_NOT_INITIALIZED) {
+      APPEND_STATUS_IF_ERROR(status, ret.status());
+    }
+  } else {
+    const auto& node_id_to_unit = ret.ValueOrDie();
+    for (const auto& entry : node_id_to_unit) {
+      uint64 node_id = entry.first;
+      int unit = entry.second;
+      ASSIGN_OR_RETURN(auto* bfrt_node, GetPINodeFromUnit(unit));
+      APPEND_STATUS_IF_ERROR(status,
+                             bfrt_node->VerifyChassisConfig(config, node_id));
+    }
+  }
+
+  if (status.ok()) {
+    LOG(INFO) << "Chassis config verified successfully.";
+  }
+
+  return status;
 }
 
 ::util::Status BFSwitch::PushForwardingPipelineConfig(

--- a/stratum/hal/lib/common/yang_parse_tree.cc
+++ b/stratum/hal/lib/common/yang_parse_tree.cc
@@ -135,18 +135,6 @@ void YangParseTree::SendNotification(const GnmiEventPtr& event) {
 ::util::Status YangParseTree::ProcessPushedConfig(
     const ConfigHasBeenPushedEvent& change) {
   absl::WriterMutexLock r(&root_access_lock_);
-  // Make sure we clear the tree before we add new nodes.
-  root_.children_.clear();
-
-  // Add the minimum nodes:
-  //   /interfaces/interface[name=*]/state/ifindex
-  //   /interfaces/interface[name=*]/state/name
-  //   /interfaces/interface/...
-  //   /
-  // The rest of nodes will be added once the config is pushed.
-  AddSubtreeAllInterfaces();
-  AddSubtreeAllComponents();
-  AddRoot();
 
   // Translation from node ID to an object describing the node.
   absl::flat_hash_map<uint64, const Node*> node_id_to_node;


### PR DESCRIPTION
Stratum internals (like the yang tree) cannot handle such changes at runtime. Therefore we save the new config and require a reboot. Individual port config changes (speed, admin state) are still possible.

Tested with bfrt, but at least one run with stratum_bf would be good, too.

Steps:
- Start without chassis config: `start-stratum.sh  --chassis_config_file=/tmp/foo.pb.txt`
- Push new, full config: `bazel run //tools/gnmi:gnmi-cli -- --grpc-addr 10.128.13.223:28000 --bytes_val_file /stratum/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/chassis_config.pb.txt --replace set "/"`
- Check that all port are there: `pm show`
- Delete some ports from the config
- Push again. Expected error: `The switch is already initialized, but we detected the newly pushed config requires a change in the port layout. The stack needs to be rebooted to finish config push.`
- Restart Stratum
- Check ports, should be less than before
- Re-add ports to config
- Push and restart
- Check port all ports again

Fixes #293 