### PR TITLE
Do not print bazel build progress in CI

### DIFF
--- a/.circleci/bazelrc
+++ b/.circleci/bazelrc
@@ -3,6 +3,7 @@
 build --announce_rc
 build --copt -O0
 build --disk_cache=/tmp/bazel-disk-cache
+build --noshow_progress
 
 # Set convenient location for Bazel files to cache
 startup --output_user_root=/tmp/bazel-cache/output-root


### PR DESCRIPTION
Keeps the CI logs clean from useless information.

https://docs.bazel.build/versions/master/command-line-reference.html#flag--show_progress