### PR TITLE
Disable file logging on Stratum docker

### DIFF
--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -45,4 +45,5 @@ docker run -it --rm --privileged \
     $CHASSIS_CONFIG_MOUNT \
     -v $LOG_DIR:/var/log/stratum \
     $DOCKER_IMAGE:$DOCKER_IMAGE_TAG \
+    -log_dir=/dev/null \
     $@

--- a/stratum/hal/bin/bcm/standalone/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/bcm/standalone/docker/start-stratum-container.sh
@@ -28,4 +28,5 @@ docker run -it --rm --privileged --cap-add ALL --shm-size=512m --network host \
     $CHASSIS_CONFIG_MOUNT \
     -v $LOG_DIR:/var/log/stratum \
     $DOCKER_IMAGE:$DOCKER_IMAGE_TAG \
+    -log_dir=/dev/null \
     $@


### PR DESCRIPTION
This PR disables logging to disk on the Docker builds of Stratum.

By setting `-log_dir=/dev/null`, no logs will be created.
There are minor problems with this solution. glog will complain that it can not create sub-directories and print this message once for each level:
```
COULD NOT CREATE A LOGGINGFILE 20200824-165925.31866!W0824 16:59:25.207049 31866 credentials_manager.cc:45] Using insecure server credentials
```
This could be a problem for downstream log parsers, like fluentd.

Alternatives:
`-minloglevel` cannot be used, as it completely disables logging, even to stderr.

`-max_log_size=0` can be used to limit file size to 1MB. If we are concerned about polluting disk. Still writes the logs to disk, if performance is a concern.