### PR TITLE
Build BF target using SDE_INSTALL_TAR

### DIFF
--- a/stratum/hal/bin/barefoot/README.md
+++ b/stratum/hal/bin/barefoot/README.md
@@ -37,7 +37,10 @@ This package installs all dependencies, configuration files and the `stratum_bf`
 In the future we might provide pre-built Debian packages, but for now, you have
 to build them yourself as lined out in this document.
 
-## Installing the SDE
+## Building Stratum for Barefoot Tofino
+
+### Prerequisites
+#### Installing the SDE
 
 Before you can build Stratum, the Barefoot SDE needs to be installed.
 
@@ -70,7 +73,7 @@ are building modules for a specific version other than the host's.
 As there are some issues with building the SDE on ONL switches, it's better to
 do that on a separate server.
 
-### Supported SDE versions
+#### Supported SDE versions
 
  - 8.9.2
  - 9.0.0
@@ -103,7 +106,17 @@ export BSP_PATH=`pwd`/bf-reference-bsp-<SDE_VERSION>
 ./p4studio_build.py -up profiles/stratum_profile.yaml --bsp-path $BSP_PATH [-kdir <path/to/linux/sources>]
 ```
 
-## Building Stratum
+### Packing the SDE install tar archive
+Stratum prefers a tarball of the release artifacts, which can be created using:
+
+```bash
+export SDE_INSTALL_TAR=`pwd`/bf-sde-<SDE_VERSION>-install.tgz
+<STRATUM_ROOT>/stratum/hal/bin/barefoot/docker/build-bf-sde-install-tar.sh
+```
+
+*Note: This script depends on `SDE` and `SDE_INSTALL`.*
+
+### Building Stratum
 
 The [SDE](#installing-the-sde) needs to be installed and set up for this step.
 

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.builder
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.builder
@@ -13,12 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libelf-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG SDE_TAR
-COPY $SDE_TAR /stratum/
+ARG SDE_TAR_NAME
+COPY $SDE_TAR_NAME /stratum/
 
 ENV SDE /bf-sde
 ENV SDE_INSTALL $SDE/install
-RUN mkdir $SDE && tar xf /stratum/$SDE_TAR -C $SDE --strip-components 1
+RUN mkdir $SDE && tar xf /stratum/$SDE_TAR_NAME -C $SDE --strip-components 1
 
 # Install an older version of pyresistent before running the P4 studio
 # since the pip will try to install newer version of it when pip install

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.builder
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.builder
@@ -35,8 +35,10 @@ RUN sed -i.bak '/package_dependencies/d; /thrift/d' profiles/stratum_profile.yam
 RUN ./p4studio_build.py -up stratum_profile -wk -j$JOBS -shc && \
     rm -rf /var/lib/apt/lists/*
 
-# Strip symbols from all .so files
-RUN strip --strip-all $SDE_INSTALL/lib/*.so*
+# Create BF SDE install package
+ARG SDE_INSTALL_TAR_NAME
+COPY build-bf-sde-install-tar.sh /output/
+RUN /output/build-bf-sde-install-tar.sh /output/$SDE_INSTALL_TAR_NAME
 
 # Remove SDE and Linux headers tarball
 RUN rm -r /stratum/*

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
@@ -18,7 +18,7 @@ RUN tar xf ${SDE_INSTALL_TAR}
 
 # Build Barefoot Kernel module if needed
 WORKDIR /stratum
-ARG KERNEL_HEADERS_TAR
+ARG KERNEL_HEADERS_TAR_NAME
 ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers
 ENV KDRV_DIR=/bf-sde-install/src/kdrv/bf_kdrv
 RUN stratum/hal/bin/barefoot/docker/build-kdrv.sh
@@ -26,7 +26,7 @@ RUN stratum/hal/bin/barefoot/docker/build-kdrv.sh
 # Stratum package
 ARG STRATUM_TARGET=stratum_bf
 ARG WITH_ONLP=true
-RUN apt install libbz2-dev
+RUN apt-get update && apt-get install -y libbz2-dev
 RUN bazel build //stratum/hal/bin/barefoot:${STRATUM_TARGET}_deb \
     --define sde_ver=$(cat $SDE_INSTALL/share/VERSION) \
     --define phal_with_onlp=$WITH_ONLP

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
@@ -3,34 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG BUILDER_IMAGE
-
-FROM $BUILDER_IMAGE as builder
+FROM stratumproject/build:build as builder
 
 # Copy stratum source code
 ADD . /stratum
-
-# Prepare the stratum_bf
 WORKDIR /stratum
 
+# Extract BF SDE install package
+ARG SDE_INSTALL_TAR_NAME
+ENV SDE_INSTALL_TAR /stratum/${SDE_INSTALL_TAR_NAME}
+ENV SDE_INSTALL /bf-sde-install
+WORKDIR ${SDE_INSTALL}
+RUN tar xf ${SDE_INSTALL_TAR}
+
 # Build Barefoot Kernel module if needed
+WORKDIR /stratum
 ARG KERNEL_HEADERS_TAR
-# Copy Linux headers tarball and build script
-COPY $KERNEL_HEADERS_TAR /stratum/
-COPY /stratum/hal/bin/barefoot/docker/build-kdrv.sh /build-kdrv.sh
-
 ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers
-ENV KDRV_DIR=/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv
-RUN /build-kdrv.sh
-
-ENV OUTPUT_BASE /output
-ARG WITH_ONLP=true
+ENV KDRV_DIR=/bf-sde-install/src/kdrv/bf_kdrv
+RUN stratum/hal/bin/barefoot/docker/build-kdrv.sh
 
 # Stratum package
-RUN bazel build //stratum/hal/bin/barefoot:stratum_bf_deb \
+ARG STRATUM_TARGET=stratum_bf
+ARG WITH_ONLP=true
+RUN apt install libbz2-dev
+RUN bazel build //stratum/hal/bin/barefoot:${STRATUM_TARGET}_deb \
     --define sde_ver=$(cat $SDE_INSTALL/share/VERSION) \
     --define phal_with_onlp=$WITH_ONLP
-RUN dpkg -x bazel-bin/stratum/hal/bin/barefoot/stratum_bf_deb.deb $OUTPUT_BASE
+RUN dpkg -x bazel-bin/stratum/hal/bin/barefoot/${STRATUM_TARGET}_deb.deb /output
 
 FROM bitnami/minideb:stretch
 LABEL maintainer="Stratum dev <stratum-dev@lists.stratumproject.org>"

--- a/stratum/hal/bin/barefoot/docker/README.md
+++ b/stratum/hal/bin/barefoot/docker/README.md
@@ -34,21 +34,27 @@ To build the Docker image for runtime or development, first, you need to have th
 To build the Docker image, run `build-stratum-bf-container.sh` script with SDE and Linux header tarball, for example:
 
 ```bash
