### PR TITLE
Touchup the gNMI cli

### DIFF
--- a/stratum/tools/gnmi/BUILD
+++ b/stratum/tools/gnmi/BUILD
@@ -19,6 +19,9 @@ stratum_cc_binary(
     srcs = ["gnmi_cli.cc"],
     arches = HOST_ARCHES,
     deps = [
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/lib:macros",
         "//stratum/lib:utils",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_grpc_grpc//:grpc++",

--- a/stratum/tools/gnmi/README.md
+++ b/stratum/tools/gnmi/README.md
@@ -44,7 +44,7 @@ bazel run //stratum/tools/gnmi:gnmi-cli -- get /interfaces/interface[name=1/1/1]
 bazel run //stratum/tools/gnmi:gnmi-cli -- set /interfaces/interface[name=1/1/1]/config/health-indicator --string-val GOOD
 
 # To subscribe one sample of port operation status per second
-bazel run //stratum/tools/gnmi:gnmi-cli -- sub-sample /interfaces/interface[name=1/1/1]/state/oper-status --inverval 1000
+bazel run //stratum/tools/gnmi:gnmi-cli -- sub-sample /interfaces/interface[name=1/1/1]/state/oper-status --interval 1000
 
 # To push chassis config
 bazel run //stratum/tools/gnmi:gnmi-cli -- --replace --bytes_val_file [chassis config file] set /


### PR DESCRIPTION
This PR addresses a few minor things of the gNMI cli:

- Pass return code to shell on errors.
  Most errors did not set the shell return code to !=0. This could mislead users into thinking the command worked, when it did not. Errors are in color now (red).
- Stop continuing on errors
  Some checks did not return on error
- Use native Status and macros