### PR TITLE
Set default glog log dir for stratum_bf

### DIFF
--- a/stratum/hal/bin/barefoot/deb/start-stratum.sh
+++ b/stratum/hal/bin/barefoot/deb/start-stratum.sh
@@ -45,5 +45,6 @@ fi
 
 exec /usr/bin/stratum_bf \
     -chassis_config_file=/etc/stratum/$PLATFORM/chassis_config.pb.txt \
+    -log_dir=/var/log/stratum \
     -flagfile=$FLAG_FILE \
     $@


### PR DESCRIPTION
See: https://github.com/stratum/stratum/blob/5851cdec95beeaa87b726e304ae6a924bd995364/stratum/hal/bin/bcm/standalone/start-stratum.sh#L19

I'd also consider putting this into the source code directly.