### PR TITLE
Add support for BFRuntime gRPC server in stratum_bf

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load(
+     "@rules_cc//cc:defs.bzl",
+     "cc_library",
+     "cc_proto_library"
+)
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(
@@ -28,15 +34,77 @@ cc_library(
         "barefoot-bin/include/mc_mgr/*.h",
         "barefoot-bin/include/port_mgr/*.h",
         "barefoot-bin/include/pipe_mgr/*.h",
+        "barefoot-bin/include/traffic_mgr/*.h",
         "barefoot-bin/include/tofino/bf_pal/*.h",
         "barefoot-bin/include/tofino/pdfixed/*.h",
     ]),
-    includes = ["barefoot-bin/include"],
+    strip_include_prefix = "barefoot-bin/include",
     linkopts = [
         "-lpthread",
         "-lm",
         "-ldl",
     ],
+)
+
+cc_library(
+    name = "bfruntime_server_h",
+    hdrs = glob([
+        "barefoot-bin/include/bf_rt/proto/*.h",
+    ]),
+    strip_include_prefix = "barefoot-bin/include",
+)
+
+cc_library(
+    name = "bfruntime_common",
+    hdrs = glob([
+        "barefoot-bin/src/bf_rt/bf_rt_common/*.hpp",
+    ]),
+    strip_include_prefix = "barefoot-bin/src/bf_rt",
+    deps = [
+        ":bfsde",
+    ],
+)
+
+cc_library(
+    name = "bfruntime_server",
+    srcs = glob([
+        "barefoot-bin/src/bf_rt/proto/*.cpp",
+    ]),
+    hdrs = glob([
+        "barefoot-bin/src/bf_rt/proto/*.hpp",
+    ]),
+    deps = [
+        ":bfsde",
+        ":bfruntime_cc_proto",
+        ":bfruntime_cc_grpc",
+        ":bfruntime_common",
+        ":bfruntime_server_h",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
+        "@com_google_googleapis//google/rpc:status_cc_proto",
+    ],
+    includes = [
+        "barefoot-bin/src/bf_rt",
+        "barefoot-bin/src/bf_rt/proto",
+    ],
+)
+
+proto_library(
+    name = "bfruntime_proto",
+    srcs = ["barefoot-bin/src/bf_rt/proto/bfruntime.proto"],
+    deps = ["@com_google_googleapis//google/rpc:status_proto"],
+)
+
+cc_proto_library(
+    name = "bfruntime_cc_proto",
+    deps = [":bfruntime_proto"],
+)
+
+cc_grpc_library(
+    name = "bfruntime_cc_grpc",
+    grpc_only = True,
+    srcs = [":bfruntime_proto"],
+    deps = [":bfruntime_cc_proto"],
 )
 
 pkg_tar(
@@ -55,10 +123,11 @@ pkg_tar(
 
 pkg_tar_with_symlinks(
     name = "bf_shareable_files",
-    srcs = glob(["barefoot-bin/share/microp_fw/**"]) + glob([
+    srcs = glob([
+        "barefoot-bin/share/microp_fw/**",
         "barefoot-bin/share/bfsys/**",
-    ]) + glob([
         "barefoot-bin/share/tofino_sds_fw/**",
+        "barefoot-bin/share/bf_rt_shared/**",
     ]),
     mode = "0644",
     package_dir = "/usr",

--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -45,6 +45,7 @@ stratum_cc_binary(
         "//stratum/hal/lib/barefoot:bf_pal_wrapper",
         "//stratum/hal/lib/barefoot:bf_pd_wrapper",
         "//stratum/hal/lib/barefoot:bf_switch",
+        "//stratum/hal/lib/barefoot:bfrt_grpc_server",
         "//stratum/hal/lib/common:hal",
         "//stratum/hal/lib/phal",
         "//stratum/hal/lib/phal:phal_sim",

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.builder
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.builder
@@ -27,11 +27,11 @@ RUN mkdir $SDE && tar xf /stratum/$SDE_TAR -C $SDE --strip-components 1
 # TODO: Remove this once we moved to Python3
 RUN pip install pyrsistent==0.14.0
 
-WORKDIR $SDE/p4studio_build
 
+# Update SDE profile and build
+COPY stratum_profile.yaml $SDE/p4studio_build/profiles/
+WORKDIR $SDE/p4studio_build
 ARG JOBS=4
-# Remove Thrift dependency from the profile (for SDE <= 8.9.x)
-RUN sed -i.bak '/package_dependencies/d; /thrift/d' profiles/stratum_profile.yaml
 RUN ./p4studio_build.py -up stratum_profile -wk -j$JOBS -shc && \
     rm -rf /var/lib/apt/lists/*
 

--- a/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile.runtime
@@ -17,6 +17,7 @@ WORKDIR ${SDE_INSTALL}
 RUN tar xf ${SDE_INSTALL_TAR}
 
 # Build Barefoot Kernel module if needed
+# FIXME(bocon): This is currently broken because we use the tar to build Stratum
 WORKDIR /stratum
 ARG KERNEL_HEADERS_TAR
 ENV KERNEL_HEADERS_PATH=/usr/src/kernel-headers

--- a/stratum/hal/bin/barefoot/docker/stratum_profile.yaml
+++ b/stratum/hal/bin/barefoot/docker/stratum_profile.yaml
@@ -1,0 +1,19 @@
+# SDE_VERSION : 9.2.0
+
+stratum_bf_profile:
+  # Global flags to configure
+  global_configure_options: ''
+
+  # SDE components to be installed
+  packages:
+    - bf-syslibs:
+      - bf_syslibs_configure_options: ''
+    - bf-utils:
+      - bf_utils_configure_options: ''
+    - bf-drivers:
+      - bf_drivers_configure_options: ''
+      - pi
+      - bf-runtime
+
+  # Tofino architecture
+  tofino_architecture: tofino

--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -21,6 +21,7 @@ int switch_pci_sysfs_str_get(char *name, size_t name_size);
 #include "stratum/hal/lib/barefoot/bf_pal_wrapper.h"
 #include "stratum/hal/lib/barefoot/bf_pd_wrapper.h"
 #include "stratum/hal/lib/barefoot/bf_switch.h"
+#include "stratum/hal/lib/barefoot/bfrt_grpc_server.h"
 #include "stratum/lib/security/auth_policy_checker.h"
 #include "stratum/lib/security/credentials_manager.h"
 
@@ -167,6 +168,8 @@ void registerDeviceMgrLogger() {
         << "Error when setting up Stratum HAL (but we will continue running): "
         << status.error_message();
   }
+
+  start_bfrt_server_if_enabled();
 
   RETURN_IF_ERROR(hal->Run());  // blocking
   LOG(INFO) << "See you later!";

--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -229,3 +229,45 @@ cc_proto_library(
     name = "bf_cc_proto",
     deps = [":bf_proto"],
 )
+
+config_setting(
+    name = "with_bfrt_grpc_server",
+    define_values = {"with_bfrt_grpc_server": "true"},
+)
+
+stratum_cc_library(
+    name = "bfrt_grpc_server",
+    hdrs = ["bfrt_grpc_server.h"],
+    deps = [
+        "//stratum/glue:logging",
+        "@com_github_gflags_gflags//:gflags",
+    ] + select({
+        "with_bfrt_grpc_server": [
+            "@com_google_absl//absl/memory",
+            "@local_barefoot_bin//:bfsde",
+            "@local_barefoot_bin//:bfruntime_grpc_server",
+        ],
+	"//conditions:default": [],
+    }),
+    defines = select({
+        "with_bfrt_grpc_server": ["WITH_BFRT_GRPC_SERVER"],
+	"//conditions:default": [],
+    }),
+)
+
+stratum_cc_test(
+    name = "bfrt_grpc_server_test",
+    srcs = [
+        "bfrt_grpc_server_test.cc",
+    ],
+    deps = [
+        ":bfrt_grpc_server",
+        "//stratum/glue/net_util:ports",
+        "@com_google_googletest//:gtest_main",
+    ],
+    defines = select({
+        "with_bfrt_grpc_server": ["WITH_BFRT_GRPC_SERVER"],
+	"//conditions:default": [],
+    }),
+)
+

--- a/stratum/hal/lib/barefoot/bfrt_grpc_server.h
+++ b/stratum/hal/lib/barefoot/bfrt_grpc_server.h
@@ -1,0 +1,48 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright (c) 2018-2019 Barefoot Networks, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_BAREFOOT_BFRT_GRPC_SERVER_H_
+#define STRATUM_HAL_LIB_BAREFOOT_BFRT_GRPC_SERVER_H_
+
+#include "gflags/gflags.h"
+#include "stratum/glue/logging.h"
+
+#ifdef WITH_BFRT_GRPC_SERVER
+#include "absl/memory/memory.h"
+// TODO(bocon): try to fix the include path for bf_rt
+#include "bf_rt_server_impl.hpp"
+#endif  // WITH_BFRT_GRPC_SERVER
+
+DEFINE_bool(incompatible_enable_bfrt_grpc_server, false,
+            "Enables the BFRuntime server");
+
+DEFINE_string(incompatible_bfrt_grpc_server_addr, "127.0.0.1:50052",
+              "Listening address for BFRuntime server");
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+inline void start_bfrt_server_if_enabled() {
+  if (FLAGS_incompatible_enable_bfrt_grpc_server) {
+#ifdef WITH_BFRT_GRPC_SERVER
+    auto server_data = absl::make_unique<bfrt::server::ServerData>(
+        "Stratum BFRuntime gRPC Server",
+	FLAGS_incompatible_bfrt_grpc_server_addr);
+    bfrt::server::BfRtServer::getInstance(std::move(server_data));
+    LOG(INFO) << "Started BFRuntime gRPC server on "
+        << FLAGS_incompatible_bfrt_grpc_server_addr;
+#else
+    LOG(ERROR) << "Tried to enable BFRuntime server, but it was not compiled.\n"
+        << "  Recompile Stratum with: --define with_bfrt_grpc_server=true";
+#endif  // WITH_BFRT_GRPC_SERVER
+  }
+}
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_BAREFOOT_BFRT_GRPC_SERVER_H_
+

--- a/stratum/hal/lib/barefoot/bfrt_grpc_server_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_grpc_server_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for bfrt_server.
+
+#include "gflags/gflags.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/net_util/ports.h"
+#include "stratum/hal/lib/barefoot/bfrt_grpc_server.h"
+
+#ifdef WITH_BFRT_GRPC_SERVER
+// TODO(bocon): try to fix the include path for bf_rt
+#include "bfruntime.grpc.pb.h"
+#endif  // WITH_BFRT_GRPC_SERVER
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+TEST(BfrtServerTest, BfrtServerStart) {
+  ::gflags::FlagSaver flag_saver_;
+  FLAGS_incompatible_enable_bfrt_grpc_server = true;
+  std::string url = "127.0.0.1:" +
+      std::to_string(stratum::PickUnusedPortOrDie());
+  FLAGS_incompatible_bfrt_grpc_server_addr = url;
+
+  start_bfrt_server_if_enabled();
+
+#ifdef WITH_BFRT_GRPC_SERVER
+  auto stub = ::bfrt_proto::BfRuntime::NewStub(
+      ::grpc::CreateChannel(url, ::grpc::InsecureChannelCredentials()));
+  ASSERT_NE(stub, nullptr);
+
+  ::grpc::ClientContext ctx;
+  ::grpc::Status status;
+  ::bfrt_proto::GetForwardingPipelineConfigRequest req;
+  ::bfrt_proto::GetForwardingPipelineConfigResponse resp;
+  status = stub->GetForwardingPipelineConfig(&ctx, req, &resp);
+
+  EXPECT_EQ(status.error_code(),
+            ::bfrt::server::to_grpc_status(BF_NOT_READY, "").error_code());
+#else
+  ASSERT_TRUE(false) << "Recompile with: --define with_bfrt_grpc_server=true";
+#endif  // WITH_BFRT_GRPC_SERVER
+}
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum


### PR DESCRIPTION
Test with: 
```bash
SDE_INSTALL_TAR=/stratum/bf-sde-9.2.0-stratum_bfrt-install.tgz \
bazel test --define with_bfrt_grpc_server=true \
--test_env LD_LIBRARY_PATH=$(bazel info | grep execution_root | sed 's/execution_root: //')/external/local_barefoot_bin/barefoot-bin/lib \
//stratum/hal/lib/barefoot:bfrt_server_test
```

TODO:
- [ ] fix kmod build issue
- [ ] update README with build, run, and test instructions