### PR TITLE
Use mtime to clean bazel cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,9 @@ save_bazel_cache: &save_bazel_cache
 
 clean_bazel_cache: &clean_bazel_cache
   run:
-    name: Clean Bazel disk cache of files that have not been touched in 30 days
-    command: /usr/bin/find /tmp/bazel-disk-cache -atime +30 -exec rm -v {} \;
+    name: Clean Bazel disk cache of files that have not been modified in 30 days
+    # mtime is the only time preserved after untaring the cache.
+    command: /usr/bin/find /tmp/bazel-disk-cache -mtime +30 -exec rm -v {} \;
 
 # Print Bazel profiling info and generate JSON report to upload as artifact.
 analyze_bazel_profile: &analyze_bazel_profile


### PR DESCRIPTION
`mtime` is the only value preserved after the tar/untar process. `atime` and `ctime` point the to time of untar-ing.
This means we never delete items from the disk cache and it keeps growing.


From a CI job:
```
# stat /tmp/bazel-disk-cache/ac_4192a48c88d2224b9f279c65eebfcaaa962fb1bbfa145e12cf61c44b1a0dfb0a
  File: /tmp/bazel-disk-cache/ac_4192a48c88d2224b9f279c65eebfcaaa962fb1bbfa145e12cf61c44b1a0dfb0a
  Size: 492       	Blocks: 8          IO Block: 4096   regular file
Device: 31h/49d	Inode: 247982      Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2020-09-08 21:55:44.456602914 +0000
Modify: 2020-07-16 06:43:13.000000000 +0000
Change: 2020-09-08 21:55:44.456602914 +0000
 Birth: -
```