### PR TITLE
Disable pointer alignment detection

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,9 @@
 ---
 BasedOnStyle:  Google
 ---
-Language:        Cpp
-PointerAlignment: Left
+Language:               Cpp
+DerivePointerAlignment: false
+PointerAlignment:       Left
 ---
 Language:      TextProto
 BasedOnStyle:  Google

--- a/stratum/glue/init_google.h
+++ b/stratum/glue/init_google.h
@@ -19,7 +19,7 @@
 // Google's side
 using gflags::ParseCommandLineFlags;
 
-inline void InitGoogle(const char *usage, int *argc, char ***argv,
+inline void InitGoogle(const char* usage, int* argc, char*** argv,
                        bool remove_flags) {
   // Here we can set Stratum-wide defaults or overrides for library flags.
   CHECK(!::gflags::SetCommandLineOptionWithMode("logtostderr", "true",

--- a/stratum/hal/lib/barefoot/test_main.cc
+++ b/stratum/hal/lib/barefoot/test_main.cc
@@ -11,7 +11,7 @@
 
 DEFINE_string(test_tmpdir, "", "Temp directory to be used for tests.");
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();

--- a/stratum/hal/lib/np4intel/test_main.cc
+++ b/stratum/hal/lib/np4intel/test_main.cc
@@ -12,7 +12,7 @@
 
 DEFINE_string(test_tmpdir, "", "Temp directory to be used for tests.");
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();

--- a/stratum/hal/lib/phal/onlp/onlp_sfp_datasource_test.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_sfp_datasource_test.cc
@@ -98,7 +98,7 @@ TEST_F(SfpDatasourceTest, GetSfpData) {
           sizeof(mock_sfp_info.sff.serial));
 
   // Mock sfp_dom info response.
-  SffDomInfo *mock_sfp_dom_info = &mock_sfp_info.dom;
+  SffDomInfo* mock_sfp_dom_info = &mock_sfp_info.dom;
   mock_sfp_dom_info->temp = 123;
   mock_sfp_dom_info->nchannels = 2;
   mock_sfp_dom_info->voltage = 234;

--- a/stratum/testing/tests/bcm_sim_test_fixture.cc
+++ b/stratum/testing/tests/bcm_sim_test_fixture.cc
@@ -24,9 +24,9 @@ DECLARE_bool(blaze_test);
 // For simulator, we don't need the diag shell, so we overwrite the openpty with
 // empty function. Without the overwriting, compiler will generate undefined
 // referenece error.
-extern "C" int openpty(int *amaster, int *aslave, char *name,
-                       const struct termios *termp,
-                       const struct winsize *winp) {
+extern "C" int openpty(int* amaster, int* aslave, char* name,
+                       const struct termios* termp,
+                       const struct winsize* winp) {
   return 0;
 }
 
@@ -135,7 +135,7 @@ void BcmSimTestFixture::SetUp() {
       bcm_acl_manager_.get(), bcm_l2_manager_.get(), bcm_l3_manager_.get(),
       bcm_packetio_manager_.get(), bcm_table_manager_.get(),
       bcm_tunnel_manager_.get(), p4_table_mapper_.get(), kUnit);
-  std::map<int, BcmNode *> unit_to_bcm_node;
+  std::map<int, BcmNode*> unit_to_bcm_node;
   unit_to_bcm_node[kUnit] = bcm_node_.get();
   bcm_switch_ = BcmSwitch::CreateInstance(
       phal_sim_.get(), bcm_chassis_manager_.get(), unit_to_bcm_node);

--- a/stratum/testing/tests/test_main.cc
+++ b/stratum/testing/tests/test_main.cc
@@ -12,7 +12,7 @@
 
 DEFINE_string(test_tmpdir, "", "Temp directory to be used for tests.");
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   InitGoogle(argv[0], &argc, &argv, true);
 


### PR DESCRIPTION
Previously we allowed for detection and accepted right-hand side format if prevailing within a file, but since the majority of the code base uses left-hand side alignment, the cost conformity is pretty low (6 instances in the currently covered code).