### PR TITLE
Remove xz compression from supported tar formats

### DIFF
--- a/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
@@ -32,7 +32,6 @@ bool IsArchive(const std::string& archive) {
   auto cleanup = gtl::MakeCleanup([&a]() { archive_read_free(a); });
   archive_read_support_filter_bzip2(a);
   archive_read_support_filter_gzip(a);
-  archive_read_support_filter_xz(a);
   archive_read_support_format_tar(a);
   int r = archive_read_open_memory(a, archive.c_str(), archive.size());
   return r == ARCHIVE_OK;
@@ -46,7 +45,6 @@ bool IsArchive(const std::string& archive) {
   auto cleanup = gtl::MakeCleanup([&a]() { archive_read_free(a); });
   archive_read_support_filter_bzip2(a);
   archive_read_support_filter_gzip(a);
-  archive_read_support_filter_xz(a);
   archive_read_support_format_tar(a);
   int r = archive_read_open_memory(a, archive.c_str(), archive.size());
   CHECK_RETURN_IF_FALSE(r == ARCHIVE_OK) << "Failed to read archive";


### PR DESCRIPTION
This PR removes xz compression from the possible tar formats of the BF pipeline.
xz would need additional dependencies inside the build docker image. Considering tar will go away soon, we have decided to remove xz instead. No documentation updates needed, as xz was never mentioned anywhere.