### PR TITLE
Backport BF macros and update calls in bf_pal_wrapper

### DIFF
--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -124,6 +124,7 @@ stratum_cc_library(
     hdrs = ["bf_pal_wrapper.h"],
     deps = [
         ":bf_pal_interface",
+        ":macros",
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",
         "//stratum/glue/status",
@@ -227,4 +228,13 @@ proto_library(
 cc_proto_library(
     name = "bf_cc_proto",
     deps = [":bf_proto"],
+)
+
+stratum_cc_library(
+    name = "macros",
+    hdrs = ["macros.h"],
+    deps = [
+        "//stratum/lib:macros",
+        "@local_barefoot_bin//:bfsde",
+    ],
 )

--- a/stratum/hal/lib/barefoot/bf_pal_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_pal_wrapper.cc
@@ -239,10 +239,10 @@ bool BFPalWrapper::PortIsValid(int unit, uint32 port_id) {
     return ::util::OkStatus();
   }
   ASSIGN_OR_RETURN(bf_loopback_mode_e lp_mode, LoopbackModeToBf(loopback_mode));
-
   RETURN_IF_BFRT_ERROR(bf_pal_port_loopback_mode_set(
       static_cast<bf_dev_id_t>(unit), static_cast<bf_dev_port_t>(port_id),
       lp_mode));
+
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/barefoot/bf_pal_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_pal_wrapper.cc
@@ -16,6 +16,7 @@ extern "C" {
 #include "stratum/glue/logging.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/barefoot/macros.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/lib/channel/channel.h"
 #include "stratum/lib/constants.h"
@@ -30,25 +31,18 @@ constexpr int32 BFPalWrapper::kDefaultMtu;
 ::util::StatusOr<PortState> BFPalWrapper::PortOperStateGet(int unit,
                                                            uint32 port_id) {
   int state;
-  auto bf_status =
+  RETURN_IF_BFRT_ERROR(
       bf_pal_port_oper_state_get(static_cast<bf_dev_id_t>(unit),
-                                 static_cast<bf_dev_port_t>(port_id), &state);
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Error when querying port oper status";
-  }
+                                 static_cast<bf_dev_port_t>(port_id), &state));
   return state ? PORT_STATE_UP : PORT_STATE_DOWN;
 }
 
 ::util::Status BFPalWrapper::PortAllStatsGet(int unit, uint32 port_id,
                                              PortCounters* counters) {
   uint64_t stats[BF_NUM_RMON_COUNTERS];
-  auto bf_status =
+  RETURN_IF_BFRT_ERROR(
       bf_pal_port_all_stats_get(static_cast<bf_dev_id_t>(unit),
-                                static_cast<bf_dev_port_t>(port_id), stats);
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Error when querying counters for port "
-                                    << port_id << " in unit " << unit;
-  }
+                                static_cast<bf_dev_port_t>(port_id), stats));
   counters->set_in_octets(stats[bf_mac_stat_OctetsReceived]);
   counters->set_out_octets(stats[bf_mac_stat_OctetsTransmittedTotal]);
   counters->set_in_unicast_pkts(
@@ -100,12 +94,8 @@ bf_status_t PortStatusChangeCbInternal(bf_dev_id_t dev_id,
     std::unique_ptr<ChannelWriter<PortStatusChangeEvent> > writer) {
   absl::WriterMutexLock l(&port_status_change_event_writer_lock_);
   port_status_change_event_writer_ = std::move(writer);
-  auto bf_status =
-      bf_pal_port_status_notif_reg(PortStatusChangeCbInternal, this);
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL)
-           << "Error when registering port status notification callback";
-  }
+  RETURN_IF_BFRT_ERROR(
+      bf_pal_port_status_notif_reg(PortStatusChangeCbInternal, this));
   return ::util::OkStatus();
 }
 
