### PR TITLE
Experimental: Add BFRuntime gRPC server to stratum_bfrt

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_library",
+    "cc_proto_library",
+)
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(
@@ -32,6 +38,7 @@ cc_library(
         "barefoot-bin/include/pipe_mgr/*.h",
         "barefoot-bin/include/pkt_mgr/*.h",
         "barefoot-bin/include/port_mgr/*.h",
+        "barefoot-bin/include/traffic_mgr/*.h",
         "barefoot-bin/include/tofino/bf_pal/*.h",
         "barefoot-bin/include/tofino/pdfixed/*.h",
     ]),
@@ -47,6 +54,72 @@ cc_library(
         "-ldl",
     ],
     strip_include_prefix = "barefoot-bin/include",
+)
+
+cc_library(
+    name = "bfruntime_server_h",
+    hdrs = glob([
+        "barefoot-bin/include/bf_rt/**/*.h",
+        "barefoot-bin/include/bf_rt/**/*.hpp",
+        "barefoot-bin/include/bf_rt/proto/bf_rt_server.h",
+    ]),
+    strip_include_prefix = "barefoot-bin/include",
+)
+
+cc_library(
+    name = "bfruntime_common",
+    hdrs = glob([
+        "barefoot-bin/src/bf_rt/bf_rt_common/*.hpp",
+    ]),
+    strip_include_prefix = "barefoot-bin/src/bf_rt",
+    deps = [
+        ":bfsde",
+    ],
+)
+
+cc_library(
+    name = "bfruntime_grpc_server",
+    srcs = glob([
+        "barefoot-bin/src/bf_rt/proto/*.cpp",
+    ]),
+    hdrs = glob([
+        "barefoot-bin/src/bf_rt/proto/*.hpp",
+    ]),
+    # TODO(bocon): These can be elimated by fixing build rules
+    includes = [
+        "barefoot-bin/src/bf_rt",
+        "barefoot-bin/src/bf_rt/proto",
+    ],
+    deps = [
+        ":bfruntime_cc_grpc",
+        ":bfruntime_cc_proto",
+        ":bfruntime_common",
+        ":bfruntime_server_h",
+        ":bfsde",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
+        "@com_google_googleapis//google/rpc:status_cc_proto",
+    ],
+)
+
+proto_library(
+    name = "bfruntime_proto",
+    srcs = ["barefoot-bin/src/bf_rt/proto/bfruntime.proto"],
+    # TODO(bocon): there's a bug in the cc_grpc_library rule that doesn't like this
+    #strip_import_prefix = "barefoot-bin/src",
+    deps = ["@com_google_googleapis//google/rpc:status_proto"],
+)
+
+cc_proto_library(
+    name = "bfruntime_cc_proto",
+    deps = [":bfruntime_proto"],
+)
+
+cc_grpc_library(
+    name = "bfruntime_cc_grpc",
+    srcs = [":bfruntime_proto"],
+    grpc_only = True,
+    deps = [":bfruntime_cc_proto"],
 )
 
 pkg_tar_with_symlinks(
@@ -70,7 +143,6 @@ pkg_tar_with_symlinks(
         "barefoot-bin/share/microp_fw/**",
         "barefoot-bin/share/bfsys/**",
         "barefoot-bin/share/tofino_sds_fw/**",
-    ]) + glob([
         "barefoot-bin/share/bf_rt_shared/**",
     ]),
     mode = "0644",

