### PR TITLE
Add node info to SwitchInterface and expose via gNMI

### DIFF
--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -229,6 +229,12 @@ BFSwitch::~BFSwitch() {}
       case DataRequest::Request::kLoopbackStatus:
         resp = bf_chassis_manager_->GetPortData(req);
         break;
+      case DataRequest::Request::kNodeInfo: {
+        auto* node_info = resp.mutable_node_info();
+        node_info->set_vendor("Barefoot");
+        node_info->set_chip_name("Generic Tofino");
+        break;
+      }
       default:
         // TODO(antonin)
         resp = MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -231,7 +231,7 @@ BFSwitch::~BFSwitch() {}
         break;
       case DataRequest::Request::kNodeInfo: {
         auto* node_info = resp.mutable_node_info();
-        node_info->set_vendor("Barefoot");
+        node_info->set_vendor_name("Barefoot");
         node_info->set_chip_name("Generic Tofino");
         break;
       }

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -401,6 +401,24 @@ BcmSwitch::~BcmSwitch() {}
         resp.mutable_node_packetio_debug_info()->set_debug_string(
             "A (sample) node debug string.");
         break;
+      case DataRequest::Request::kNodeInfo: {
+        auto unit =
+            bcm_chassis_manager_->GetUnitFromNodeId(req.node_info().node_id());
+        if (!unit.ok()) {
+          status.Update(unit.status());
+        } else {
+          auto bcm_chip = bcm_chassis_manager_->GetBcmChip(unit.ValueOrDie());
+          if (!bcm_chip.ok()) {
+            status.Update(bcm_chip.status());
+          } else {
+            auto* node_info = resp.mutable_node_info();
+            node_info->set_vendor("Broadcom");
+            node_info->set_chip_name(
+                BcmChip::BcmChipType_Name(bcm_chip.ValueOrDie().type()));
+          }
+        }
+        break;
+      }
       case DataRequest::Request::kOpticalTransceiverInfo:
         // Retrieve current optical transceiver state from phal.
         status.Update(phal_interface_->GetOpticalTransceiverInfo(

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -412,7 +412,7 @@ BcmSwitch::~BcmSwitch() {}
             status.Update(bcm_chip.status());
           } else {
             auto* node_info = resp.mutable_node_info();
-            node_info->set_vendor("Broadcom");
+            node_info->set_vendor_name("Broadcom");
             node_info->set_chip_name(
                 BcmChip::BcmChipType_Name(bcm_chip.ValueOrDie().type()));
           }

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1134,7 +1134,7 @@ message Alarm {
 }
 
 message NodeInfo {
-  string vendor = 1;
+  string vendor_name = 1;
   string chip_name = 2;
 }
 

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1133,6 +1133,11 @@ message Alarm {
   bool status = 4;          // required.
 }
 
+message NodeInfo {
+  string vendor = 1;
+  string chip_name = 2;
+}
+
 // Wrapper around an optional debug info for a node/chip.
 message NodeDebugInfo {
   string debug_string = 1;
@@ -1214,6 +1219,7 @@ message DataRequest {
       Port fec_status = 18;
       OpticalNetworkInterface optical_transceiver_info = 19;
       Port loopback_status = 20;
+      Node node_info = 21;
     }
   }
   repeated Request requests = 1;
@@ -1245,6 +1251,7 @@ message DataResponse {
     FecStatus fec_status = 18;
     OpticalTransceiverInfo optical_transceiver_info = 19;
     LoopbackStatus loopback_status = 20;
+    NodeInfo node_info = 21;
   }
 }
 

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1133,6 +1133,7 @@ message Alarm {
   bool status = 4;          // required.
 }
 