@@ -194,52 +184,36 @@ namespace {
                                      FecMode fec_mode) {
   ASSIGN_OR_RETURN(auto bf_speed, PortSpeedHalToBf(speed_bps));
   ASSIGN_OR_RETURN(auto bf_fec_mode, FecModeHalToBf(fec_mode, speed_bps));
-  auto bf_status = bf_pal_port_add(static_cast<bf_dev_id_t>(unit),
-                                   static_cast<bf_dev_port_t>(port_id),
-                                   bf_speed, bf_fec_mode);
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Error when adding port with BF_PAL.";
-  }
+  RETURN_IF_BFRT_ERROR(bf_pal_port_add(static_cast<bf_dev_id_t>(unit),
+                                       static_cast<bf_dev_port_t>(port_id),
+                                       bf_speed, bf_fec_mode));
   return ::util::OkStatus();
 }
 
 ::util::Status BFPalWrapper::PortDelete(int unit, uint32 port_id) {
-  auto bf_status = bf_pal_port_del(static_cast<bf_dev_id_t>(unit),
-                                   static_cast<bf_dev_port_t>(port_id));
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Error when deleting port with BF_PAL.";
-  }
+  RETURN_IF_BFRT_ERROR(bf_pal_port_del(static_cast<bf_dev_id_t>(unit),
+                                       static_cast<bf_dev_port_t>(port_id)));
   return ::util::OkStatus();
 }
 
 ::util::Status BFPalWrapper::PortEnable(int unit, uint32 port_id) {
-  auto bf_status = bf_pal_port_enable(static_cast<bf_dev_id_t>(unit),
-                                      static_cast<bf_dev_port_t>(port_id));
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Error when enabling port with BF_PAL.";
-  }
+  RETURN_IF_BFRT_ERROR(bf_pal_port_enable(static_cast<bf_dev_id_t>(unit),
+                                          static_cast<bf_dev_port_t>(port_id)));
   return ::util::OkStatus();
 }
 
 ::util::Status BFPalWrapper::PortDisable(int unit, uint32 port_id) {
-  auto bf_status = bf_pal_port_disable(static_cast<bf_dev_id_t>(unit),
-                                       static_cast<bf_dev_port_t>(port_id));
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Error when disabling port with BF_PAL.";
-  }
+  RETURN_IF_BFRT_ERROR(bf_pal_port_disable(
+      static_cast<bf_dev_id_t>(unit), static_cast<bf_dev_port_t>(port_id)));
   return ::util::OkStatus();
 }
 
 ::util::Status BFPalWrapper::PortAutonegPolicySet(int unit, uint32 port_id,
                                                   TriState autoneg) {
   ASSIGN_OR_RETURN(auto autoneg_v, AutonegHalToBf(autoneg));
-  auto bf_status = bf_pal_port_autoneg_policy_set(
+  RETURN_IF_BFRT_ERROR(bf_pal_port_autoneg_policy_set(
       static_cast<bf_dev_id_t>(unit), static_cast<bf_dev_port_t>(port_id),
-      autoneg_v);
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL)
-           << "Error when setting autoneg policy with BF_PAL.";
-  }
+      autoneg_v));
   return ::util::OkStatus();
 }
 
@@ -248,13 +222,9 @@ namespace {
     RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
   }
   if (mtu == 0) mtu = kDefaultMtu;
-  auto bf_status = bf_pal_port_mtu_set(
+  RETURN_IF_BFRT_ERROR(bf_pal_port_mtu_set(
       static_cast<bf_dev_id_t>(unit), static_cast<bf_dev_port_t>(port_id),
-      static_cast<uint32>(mtu), static_cast<uint32>(mtu));
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL)
-           << "Error when setting port MTU with BF_PAL.";
-  }
+      static_cast<uint32>(mtu), static_cast<uint32>(mtu)));
   return ::util::OkStatus();
 }
 
@@ -269,14 +239,10 @@ bool BFPalWrapper::PortIsValid(int unit, uint32 port_id) {
     return ::util::OkStatus();
   }
   ASSIGN_OR_RETURN(bf_loopback_mode_e lp_mode, LoopbackModeToBf(loopback_mode));
