### PR TITLE
Remove the bazel bash completed

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,8 +11,7 @@ ARG GIT_GLOBAL_EDITOR=vim
 
 RUN useradd -ms /bin/bash -l -u $USER_ID $USER_NAME && \
     adduser $USER_NAME sudo && \
-    echo "%sudo ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers && \
-    echo "source /usr/local/lib/bazel/bin/bazel-complete.bash" >> /home/$USER_NAME/.bashrc
+    echo "%sudo ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers
 
 USER $USER_NAME
 


### PR DESCRIPTION
The current Bazelist doesn't support install the `bazel-complete.bash` automatically.
Remove it from the `.bashrc` until it supports

Reference: https://github.com/bazelbuild/bazelisk/issues/29