### PR TITLE
Disable formatting of inline text proto messages

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,8 @@ BasedOnStyle:  Google
 ---
 Language:        Cpp
 PointerAlignment: Left
+---
+Language:      TextProto
+BasedOnStyle:  Google
+DisableFormat: true
 ...


### PR DESCRIPTION
The current clang-format rules would require changing a lot of existing inline text proto messages to an undesired format:

```proto
      description: "Sample test config."
      nodes {
        id:  $0
        slot: 1
        index: $1
      }
```
would become:
```proto
      description: "Sample test config."
      nodes {id: $0 slot: 1 index: $1}
```

Until we find the corresponding [option](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) to correct that, we disable formatting for text protos altogether.