### PR TITLE
Create Stratum-bf directories at runtime

### DIFF
--- a/stratum/hal/bin/barefoot/deb/start-stratum.sh
+++ b/stratum/hal/bin/barefoot/deb/start-stratum.sh
@@ -43,6 +43,8 @@ else
     echo "Cannot find $KDRV_PATH, skip installing the Kernel module."
 fi
 
+mkdir -p /var/run/stratum /var/log/stratum
+
 exec /usr/bin/stratum_bf \
     -chassis_config_file=/etc/stratum/$PLATFORM/chassis_config.pb.txt \
     -log_dir=/var/log/stratum \


### PR DESCRIPTION
`/var/run/` (symlink to `/run`) is cleared at device boot according to the [FHS spec](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html). Therefore we have re-create `/var/run/stratum` and `/var/log/stratum` as part of the start script.