+// Wrapper around the optional node info.
 message NodeInfo {
   string vendor_name = 1;
   string chip_name = 2;

--- a/stratum/hal/lib/common/gnmi_publisher.h
+++ b/stratum/hal/lib/common/gnmi_publisher.h
@@ -207,7 +207,7 @@ class GnmiPublisher {
                 if (FLAGS_v >= 1) LOG(INFO) << "Configuration has changed.";
                 if (auto* event = dynamic_cast<const ConfigHasBeenPushedEvent*>(
                         &event_base)) {
-                  return parse_tree_.ProcessPushedConfig(*event);
+                  parse_tree_.ProcessPushedConfig(*event);
                 }
                 return ::util::OkStatus();
               };  // NOLINT

--- a/stratum/hal/lib/common/yang_parse_tree.h
+++ b/stratum/hal/lib/common/yang_parse_tree.h
@@ -455,7 +455,7 @@ class YangParseTree {
       LOCKS_EXCLUDED(root_access_lock_);
 
   // An action that modifies the tree to reflect new configuration.
-  ::util::Status ProcessPushedConfig(const ConfigHasBeenPushedEvent& change)
+  void ProcessPushedConfig(const ConfigHasBeenPushedEvent& change)
       LOCKS_EXCLUDED(root_access_lock_);
 
  protected:

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -3439,7 +3439,7 @@ void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
   const std::string& name =
       !singleton.name().empty()
           ? singleton.name()
-          : absl::StrFormat("%d/%d/%d", singleton.port(), singleton.slot(),
+          : absl::StrFormat("%d/%d/%d", singleton.slot(), singleton.port(),
                             singleton.channel());
   uint64 node_id = singleton.node();
   uint32 port_id = singleton.id();

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -3439,7 +3439,8 @@ void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
   const std::string& name =
       !singleton.name().empty()
           ? singleton.name()
-          : absl::StrFormat("%d/%d", singleton.port(), singleton.slot());
+          : absl::StrFormat("%d/%d/%d", singleton.port(), singleton.slot(),
+                            singleton.channel());
   uint64 node_id = singleton.node();
   uint32 port_id = singleton.id();
   TreeNode* node =

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -3194,6 +3194,39 @@ void SetUpComponentsComponentIntegratedCircuitStatePartNo(uint64 node_id,
       ->SetOnChangeHandler(on_change_functor);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// /components/component[name=<name>]/integrated-circuit/state/mfg-name
+void SetUpComponentsComponentIntegratedCircuitStateMfgName(
+    uint64 node_id, TreeNode* node, YangParseTree* tree) {
+  auto poll_functor = [node_id, tree](const GnmiEvent& event,
+                                      const ::gnmi::Path& path,
+                                      GnmiSubscribeStream* stream) {
+    // Create a data retrieval request.
+    DataRequest req;
+    auto* request = req.add_requests()->mutable_node_info();
+    request->set_node_id(node_id);
+    // In-place definition of method retrieving data from generic response
+    // and saving into 'resp' local variable.
+    std::string resp{};
+    DataResponseWriter writer([&resp](const DataResponse& in) {
+      if (!in.has_node_info()) return false;
+      resp = in.node_info().vendor_name();
+      return true;
+    });
+    // Query the switch. The returned status is ignored as there is no way to
+    // notify the controller that something went wrong. The error is logged when
+    // it is created.
+    tree->GetSwitchInterface()
+        ->RetrieveValue(node_id, req, &writer, /* details= */ nullptr)
+        .IgnoreError();
+    return SendResponse(GetResponse(path, resp), stream);
+  };
+  auto on_change_functor = UnsupportedFunc();
+  node->SetOnPollHandler(poll_functor)
+      ->SetOnTimerHandler(poll_functor)
+      ->SetOnChangeHandler(on_change_functor);
+}
+
 }  // namespace
 
 // Path of leafs created by this method are defined 'manualy' by analysing
@@ -3618,21 +3651,29 @@ void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
 
 void YangParseTreePaths::AddSubtreeNode(const Node& node, YangParseTree* tree) {
   // No need to lock the mutex - it is locked by method calling this one.
+  std::string node_name = node.name();
+  if (node_name.empty()) {
+    node_name = absl::StrFormat("node-%d", node.id());
+  }
   TreeNode* tree_node = tree->AddNode(GetPath("debug")("nodes")(
-      "node", node.name())("packet-io")("debug-string")());
+      "node", node_name)("packet-io")("debug-string")());
   SetUpDebugNodesNodePacketIoDebugString(node.id(), tree_node, tree);
   tree_node = tree->AddNode(GetPath("components")(
-      "component", node.name())("integrated-circuit")("config")("node-id")());
+      "component", node_name)("integrated-circuit")("config")("node-id")());
   SetUpComponentsComponentIntegratedCircuitConfigNodeId(node.id(), tree_node,
                                                         tree);
   tree_node = tree->AddNode(GetPath("components")(
-      "component", node.name())("integrated-circuit")("state")("node-id")());
+      "component", node_name)("integrated-circuit")("state")("node-id")());
   SetUpComponentsComponentIntegratedCircuitStateNodeId(node.id(), tree_node,
                                                        tree);
   tree_node = tree->AddNode(GetPath("components")(
-      "component", node.name())("integrated-circuit")("state")("part-no")());
+      "component", node_name)("integrated-circuit")("state")("part-no")());
   SetUpComponentsComponentIntegratedCircuitStatePartNo(node.id(), tree_node,
                                                        tree);