--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -50,6 +50,7 @@ stratum_cc_binary(
         "tofino_skip_p4_no_bsp.conf",
     ],
     deps = [
+        "//stratum/hal/lib/barefoot:bfrt_grpc_server",
         "//stratum/hal/lib/barefoot:bf_chassis_manager",
         "//stratum/hal/lib/barefoot:bf_pal_wrapper",
         "//stratum/hal/lib/barefoot:bf_pd_wrapper",

--- a/stratum/hal/bin/barefoot/README.build.md
+++ b/stratum/hal/bin/barefoot/README.build.md
@@ -263,6 +263,29 @@ Method 2:
 export WITH_ONLP=false
 ```
 
+### BFRuntime gRPC Server Support
+
+Stratum is designed to use P4Runtime and gNMI as the primary interfaces for
+programming and configuring the Tofino ASIC. However, if you need to use
+BFRuntime directly, you can compile Stratum with the
+`--define with_bfrt_grpc_server=true` flag which links the BFRuntime gRPC
+server into the Stratum binary.
+
+*Note: Even though the code is linked into the binary, it needs to be enabled
+at runtime with a special flag.
+See [the runtime guide](./README.run.md#running-the-bfruntime-grpc-server)
+for more details.*
+
+If you are having trouble building with the option, you may not have built
+you BF SDE correctly (e.g. without the `bf-runtime` option in `bf-drivers`).
+You can test to make sure the BFRuntime gRPC server is linked properly using:
+
+```bash
+bazel test \
+--define with_bfrt_grpc_server=true \
+//stratum/hal/lib/barefoot:bfrt_grpc_server_test
+```
+
 -----
 
 ## BF SDE Build Options

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -249,6 +249,29 @@ will configure device port 132 in 100G mode with Reed-Solomon (RS) FEC.
 
 FEC can also be configured when adding a port through gNMI.
 
+
+### Running the BFRuntime gRPC Server
+
+You can enable the BFRuntime gRPC server on compatible binaries by passing the
+`-incompatible_enable_bfrt_grpc_server` flag when starting Stratum.
+
+By default, the server listens for local connections on TCP port 50052. You can
+customize this with the `-incompatible_bfrt_grpc_server_addr` flag`.
+For example to listen to all connection on TCP port 12345, use:
+
+```bash
+start-stratum.sh \
+-incompatible_enable_bfrt_grpc_server \
+-incompatible_bfrt_grpc_server_addr=0.0.0.0:12345
+```
+
+*Note: If you see an error
+(`"Tried to enable BFRuntime gRPC server, but it was not compiled."`),
+then Stratum was not compiled with support for the BFRuntime gRPC server.
+See [the build guide](./README.build.md#bfruntime-grpc-server-support)
+for more details.*
+
+
 -----
 
 ## Troubleshooting

--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -21,6 +21,7 @@ int switch_pci_sysfs_str_get(char *name, size_t name_size);
 #include "stratum/hal/lib/barefoot/bf_pal_wrapper.h"
 #include "stratum/hal/lib/barefoot/bf_pd_wrapper.h"
 #include "stratum/hal/lib/barefoot/bf_switch.h"
+#include "stratum/hal/lib/barefoot/bfrt_grpc_server.h"
 #include "stratum/lib/security/auth_policy_checker.h"
 #include "stratum/lib/security/credentials_manager.h"
 
@@ -167,6 +168,8 @@ void registerDeviceMgrLogger() {
         << "Error when setting up Stratum HAL (but we will continue running): "
         << status.error_message();
   }
+
+  StartBfRtServerIfEnabled();
 
   RETURN_IF_ERROR(hal->Run());  // blocking
   LOG(INFO) << "See you later!";

--- a/stratum/hal/bin/barefoot/main_bfrt.cc
+++ b/stratum/hal/bin/barefoot/main_bfrt.cc
@@ -20,6 +20,7 @@ int switch_pci_sysfs_str_get(char* name, size_t name_size);
 #include "stratum/hal/lib/barefoot/bfrt_node.h"
 #include "stratum/hal/lib/barefoot/bfrt_pre_manager.h"
 #include "stratum/hal/lib/barefoot/bfrt_switch.h"
+#include "stratum/hal/lib/barefoot/bfrt_grpc_server.h"
 #include "stratum/hal/lib/barefoot/bfrt_table_manager.h"
 #include "stratum/hal/lib/common/hal.h"
 #include "stratum/hal/lib/phal/phal.h"
@@ -138,6 +139,8 @@ namespace barefoot {
         << "Error when setting up Stratum HAL (but we will continue running): "
         << status.error_message();
   }
+
+  StartBfRtServerIfEnabled();
 
   RETURN_IF_ERROR(hal->Run());  // blocking
   LOG(INFO) << "See you later!";

--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -521,3 +521,44 @@ stratum_cc_test(
         "@local_barefoot_bin//:bfsde",
     ],
 )
+
+config_setting(
+    name = "with_bfrt_grpc_server",
+    define_values = {"with_bfrt_grpc_server": "true"},
+)
+
+stratum_cc_library(
+    name = "bfrt_grpc_server",
+    hdrs = ["bfrt_grpc_server.h"],
+    srcs = ["bfrt_grpc_server.cc"],
+    deps = [
+        "//stratum/glue:logging",
+        "@com_github_gflags_gflags//:gflags",
+    ] + select({
+        "with_bfrt_grpc_server": [
+            "@com_google_absl//absl/memory",
+            "@local_barefoot_bin//:bfsde",
+            "@local_barefoot_bin//:bfruntime_grpc_server",
+        ],
+        "//conditions:default": [],
+    }),
+    defines = select({
+        "with_bfrt_grpc_server": ["WITH_BFRT_GRPC_SERVER"],
+	    "//conditions:default": [],
+    }),
+)
+
+stratum_cc_test(
+    name = "bfrt_grpc_server_test",
+    srcs = [
+        "bfrt_grpc_server_test.cc",
+    ],
+    deps = [
+        ":bfrt_grpc_server",
+        "//stratum/glue/net_util:ports",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+

--- a/stratum/hal/lib/barefoot/bfrt_grpc_server.cc
+++ b/stratum/hal/lib/barefoot/bfrt_grpc_server.cc
@@ -1,0 +1,46 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright (c) 2018-2019 Barefoot Networks, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/barefoot/bfrt_grpc_server.h"
+
+#include "gflags/gflags.h"
+#include "stratum/glue/logging.h"
+
+#ifdef WITH_BFRT_GRPC_SERVER
+#include <utility>
+#include "absl/memory/memory.h"
+// TODO(bocon): try to fix the include path for bf_rt
+#include "proto/bf_rt_server_impl.hpp"
+#endif  // WITH_BFRT_GRPC_SERVER
+
+DEFINE_bool(incompatible_enable_bfrt_grpc_server, false,
+            "Enables the BFRuntime gRPC server");
+
+DEFINE_string(incompatible_bfrt_grpc_server_addr, "127.0.0.1:50052",
+              "Listening address for BFRuntime gRPC server");
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+void StartBfRtServerIfEnabled() {
+  if (FLAGS_incompatible_enable_bfrt_grpc_server) {
+#ifdef WITH_BFRT_GRPC_SERVER
+    auto server_data = absl::make_unique<bfrt::server::ServerData>(
+        "Stratum BFRuntime gRPC Server",
+        FLAGS_incompatible_bfrt_grpc_server_addr);
+    bfrt::server::BfRtServer::getInstance(std::move(server_data));
+    LOG(INFO) << "Started BFRuntime gRPC server on "
+        << FLAGS_incompatible_bfrt_grpc_server_addr;
+#else
+    LOG(ERROR)
+        << "Tried to enable BFRuntime gRPC server, but it was not compiled.\n"
+        << "  Recompile Stratum with: --define with_bfrt_grpc_server=true";
+#endif  // WITH_BFRT_GRPC_SERVER
+  }
+}
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/barefoot/bfrt_grpc_server.h
+++ b/stratum/hal/lib/barefoot/bfrt_grpc_server.h
@@ -1,0 +1,18 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright (c) 2018-2019 Barefoot Networks, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_BAREFOOT_BFRT_GRPC_SERVER_H_
+#define STRATUM_HAL_LIB_BAREFOOT_BFRT_GRPC_SERVER_H_
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+void StartBfRtServerIfEnabled();
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_BAREFOOT_BFRT_GRPC_SERVER_H_

--- a/stratum/hal/lib/barefoot/bfrt_grpc_server_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_grpc_server_test.cc
@@ -1,0 +1,56 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for bfrt_server.
+
+#include <string>
+
+#include "gflags/gflags.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/net_util/ports.h"
+#include "stratum/hal/lib/barefoot/bfrt_grpc_server.h"
+
+#ifdef WITH_BFRT_GRPC_SERVER
+// TODO(bocon): try to fix the include path for bf_rt
+#include "proto/bfruntime.grpc.pb.h"
+#include "proto/bf_rt_server_impl.hpp"
+#endif  // WITH_BFRT_GRPC_SERVER
+
+DECLARE_bool(incompatible_enable_bfrt_grpc_server);
+DECLARE_string(incompatible_bfrt_grpc_server_addr);
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+TEST(BfrtServerTest, BfrtServerStart) {
+  ::gflags::FlagSaver flag_saver_;
+  FLAGS_incompatible_enable_bfrt_grpc_server = true;
+  std::string url = "127.0.0.1:" +
+      std::to_string(stratum::PickUnusedPortOrDie());
+  FLAGS_incompatible_bfrt_grpc_server_addr = url;
+
+  StartBfRtServerIfEnabled();
+
+#ifdef WITH_BFRT_GRPC_SERVER
+  auto stub = ::bfrt_proto::BfRuntime::NewStub(
+      ::grpc::CreateChannel(url, ::grpc::InsecureChannelCredentials()));
+  ASSERT_NE(stub, nullptr);
+
+  ::grpc::ClientContext ctx;
+  ::grpc::Status status;
+  ::bfrt_proto::GetForwardingPipelineConfigRequest req;
+  ::bfrt_proto::GetForwardingPipelineConfigResponse resp;
+  status = stub->GetForwardingPipelineConfig(&ctx, req, &resp);
+
+  EXPECT_EQ(status.error_code(),
+            ::bfrt::server::to_grpc_status(BF_NOT_READY, "").error_code());
+#else
+  ASSERT_TRUE(false) << "Recompile with: --define with_bfrt_grpc_server=true";
+#endif  // WITH_BFRT_GRPC_SERVER
+}
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum


### PR DESCRIPTION
**This is currently an experiment that builds on #388.**

You can make sure that your SDE_INSTALL directory is set up properly with:
```
SDE_INSTALL_TAR=/stratum/bf-sde-9.2.0-install.tgz \
bazel test \
--define with_bfrt_grpc_server=true \
//stratum/hal/lib/barefoot:bfrt_grpc_server_test
```

To enable the BFRuntime server, you need to build `stratum_bfrt` with `--define with_bfrt_grpc_server=true`