-  auto bf_status = bf_pal_port_loopback_mode_set(
+
+  RETURN_IF_BFRT_ERROR(bf_pal_port_loopback_mode_set(
       static_cast<bf_dev_id_t>(unit), static_cast<bf_dev_port_t>(port_id),
-      lp_mode);
-  if (bf_status != BF_SUCCESS) {
-    return MAKE_ERROR(ERR_INTERNAL)
-           << "Error when setting loopback mode on dev " << unit << " port "
-           << port_id << ".";
-  }
+      lp_mode));
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/barefoot/macros.h
+++ b/stratum/hal/lib/barefoot/macros.h
@@ -1,0 +1,105 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_BAREFOOT_MACROS_H_
+#define STRATUM_HAL_LIB_BAREFOOT_MACROS_H_
+
+extern "C" {
+#include "bf_types/bf_types.h"
+}
+
+#include "stratum/glue/status/status.h"
+#include "stratum/lib/macros.h"
+#include "stratum/public/lib/error.h"
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+class BooleanBfStatus {
+ public:
+  explicit BooleanBfStatus(bf_status_t status) : status_(status) {}
+  operator bool() const { return status_ == BF_SUCCESS; }
+  inline bf_status_t status() const { return status_; }
+  inline ErrorCode error_code() const {
+    switch (status_) {
+      case BF_SUCCESS:
+        return ERR_SUCCESS;
+      case BF_NOT_READY:
+        return ERR_NOT_INITIALIZED;
+      case BF_INVALID_ARG:
+        return ERR_INVALID_PARAM;
+      case BF_ALREADY_EXISTS:
+        return ERR_ENTRY_EXISTS;
+      case BF_NO_SYS_RESOURCES:
+      case BF_MAX_SESSIONS_EXCEEDED:
+      case BF_NO_SPACE:
+      case BF_EAGAIN:
+        return ERR_NO_RESOURCE;
+      case BF_ENTRY_REFERENCES_EXIST:
+        return ERR_PERMISSION_DENIED;
+      case BF_TXN_NOT_SUPPORTED:
+      case BF_NOT_SUPPORTED:
+        return ERR_OPER_NOT_SUPPORTED;
+      case BF_HW_COMM_FAIL:
+      case BF_HW_UPDATE_FAILED:
+        return ERR_HARDWARE_ERROR;
+      case BF_NO_LEARN_CLIENTS:
+        return ERR_FEATURE_UNAVAILABLE;
+      case BF_IDLE_UPDATE_IN_PROGRESS:
+        return ERR_OPER_STILL_RUNNING;
+      case BF_OBJECT_NOT_FOUND:
+      case BF_TABLE_NOT_FOUND:
+        return ERR_ENTRY_NOT_FOUND;
+      case BF_NOT_IMPLEMENTED:
+        return ERR_UNIMPLEMENTED;
+      case BF_SESSION_NOT_FOUND:
+      case BF_INIT_ERROR:
+      case BF_TABLE_LOCKED:
+      case BF_IO:
+      case BF_UNEXPECTED:
+      case BF_DEVICE_LOCKED:
+      case BF_INTERNAL_ERROR:
+      case BF_IN_USE:
+      default:
+        return ERR_INTERNAL;
+    }
+  }
+
+ private:
+  bf_status_t status_;
+};
+
+// A macro for simplify checking and logging the return value of a SDE function
+// call.
+#define RETURN_IF_BFRT_ERROR(expr)                            \
+  if (const BooleanBfStatus __ret = BooleanBfStatus(expr)) {  \
+  } else /* NOLINT */                                         \
+    return MAKE_ERROR(__ret.error_code())                     \
+           << "'" << #expr << "' failed with error message: " \
+           << FixMessage(bf_err_str(__ret.status()))
+
+// A macro for simplify creating a new error or appending new info to an
+// error based on the return value of a SDE function call. The caller function
+// will not return. The variable given as "status" must be an object of type
+// ::util::Status.
+#define APPEND_STATUS_IF_BFRT_ERROR(status, expr)                           \
+  if (const BooleanBfStatus __ret = BooleanBfStatus(expr)) {                \
+  } else /* NOLINT */                                                       \
+    status =                                                                \
+        APPEND_ERROR(!status.ok() ? status                                  \
+                                  : ::util::Status(StratumErrorSpace(),     \
+                                                   __ret.error_code(), "")) \
+            .without_logging()                                              \
+        << (status.error_message().empty() ||                               \
+                    status.error_message().back() == ' '                    \
+                ? ""                                                        \
+                : " ")                                                      \
+        << "'" << #expr << "' failed with error message: "                  \
+        << FixMessage(bf_err_str(__ret.status()))
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_BAREFOOT_MACROS_H_


### PR DESCRIPTION
This PR introduces utility macros to make the handling of BF SDE function calls easier and safer. The macros are modeled after their BCM equivalent.

Original code by @Yi-Tseng and @pudelkoM.

Co-authored-by: Maximilian Pudelko <pudelkoM@users.noreply.github.com>
Co-authored-by: Yi Tseng <yi@opennetworking.org>