### PR TITLE
Build Stratum dev image before running other CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,25 @@ docker_push: &docker_push
     name: Push Docker image
     command: docker push $DOCKER_IMG
 
+commands:
+    docker_build2:
+      parameters:
+          image:
+            type: string
+          tag:
+            type: string
+          file:
+            type: string
+          scope:
+            type: string
+      steps:
+          - run:
+              name: Build Docker image
+              command: |
+                docker pull <<parameters.image>>:build || true
+                cd <<parameters.scope>>
+                docker build -f <<parameters.file>> -t <<parameters.image>>:<<parameters.tag>> --cache-from <<parameters.image>>:build --label vcs-ref=$CIRCLE_SHA1 .
+
 jobs:
 
   # Build targets and run unit tests.
@@ -153,14 +172,17 @@ jobs:
     environment:
       - DOCKER_SCOPE: .
       - DOCKER_FILE: Dockerfile.build
-      - DOCKER_IMG: stratumproject/build:git-$CIRCLE_SHA1
+      - DOCKER_IMG: stratumproject/build
     steps:
       - setup_remote_docker
       - checkout
-      - run: echo "$CIRCLE_SHA1" && echo $DOCKER_IMG && exit 1
       - *docker_login
-      - *docker_build
-      - run: docker image inspect --format='{{index .RepoDigests 0}}' $DOCKER_IMG
+      - docker_build2:
+          image: stratumproject/build
+          tag: git-$CIRCLE_SHA1
+          file: Dockerfile.build
+          scope: .
+      - run: docker image inspect $DOCKER_IMG:git-$CIRCLE_SHA1
       - *docker_push
 
   publish-docker-mininet:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,22 @@ jobs:
       - *docker_build
       - *docker_push
 
+  publish-docker-build2:
+    docker:
+      - image: docker:19
+    environment:
+      - DOCKER_SCOPE: .
+      - DOCKER_FILE: Dockerfile.build
+      - DOCKER_IMG: stratumproject/build:git-$CIRCLE_SHA1
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run: echo "$CIRCLE_SHA1" && echo $DOCKER_IMG && exit 1
+      - *docker_login
+      - *docker_build
+      - run: docker image inspect --format='{{index .RepoDigests 0}}' $DOCKER_IMG
+      - *docker_push
+
   publish-docker-mininet:
     machine: true
     environment:
@@ -275,12 +291,25 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - unit_tests
-      - cdlang_tests
-      - coverage
-      - cpp-style-check
-      - license-check
-      - bazel-style-check
+      - publish-docker-build2
+      - unit_tests:
+          requires:
+            - publish-docker-build2
+      - cdlang_tests:
+          requires:
+            - publish-docker-build2
+      - coverage:
+          requires:
+            - publish-docker-build2
+      - cpp-style-check:
+          requires:
+            - publish-docker-build2
+      - license-check:
+          requires:
+            - publish-docker-build2
+      - bazel-style-check:
+          requires:
+            - publish-docker-build2
   docker-publish:
     jobs:
       - publish-docker-build:


### PR DESCRIPTION
This PR restructures how the CI systems handles the docker images it builds and uses.

TODOs:

- [ ] Try building all images on all PRs, but not push. This should prevent surprises after merging to master and figuring out why a certain image does not build.

Fixes #333 