-$ ./build-stratum-bf-container.sh ~/bf-sde-9.0.0.tgz ~/linux-4.14.49-ONL.tar.xz
+$ ./build-stratum-bf-container.sh -s ~/bf-sde-9.2.0.tgz -i ~/linux-4.14.49-ONL.tar.xz
 ```
 
 You can also build the container image without Kernel headers, and the script will skip building the Kernel module.
 
 ```bash
-$ ./build-stratum-bf-container.sh ~/bf-sde-9.0.0.tgz
+$ ./build-stratum-bf-container.sh -s ~/bf-sde-9.2.0.tgz
 ```
 
-Optional environment variables for this script:
+If you already have generated an SDE install tarball, you can provide it instead of the SDE tarball.
 
- - JOBS: The number of jobs to run simultaneously while building the SDE. Default is 4
- - WITH_ONLP: Includes ONLP library linking. The default is true.
+```bash
+$ ./build-stratum-bf-container.sh -s ~/bf-sde-9.2.0-install.tgz
+```
 
-__Note:__ This script saves an intermediate image named `stratumproject/stratum-bf-builder` for caching artifacts from building SDE, which could be used to speed up future builds when the same SDE tarballs are used as input to the script.
+For more build options, run:
+```bash
+$ ./build-stratum-bf-container.sh --help
+```
+
+__Note:__ If an SDE tarball is provided, this script saves an intermediate image named `stratumproject/stratum-bf-builder` for caching artifacts from building SDE. It also generates an SDE install tar that can be used for future builds.
 
 ## Deploy the container to the device
 

--- a/stratum/hal/bin/barefoot/docker/build-bf-sde-install-tar.sh
+++ b/stratum/hal/bin/barefoot/docker/build-bf-sde-install-tar.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $(basename "$0") <Stratum BF-SDE deps package>.tgz"
+  exit 1
+fi
+
+: ${SDE:?"Barefoot SDE variable is not set"}
+echo "SDE: $SDE"
+: ${SDE_INSTALL:?"Barefoot SDE_INSTALL is not set"}
+echo "SDE_INSTALL: $SDE_INSTALL"
+
+set -x
+tmpdir="$(mktemp -d /tmp/bf_sde_install.XXXXXX)"
+
+# Copy install directory and strip shared libraries
+cp -ar $SDE_INSTALL/. $tmpdir
+find $tmpdir -name "*\.so*" -a -type f | xargs -n1 chmod +w
+find $tmpdir -name "*\.so*" -a -type f | xargs -n1 strip --strip-all
+find $tmpdir -name "*\.so*" -a -type f | xargs -n1 chmod -w
+
+# Copy required SDE sources and make any required changes
+mkdir -p $tmpdir/src/bf_rt/proto
+cp -an $SDE/pkgsrc/bf-drivers/src/bf_rt/proto/* $tmpdir/src/bf_rt/proto
+sed -i'' 's#<google/rpc/status.grpc.pb.h>#"google/rpc/status.pb.h"#' \
+  $tmpdir/src/bf_rt/proto/bf_rt_server_impl.hpp
+sed -i'' 's#<google/rpc/code.grpc.pb.h>#"google/rpc/code.pb.h"#' \
+  $tmpdir/src/bf_rt/proto/bf_rt_server_impl.hpp
+
+mkdir -p $tmpdir/src/bf_rt/bf_rt_common
+cp -an $SDE/pkgsrc/bf-drivers/src/bf_rt/bf_rt_common/* $tmpdir/src/bf_rt/bf_rt_common
+
+mkdir -p $tmpdir/include/pipe_mgr
+cp -an $SDE/pkgsrc/bf-drivers/include/pipe_mgr/pktgen_intf.h $tmpdir/include/pipe_mgr
+
+cp -anr $SDE/pkgsrc/bf-drivers/kdrv $tmpdir/src
+
+# Build the Stratum BF SDE Install archive
+tar czf $1 -C $tmpdir .
+rm -rf $tmpdir

--- a/stratum/hal/bin/barefoot/docker/build-kdrv.sh
+++ b/stratum/hal/bin/barefoot/docker/build-kdrv.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 KERNEL_HEADERS_PATH=${KERNEL_HEADERS_PATH:-/usr/src/kernel-headers}
-KDRV_DIR=${KDRV_DIR:-/bf-sde/pkgsrc/bf-drivers/kdrv/bf_kdrv}
+KDRV_DIR=${KDRV_DIR:-/bf-sde-install/src/kdrv/bf_kdrv}
 
 if [ -n "$KERNEL_HEADERS_TAR" ]; then
   mkdir -p "$KERNEL_HEADERS_PATH"

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
-set -xe
 DOCKERFILE_DIR=$( cd $(dirname "${BASH_SOURCE[0]}") >/dev/null 2>&1 && pwd )
 STRATUM_ROOT=${STRATUM_ROOT:-"$( cd "$DOCKERFILE_DIR/../../../../.." >/dev/null 2>&1 && pwd )"}
 STRATUM_TARGET=${STRATUM_TARGET:-stratum_bf}
@@ -11,24 +10,42 @@ WITH_ONLP=${WITH_ONLP:-true}
 print_help() {
 echo "
 The script builds containerized version of Stratum for Barefoot Tofino based device.
-It builds SDE using Dockerfile.builder and saves artifacts to an intermediate builder image.
-It also builds the kernel module if kernel header tarball is given.
-Then it runs Bazel build for Stratum code base and copies libraries from builder to runtime image using Dockerfile.runtime.
 
-Usage: $0 SDE_TAR [KERNEL_HEADERS_TAR]
+First, it builds SDE using Dockerfile.builder, create a tar archive of required build artifacts,
+and saves artifacts to an intermediate builder image. 
 
-FIXME(bocon): update usage to include named parameters
+Second, it runs Bazel build for Stratum code base using Dockerfile.runtime and the tar archive
+from the first phase. You can also skip the first phase by passing an SDE install archive to
+this command. This phase also builds the kernel module if a kernel header tarball is given.
 
-Example:
-    $0 ~/bf-sde-9.0.0.tgz
+Usage: $0 [<options>] [SDE_TAR [KERNEL_HEADERS_TAR]]
+
+Options:
+
+    -s, --bf-sde-tar: BF SDE tarball
+    -i, --bf-sde-install-tar: BF SDE install tarball
+       If BF SDE tarball is provided, this is the output file for phase 1
+       If BF SDE tarball is not provided, this the input file for phase 2
+    -k, --kernel-headers-tar: Linux Kernel headers tarball
+    -o, --sde-build-only: Only build the SDE (phase 1)
+    -j, --jobs: Number of jobs for BF SDE build (Default: 4)
+    -v, --sde-version: BF SDE version string (Default: inferred from SDE tar name)
+
+
+Examples:
+
+    $0 ~/bf-sde-9.2.0.tgz
     $0 ~/bf-sde-9.0.0.tgz ~/linux-4.14.49-ONL.tar.xz
+    $0 -s ~/bf-sde-9.2.0.tgz
+    $0 -s ~/bf-sde-9.2.0.tgz -i ~/bf-sde-9.2.0-install.tgz -o
+    $0 -s ~/bf-sde-9.0.0.tgz -k ~/linux-4.14.49-ONL.tar.xz
 
 Additional environment variables:
 
-STRATUM_ROOT: The root directory of Stratum.
-STRATUM_TARGET: stratum_bf or stratum_bfrt
-JOBS: The number of jobs to run simultaneously while building the base container. (Default: 4)
-WITH_ONLP: Includes ONLP support. (Default: true)
+    STRATUM_ROOT: The root directory of Stratum. (Default: stratum directory containing this script)
+    STRATUM_TARGET: stratum_bf or stratum_bfrt (Default: stratum_bf)
+    JOBS: The number of jobs to run simultaneously while building the base container. (Default: 4)
+    WITH_ONLP: Includes ONLP support. (Default: true)
 "
 }
 
@@ -53,7 +70,7 @@ while (( "$#" )); do
         exit 1
       fi
       ;;
-    -k|--kernel-headers)
+    -k|--kernel-headers-tar)
       if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
         KERNEL_HEADERS_TAR=$2
         shift 2
@@ -109,7 +126,14 @@ if [ -n "$2" ]; then
     KERNEL_HEADERS_TAR=$2
 fi
 
+set -e
+
 # ---------- Validate params ----------
+
+if [ -z "$SDE_TAR" ] && [ -z "$SDE_INSTALL_TAR" ]; then
+  echo "You must provide either an BF SDE tar or SDE install tar"
+  exit 1
+fi
 
 # Get tar file names
 SDE_TAR_NAME=$(basename "$SDE_TAR")
@@ -121,29 +145,31 @@ SDE_TAR_VERSION=${SDE_TAR_NAME%.tgz}
 SDE_VERSION=${SDE_VERSION:-$SDE_TAR_VERSION}
 
 # Build BF SDE install tar filename, if not provided
-SDE_INSTALL_TAR_NAME=${SDE_INSTALL_TAR_NAME:-"${SDE_TAR_VERSION}-${STRATUM_TARGET}-install.tgz"}
+SDE_INSTALL_TAR_NAME=${SDE_INSTALL_TAR_NAME:-"${SDE_TAR_VERSION}-install.tgz"}
 SDE_INSTALL_TAR=${SDE_INSTALL_TAR:-$(dirname $SDE_TAR)/$SDE_INSTALL_TAR_NAME}
 
-if [ -z "$SDE_INSTALL_TAR_NAME" ]; then
-  echo "You need to provide a BF SDE archive or a BF SDE install archive"
-  exit 1
-fi
-
 # Infer version from BF SDE install tar filename, if needed
-SDE_INSTALL_TAR_VERSION=${SDE_INSTALL_TAR_NAME%"-${STRATUM_TARGET}-install.tgz"}
+SDE_INSTALL_TAR_VERSION=${SDE_INSTALL_TAR_NAME%"-install.tgz"}
 SDE_VERSION=${SDE_VERSION:-$SDE_INSTALL_TAR_VERSION}
 if [ -z "$SDE_VERSION" ]; then
-  echo "BF SDE could not be inferred, so it must be specified"
+  echo "BF SDE version could not be inferred, so it must be specified"
   exit 1
 fi
 IMG_TAG=${IMG_TAG:-$SDE_VERSION}
 
-# FIXME(bocon)
-#RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}"
-#cp -f "$2" "$STRATUM_ROOT"
+# Print build params
+cat << EOF
+Build params:
+  SDE_TAR: $SDE_TAR
+  SDE_INSTALL_TAR: $SDE_INSTALL_TAR
+  SDE_VERSION: $SDE_VERSION
+  KERNEL_HEADERS_TAR_NAME: $KERNEL_HEADERS_TAR
+  STRATUM_ROOT: $STRATUM_ROOT
+  STRATUM_TARGET: $STRATUM_TARGET
+  JOBS: $JOBS
+  WITH_ONLP: $WITH_ONLP
 
-#FIXME(bocon)
-( set -o posix ; set )
+EOF
 
 # ---------- Build BF-SDE if provided ----------
 if [ -n "$SDE_TAR" ]; then
@@ -153,13 +179,14 @@ Copying BF SDE tarball to $DOCKERFILE_DIR/
 NOTE: Copied tarball will be DELETED after the build
 EOF
 
+  set -x
   cp -f "$SDE_TAR" "$DOCKERFILE_DIR"
   # Build base builder image
   echo "Building $BUILDER_IMAGE"
   docker build -t "$BUILDER_IMAGE" \
     --build-arg JOBS="$JOBS" \
-    --build-arg SDE_TAR="$SDE_TAR_NAME" \
-    --build-arg SDE_INSTALL_TAR="$SDE_INSTALL_TAR_NAME" \
+    --build-arg SDE_TAR_NAME="$SDE_TAR_NAME" \
+    --build-arg SDE_INSTALL_TAR_NAME="$SDE_INSTALL_TAR_NAME" \
     --build-arg STRATUM_TARGET="$STRATUM_TARGET" \
     -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
   # Remove BF SDE tarball
@@ -172,6 +199,7 @@ EOF
     -v $(dirname "$SDE_INSTALL_TAR"):/cp-mnt \
     --entrypoint cp "$BUILDER_IMAGE" \
     /output/"$SDE_INSTALL_TAR_NAME" /cp-mnt/
+  set +x
 else
   echo "No bf-sde tar provided, skipping SDE build..."
 fi
@@ -183,7 +211,7 @@ if [ -z "$SDE_BUILD_ONLY" ]; then
 Copying SDE install and kernel header tarballs to $STRATUM_ROOT/
 NOTE: Copied tarballs will be DELETED after the build
 EOF
-
+  set -x
   RUNTIME_IMG_TAG="$IMG_TAG"
   cp -f "$SDE_INSTALL_TAR" "$STRATUM_ROOT"
   if [ -f "$KERNEL_HEADERS_TAR" ]; then
@@ -197,7 +225,7 @@ EOF
   docker build -t "$RUNTIME_IMAGE" \
     --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
     --build-arg SDE_INSTALL_TAR_NAME="$SDE_INSTALL_TAR_NAME" \
-    --build-arg KERNEL_HEADERS_TAR="$KERNEL_HEADERS_TAR_NAME" \
+    --build-arg KERNEL_HEADERS_TAR_NAME="$KERNEL_HEADERS_TAR_NAME" \
     --build-arg STRATUM_TARGET="$STRATUM_TARGET" \
     --build-arg WITH_ONLP="$WITH_ONLP" \
     -f "$DOCKERFILE_DIR/Dockerfile.runtime" "$STRATUM_ROOT"

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -2,8 +2,9 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 set -xe
-DOCKERFILE_DIR=$(dirname "${BASH_SOURCE[0]}")
+DOCKERFILE_DIR=$( cd $(dirname "${BASH_SOURCE[0]}") >/dev/null 2>&1 && pwd )
 STRATUM_ROOT=${STRATUM_ROOT:-"$( cd "$DOCKERFILE_DIR/../../../../.." >/dev/null 2>&1 && pwd )"}
+STRATUM_TARGET=${STRATUM_TARGET:-stratum_bf}
 JOBS=${JOBS:-4}
 WITH_ONLP=${WITH_ONLP:-true}
 
@@ -16,6 +17,8 @@ Then it runs Bazel build for Stratum code base and copies libraries from builder
 
 Usage: $0 SDE_TAR [KERNEL_HEADERS_TAR]
 
+FIXME(bocon): update usage to include named parameters
+
 Example:
     $0 ~/bf-sde-9.0.0.tgz
     $0 ~/bf-sde-9.0.0.tgz ~/linux-4.14.49-ONL.tar.xz
@@ -23,60 +26,187 @@ Example:
 Additional environment variables:
 
 STRATUM_ROOT: The root directory of Stratum.
+STRATUM_TARGET: stratum_bf or stratum_bfrt
 JOBS: The number of jobs to run simultaneously while building the base container. (Default: 4)
 WITH_ONLP: Includes ONLP support. (Default: true)
 "
 }
 
-SDE_TAR=""
-KERNEL_HEADERS_TAR=""
-RUNTIME_IMG_TAG=""
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    -s|--bf-sde-tar)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        SDE_TAR=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -i|--bf-sde-install-tar)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        SDE_INSTALL_TAR=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -k|--kernel-headers)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        KERNEL_HEADERS_TAR=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -o|--sde-build-only)
+      SDE_BUILD_ONLY=1
+      shift
+      ;;
+    -j|--jobs)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        JOBS=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -v|--sde-version)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        SDE_VERSION=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      print_help
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
 
-if [ "$#" -eq 0 ]; then
-    print_help
-    exit 1
+# Support for legacy positional argument usage
+eval set -- "$PARAMS"
+if [ -n "$1" ]; then
+    SDE_TAR=$1
+fi
+if [ -n "$2" ]; then
+    KERNEL_HEADERS_TAR=$2
 fi
 
-# Copy tarballs to Stratum root
-cat << EOF
-Copying SDE and Kernel header tarballs to $DOCKERFILE_DIR/
+# ---------- Validate params ----------
+
+# Get tar file names
+SDE_TAR_NAME=$(basename "$SDE_TAR")
+SDE_INSTALL_TAR_NAME=$(basename "$SDE_INSTALL_TAR")
+KERNEL_HEADERS_TAR_NAME=$(basename "$KERNEL_HEADERS_TAR")
+
+# Infer version from BF SDE tar filename, if not provided
+SDE_TAR_VERSION=${SDE_TAR_NAME%.tgz}
+SDE_VERSION=${SDE_VERSION:-$SDE_TAR_VERSION}
+
+# Build BF SDE install tar filename, if not provided
+SDE_INSTALL_TAR_NAME=${SDE_INSTALL_TAR_NAME:-"${SDE_TAR_VERSION}-${STRATUM_TARGET}-install.tgz"}
+SDE_INSTALL_TAR=${SDE_INSTALL_TAR:-$(dirname $SDE_TAR)/$SDE_INSTALL_TAR_NAME}
+
+if [ -z "$SDE_INSTALL_TAR_NAME" ]; then
+  echo "You need to provide a BF SDE archive or a BF SDE install archive"
+  exit 1
+fi
+
+# Infer version from BF SDE install tar filename, if needed
+SDE_INSTALL_TAR_VERSION=${SDE_INSTALL_TAR_NAME%"-${STRATUM_TARGET}-install.tgz"}
+SDE_VERSION=${SDE_VERSION:-$SDE_INSTALL_TAR_VERSION}
+if [ -z "$SDE_VERSION" ]; then
+  echo "BF SDE could not be inferred, so it must be specified"
+  exit 1
+fi
+IMG_TAG=${IMG_TAG:-$SDE_VERSION}
+
+# FIXME(bocon)
+#RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}"
+#cp -f "$2" "$STRATUM_ROOT"
+
+#FIXME(bocon)
+( set -o posix ; set )
+
+# ---------- Build BF-SDE if provided ----------
+if [ -n "$SDE_TAR" ]; then
+  BUILDER_IMAGE=stratumproject/$STRATUM_TARGET-builder:$IMG_TAG
+  cat << EOF
+Copying BF SDE tarball to $DOCKERFILE_DIR/
+NOTE: Copied tarball will be DELETED after the build
+EOF
+
+  cp -f "$SDE_TAR" "$DOCKERFILE_DIR"
+  # Build base builder image
+  echo "Building $BUILDER_IMAGE"
+  docker build -t "$BUILDER_IMAGE" \
+    --build-arg JOBS="$JOBS" \
+    --build-arg SDE_TAR="$SDE_TAR_NAME" \
+    --build-arg SDE_INSTALL_TAR="$SDE_INSTALL_TAR_NAME" \
+    --build-arg STRATUM_TARGET="$STRATUM_TARGET" \
+    -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
+  # Remove BF SDE tarball
+  if [ -f "$DOCKERFILE_DIR/$SDE_TAR" ]; then
+    rm -f "$DOCKERFILE_DIR/$SDE_TAR"
+  fi
+
+  # Extract Stratum BF SDE install package
+  docker run --rm \
+    -v $(dirname "$SDE_INSTALL_TAR"):/cp-mnt \
+    --entrypoint cp "$BUILDER_IMAGE" \
+    /output/"$SDE_INSTALL_TAR_NAME" /cp-mnt/
+else
+  echo "No bf-sde tar provided, skipping SDE build..."
+fi
+
+# ---------- Build Stratum ----------
+if [ -z "$SDE_BUILD_ONLY" ]; then
+  # Copy tarballs to Stratum root
+  cat << EOF
+Copying SDE install and kernel header tarballs to $STRATUM_ROOT/
 NOTE: Copied tarballs will be DELETED after the build
 EOF
 
-if [ -n "$1" ]; then
-    SDE_TAR=$(basename $1)
-    IMG_TAG=${SDE_TAR%.tgz}
-    RUNTIME_IMG_TAG="$IMG_TAG"
-    cp -f "$1" "$DOCKERFILE_DIR"
-fi
-if [ -n "$2" ]; then
-    KERNEL_HEADERS_TAR=$(basename $2)
-    RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR%.tar.xz}"
-    cp -f "$2" "$STRATUM_ROOT"
-fi
+  RUNTIME_IMG_TAG="$IMG_TAG"
+  cp -f "$SDE_INSTALL_TAR" "$STRATUM_ROOT"
+  if [ -f "$KERNEL_HEADERS_TAR" ]; then
+    cp -f "$KERNEL_HEADERS_TAR" "$STRATUM_ROOT"
+    RUNTIME_IMG_TAG="$IMG_TAG-${KERNEL_HEADERS_TAR_NAME%.tar.xz}"
+  fi
 
-BUILDER_IMAGE=stratumproject/stratum-bf-builder:$IMG_TAG
-RUNTIME_IMAGE=stratumproject/stratum-bf:$RUNTIME_IMG_TAG
-
-# Build base builder image
-echo "Building $BUILDER_IMAGE"
-docker build -t "$BUILDER_IMAGE" \
-     --build-arg JOBS="$JOBS" \
-     --build-arg SDE_TAR="$SDE_TAR" \
-     -f "$DOCKERFILE_DIR/Dockerfile.builder" "$DOCKERFILE_DIR"
-
-# Build runtime image
-echo "Building $RUNTIME_IMAGE"
-docker build -t "$RUNTIME_IMAGE" \
+  RUNTIME_IMAGE=stratumproject/$STRATUM_TARGET:$RUNTIME_IMG_TAG
+  # Build runtime image
+  echo "Building $RUNTIME_IMAGE"
+  docker build -t "$RUNTIME_IMAGE" \
     --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
-    --build-arg KERNEL_HEADERS_TAR="$KERNEL_HEADERS_TAR" \
+    --build-arg SDE_INSTALL_TAR_NAME="$SDE_INSTALL_TAR_NAME" \
+    --build-arg KERNEL_HEADERS_TAR="$KERNEL_HEADERS_TAR_NAME" \
+    --build-arg STRATUM_TARGET="$STRATUM_TARGET" \
     --build-arg WITH_ONLP="$WITH_ONLP" \
     -f "$DOCKERFILE_DIR/Dockerfile.runtime" "$STRATUM_ROOT"
 
-# Remove copied tarballs
-if [ -f "$DOCKERFILE_DIR/$SDE_TAR" ]; then
-    rm -f "$DOCKERFILE_DIR/$SDE_TAR"
-fi
-if [ -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR" ]; then
-    rm -f "$DOCKERFILE_DIR/$KERNEL_HEADERS_TAR"
+  # Remove copied tarballs
+  if [ -f "$STRATUM_ROOT/$KERNEL_HEADERS_TAR_NAME" ]; then
+    rm -f "$STRATUM_ROOT/$KERNEL_HEADERS_TAR_NAME"
+  fi
+  if [ -f "$STRATUM_ROOT/$SDE_INSTALL_TAR_NAME" ]; then
+      rm -f "$STRATUM_ROOT/$SDE_INSTALL_TAR_NAME"
+  fi
 fi

--- a/stratum/hal/lib/barefoot/barefoot.bzl
+++ b/stratum/hal/lib/barefoot/barefoot.bzl
@@ -2,19 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This Starlark rule imports the BF SDE shared libraries and headers. The
-# SDE_INSTALL environment variable needs to be set, otherwise the Stratum
-# rules for barefoot platforms cannot be built.
+# SDE_INSTALL or SDE_INSTALL_TAR environment variable needs to be set,
+# otherwise the Stratum rules for barefoot platforms cannot be built.
 
 def _impl(repository_ctx):
-    if "SDE_INSTALL" not in repository_ctx.os.environ:
+    if ( "SDE_INSTALL" not in repository_ctx.os.environ and
+         "SDE_INSTALL_TAR" not in repository_ctx.os.environ ):
+        print("SDE_INSTALL_TAR is not defined")
         repository_ctx.file("BUILD", "")
         return
-    bf_sde_path = repository_ctx.os.environ["SDE_INSTALL"]
-    repository_ctx.symlink(bf_sde_path, "barefoot-bin")
+    local_install_path = "barefoot-bin"
+    if "SDE_INSTALL_TAR" in repository_ctx.os.environ:
+        bf_sde_install_tar_path = repository_ctx.os.environ["SDE_INSTALL_TAR"]
+        repository_ctx.extract(bf_sde_install_tar_path, local_install_path)
+    elif "SDE_INSTALL" in repository_ctx.os.environ:
+        print("SDE_INSTALL is deprecated, please use SDE_INSTALL_TAR")
+        bf_sde_install_path = repository_ctx.os.environ["SDE_INSTALL"]
+        repository_ctx.symlink(bf_sde_install_path, local_install_path)
     repository_ctx.symlink(Label("@//bazel:external/bfsde.BUILD"), "BUILD")
 
 barefoot_configure = repository_rule(
     implementation = _impl,
     local = True,
-    environ = ["SDE_INSTALL"],
+    environ = ["SDE_INSTALL", "SDE_INSTALL_TAR"],
 )


### PR DESCRIPTION
Add support for a new tar format for building stratum_bf.
The old SDE_INSTALL way is still supported, but now deprecated.

supersedes #290 

TODO
- [ ] address FIXMEs
- [ ] update README to introduce new tar format
