### PR TITLE
Remove libavago, libpython3.4m from direct bfsde link targets

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -12,12 +12,10 @@ package(
 cc_library(
     name = "bfsde",
     srcs = glob([
-        "barefoot-bin/lib/libavago.so*",
         "barefoot-bin/lib/libbf_switchd_lib.so*",
         "barefoot-bin/lib/libbfsys.so*",
         "barefoot-bin/lib/libbfutils.so*",
         "barefoot-bin/lib/libdriver.so*",
-        "barefoot-bin/lib/libpython3.4m.so*",
     ]),
     hdrs = glob([
         "barefoot-bin/include/bf_switchd/*.h",


### PR DESCRIPTION
They are needed as a shared lib at runtime by the SDE, but not when compiling Stratum code.
Linking libavago causes linker errors around missing symbols and mismatched libstdc++ versions.