### PR TITLE
Fix handling of bmv2 DataRequest::SdnPortId

### DIFF
--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -275,6 +275,7 @@ namespace {
     }
     case DataRequest::Request::kSdnPortId: {
       resp.mutable_sdn_port_id()->set_port_id(request.sdn_port_id().port_id());
+      break;
     }
     default:
       RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";


### PR DESCRIPTION
Add missing break in DataRequest::SdnPortId handling of bmv2 chassis manager

Fixes #438 