### PR TITLE
Revert "Do not print bazel build progress in CI (#314)" 

### DIFF
--- a/.circleci/bazelrc
+++ b/.circleci/bazelrc
@@ -3,7 +3,6 @@
 build --announce_rc
 build --copt -O0
 build --disk_cache=/tmp/bazel-disk-cache
-build --noshow_progress
 
 # Set convenient location for Bazel files to cache
 startup --output_user_root=/tmp/bazel-cache/output-root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,6 @@ jobs:
       - run:
           name: Run test and collect coverage data
           command: xargs -a .circleci/test-targets.txt bazel coverage
-          no_output_timeout: 20m
       - *analyze_bazel_profile
       - *store_bazel_profile
       - run:


### PR DESCRIPTION
We have several failing CI jobs, because Bazel now (https://github.com/stratum/stratum/commit/1bacba7b5366d7b3194c0109eec17584169bf37a) prints less output.