+  tree_node = tree->AddNode(GetPath("components")(
+      "component", node_name)("integrated-circuit")("state")("mfg-name")());
+  SetUpComponentsComponentIntegratedCircuitStateMfgName(node.id(), tree_node,
+                                                        tree);
 }
 
 void YangParseTreePaths::AddSubtreeChassis(const Chassis& chassis,

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -3436,7 +3436,10 @@ void YangParseTreePaths::AddSubtreeInterfaceFromTrunk(
 void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
     const SingletonPort& singleton, const NodeConfigParams& node_config,
     YangParseTree* tree) {
-  const std::string& name = singleton.name();
+  const std::string& name =
+      !singleton.name().empty()
+          ? singleton.name()
+          : absl::StrFormat("%d/%d", singleton.port(), singleton.slot());
   uint64 node_id = singleton.node();
   uint32 port_id = singleton.id();
   TreeNode* node =
@@ -3513,7 +3516,10 @@ void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
 
 void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
     const OpticalNetworkInterface& optical_port, YangParseTree* tree) {
-  const std::string& name = optical_port.name();
+  const std::string& name =
+      !optical_port.name().empty()
+          ? optical_port.name()
+          : absl::StrFormat("netif-%d", optical_port.network_interface());
   int32 module = optical_port.module();
   int32 network_interface = optical_port.network_interface();
   TreeNode* node{nullptr};
@@ -3643,35 +3649,35 @@ void YangParseTreePaths::AddSubtreeInterfaceFromOptical(
 
 void YangParseTreePaths::AddSubtreeNode(const Node& node, YangParseTree* tree) {
   // No need to lock the mutex - it is locked by method calling this one.
-  std::string node_name = node.name();
-  if (node_name.empty()) {
-    node_name = absl::StrFormat("node-%d", node.id());
-  }
-  TreeNode* tree_node = tree->AddNode(GetPath("debug")("nodes")(
-      "node", node_name)("packet-io")("debug-string")());
+  const std::string& name = !node.name().empty()
+                                ? node.name()
+                                : absl::StrFormat("node-%d", node.id());
+  TreeNode* tree_node = tree->AddNode(
+      GetPath("debug")("nodes")("node", name)("packet-io")("debug-string")());
   SetUpDebugNodesNodePacketIoDebugString(node.id(), tree_node, tree);
   tree_node = tree->AddNode(GetPath("components")(
-      "component", node_name)("integrated-circuit")("config")("node-id")());
+      "component", name)("integrated-circuit")("config")("node-id")());
   SetUpComponentsComponentIntegratedCircuitConfigNodeId(node.id(), tree_node,
                                                         tree);
   tree_node = tree->AddNode(GetPath("components")(
-      "component", node_name)("integrated-circuit")("state")("node-id")());
+      "component", name)("integrated-circuit")("state")("node-id")());
   SetUpComponentsComponentIntegratedCircuitStateNodeId(node.id(), tree_node,
                                                        tree);
   tree_node = tree->AddNode(
-      GetPath("components")("component", node_name)("state")("type")());
+      GetPath("components")("component", name)("state")("type")());
   SetUpComponentsComponentStateType("INTEGRATED_CIRCUIT", tree_node);
   tree_node = tree->AddNode(
-      GetPath("components")("component", node_name)("state")("part-no")());
+      GetPath("components")("component", name)("state")("part-no")());
   SetUpComponentsComponentStatePartNo(node.id(), tree_node, tree);
   tree_node = tree->AddNode(
-      GetPath("components")("component", node_name)("state")("mfg-name")());
+      GetPath("components")("component", name)("state")("mfg-name")());
   SetUpComponentsComponentStateMfgName(node.id(), tree_node, tree);
 }
 
 void YangParseTreePaths::AddSubtreeChassis(const Chassis& chassis,
                                            YangParseTree* tree) {
-  const std::string& name = chassis.name();
+  const std::string& name =
+      !chassis.name().empty() ? chassis.name() : "chassis";
   TreeNode* node = tree->AddNode(GetPath("components")(
       "component", name)("chassis")("alarms")("memory-error")());
   SetUpComponentsComponentChassisAlarmsMemoryError(node, tree);

--- a/stratum/hal/lib/dummy/dummy_chassis_mgr.cc
+++ b/stratum/hal/lib/dummy/dummy_chassis_mgr.cc
@@ -77,7 +77,17 @@ DummyChassisManager* DummyChassisManager::GetSingleton() {
 ::util::StatusOr<DataResponse>
 DummyChassisManager::RetrieveChassisData(const Request request) {
   // TODO(Yi Tseng): Implement this method.
-  return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet!";
+  switch (request.request_case()) {
+    case Request::kNodeInfo: {
+      DataResponse resp;
+      NodeInfo* node_info = resp.mutable_node_info();
+      node_info->set_vendor("dummy vendor");
+      node_info->set_chip_name("dummy chip name");
+      return resp;
+    }
+    default:
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet!";
+  }
 }
 
 }  // namespace dummy_switch

--- a/stratum/hal/lib/dummy/dummy_chassis_mgr.cc
+++ b/stratum/hal/lib/dummy/dummy_chassis_mgr.cc
@@ -81,7 +81,7 @@ DummyChassisManager::RetrieveChassisData(const Request request) {
     case Request::kNodeInfo: {
       DataResponse resp;
       NodeInfo* node_info = resp.mutable_node_info();
-      node_info->set_vendor("dummy vendor");
+      node_info->set_vendor_name("dummy vendor");
       node_info->set_chip_name("dummy chip name");
       return resp;
     }

--- a/stratum/hal/lib/dummy/dummy_switch.cc
+++ b/stratum/hal/lib/dummy/dummy_switch.cc
@@ -256,6 +256,7 @@ namespace dummy_switch {
         break;
       case Request::kMemoryErrorAlarm:
       case Request::kFlowProgrammingExceptionAlarm:
+      case Request::kNodeInfo:
         resp = chassis_mgr_->RetrieveChassisData(request);
         break;
       case Request::kPortQosCounters:

--- a/stratum/public/yang/openconfig-platform-stratum.yang
+++ b/stratum/public/yang/openconfig-platform-stratum.yang
@@ -76,4 +76,13 @@ module openconfig-platform-stratum {
       description "Stratum does not support components/component/backplane";
       deviate not-supported;
   }
+
+  augment "/oc-platform:components/oc-platform:component/oc-platform:integrated-circuit/oc-platform:state" {
+      leaf part-no {
+          type string;
+      }
+      leaf mfg-name {
+          type string;
+      }
+  }
 }

--- a/stratum/public/yang/openconfig-platform-stratum.yang
+++ b/stratum/public/yang/openconfig-platform-stratum.yang
@@ -76,13 +76,4 @@ module openconfig-platform-stratum {
       description "Stratum does not support components/component/backplane";
       deviate not-supported;
   }
-
-  augment "/oc-platform:components/oc-platform:component/oc-platform:integrated-circuit/oc-platform:state" {
-      leaf part-no {
-          type string;
-      }
-      leaf mfg-name {
-          type string;
-      }
-  }
 }


### PR DESCRIPTION
This PR adds a `NodeInfo` message to the `SwitchInterface` to retrieve data about the switching ASIC. It implements basic support for Tofino (no chip detection) and dummy, and full support for Broadcom.

There are a few open questions:
- <s>The component name in the gNMI path is constructed from the node name, which is not set in most of the chassis configs</s> `node-<id>` if node name is empty

New paths:
- `/components/component[name="dummy node 1"]/state/part-no` => TOMAHAWK, TRIDENT2
- `/components/component[name="dummy node 1"]/state/mfg-name` => Broadcom, Barefoot
- `/components/component[name="dummy node 1"]/state/type` => INTEGRATED_CIRCUIT

gNMI command:
```bash
bazel run //stratum/tools/gnmi:gnmi-cli -- --grpc-addr 127.0.0.1:28000 get /components/component[name="dummy node 1"]/state
```

Fixes #166 
