### PR TITLE
Fix style in hal and credential manager

### DIFF
--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -20,10 +20,9 @@
 #include "stratum/procmon/procmon.grpc.pb.h"
 
 // TODO(unknown): Use FLAG_DEFINE for all flags.
-DEFINE_string(
-    external_stratum_urls, stratum::kExternalStratumUrls,
-    "Comma-separated list of URLs for server to listen to for external"
-    " calls from SDN controller, etc.");
+DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
+              "Comma-separated list of URLs for server to listen to for "
+              "external calls from SDN controller, etc.");
 DEFINE_string(local_stratum_url, stratum::kLocalStratumUrl,
               "URL for listening to local calls from stratum stub.");
 DEFINE_bool(warmboot, false, "Determines whether HAL is in warmboot stage.");
@@ -199,15 +198,14 @@ Hal::~Hal() {
     for (const auto& url : external_stratum_urls) {
       builder.AddListeningPort(url, server_credentials);
     }
+    constexpr int MB = 1024 * 1024;
     if (FLAGS_grpc_max_recv_msg_size > 0) {
-      builder.SetMaxReceiveMessageSize(FLAGS_grpc_max_recv_msg_size * 1024 *
-                                       1024);
-      builder.AddChannelArgument<int>(
-          GRPC_ARG_MAX_METADATA_SIZE,
-          FLAGS_grpc_max_recv_msg_size * 1024 * 1024);
+      builder.SetMaxReceiveMessageSize(FLAGS_grpc_max_recv_msg_size * MB);
+      builder.AddChannelArgument<int>(GRPC_ARG_MAX_METADATA_SIZE,
+                                      FLAGS_grpc_max_recv_msg_size * MB);
     }
     if (FLAGS_grpc_max_send_msg_size) {
-      builder.SetMaxSendMessageSize(FLAGS_grpc_max_send_msg_size * 1024 * 1024);
+      builder.SetMaxSendMessageSize(FLAGS_grpc_max_send_msg_size * MB);
     }
     builder.RegisterService(config_monitoring_service_.get());
     builder.RegisterService(p4_service_.get());

--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -2,28 +2,28 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/common/hal.h"
 
 #include <chrono>  // NOLINT
 #include <utility>
 
-#include "gflags/gflags.h"
-#include "stratum/glue/logging.h"
-#include "stratum/lib/constants.h"
-#include "stratum/lib/macros.h"
-#include "stratum/procmon/procmon.grpc.pb.h"
-#include "stratum/lib/utils.h"
 #include "absl/base/macros.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/synchronization/mutex.h"
+#include "gflags/gflags.h"
+#include "stratum/glue/logging.h"
+#include "stratum/lib/constants.h"
+#include "stratum/lib/macros.h"
+#include "stratum/lib/utils.h"
+#include "stratum/procmon/procmon.grpc.pb.h"
 
 // TODO(unknown): Use FLAG_DEFINE for all flags.
-DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
-            "Comma-separated list of URLs for server to listen to for external"
-            " calls from SDN controller, etc.");
+DEFINE_string(
+    external_stratum_urls, stratum::kExternalStratumUrls,
+    "Comma-separated list of URLs for server to listen to for external"
+    " calls from SDN controller, etc.");
 DEFINE_string(local_stratum_url, stratum::kLocalStratumUrl,
               "URL for listening to local calls from stratum stub.");
 DEFINE_bool(warmboot, false, "Determines whether HAL is in warmboot stage.");
@@ -102,19 +102,20 @@ Hal::~Hal() {
   CHECK_RETURN_IF_FALSE(!external_stratum_urls.empty())
       << "No external URL was given. This is invalid.";
 
-  auto it = std::find_if(external_stratum_urls.begin(),
-                         external_stratum_urls.end(),
-                         [](const std::string& url) {
-                           return (url == FLAGS_local_stratum_url ||
-                                   // FIXME(boc) google only url ==
-                                   // FLAGS_cmal_service_url ||
-                                   url == FLAGS_procmon_service_addr);
-                         });
+  auto it =
+      std::find_if(external_stratum_urls.begin(), external_stratum_urls.end(),
+                   [](const std::string& url) {
+                     return (url == FLAGS_local_stratum_url ||
+                             // FIXME(boc) google only url ==
+                             // FLAGS_cmal_service_url ||
+                             url == FLAGS_procmon_service_addr);
+                   });
   CHECK_RETURN_IF_FALSE(it == external_stratum_urls.end())
       << "You used one of these reserved local URLs as your external URLs: "
-      << FLAGS_local_stratum_url << ", "
-      /*FIXME(boc) google only << FLAGS_cmal_service_url */<< ", "
-      << FLAGS_procmon_service_addr << ".";
+      << FLAGS_local_stratum_url
+      << ", "
+      /*FIXME(boc) google only << FLAGS_cmal_service_url */
+      << ", " << FLAGS_procmon_service_addr << ".";
 
   CHECK_RETURN_IF_FALSE(!FLAGS_persistent_config_dir.empty())
       << "persistent_config_dir flag needs to be explicitly given.";
@@ -187,7 +188,7 @@ Hal::~Hal() {
   // stratum_stub binary running on the switch, since local connections cannot
   // support auth.
   const std::vector<std::string> external_stratum_urls =
-          absl::StrSplit(FLAGS_external_stratum_urls, ',');
+      absl::StrSplit(FLAGS_external_stratum_urls, ',');
   {
     std::shared_ptr<::grpc::ServerCredentials> server_credentials =
         credentials_manager_->GenerateExternalFacingServerCredentials();
@@ -199,14 +200,14 @@ Hal::~Hal() {
       builder.AddListeningPort(url, server_credentials);
     }
     if (FLAGS_grpc_max_recv_msg_size > 0) {
-      builder.SetMaxReceiveMessageSize(
-          FLAGS_grpc_max_recv_msg_size * 1024 * 1024);
-      builder.AddChannelArgument<int>(GRPC_ARG_MAX_METADATA_SIZE,
+      builder.SetMaxReceiveMessageSize(FLAGS_grpc_max_recv_msg_size * 1024 *
+                                       1024);
+      builder.AddChannelArgument<int>(
+          GRPC_ARG_MAX_METADATA_SIZE,
           FLAGS_grpc_max_recv_msg_size * 1024 * 1024);
     }
     if (FLAGS_grpc_max_send_msg_size) {
-      builder.SetMaxSendMessageSize(
-          FLAGS_grpc_max_send_msg_size * 1024 * 1024);
+      builder.SetMaxSendMessageSize(FLAGS_grpc_max_send_msg_size * 1024 * 1024);
     }
     builder.RegisterService(config_monitoring_service_.get());
     builder.RegisterService(p4_service_.get());

--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -36,10 +36,10 @@ DEFINE_int32(grpc_keepalive_timeout_ms, 20000,
 DEFINE_int32(grpc_keepalive_min_ping_interval, 10000,
              "grpc keep alive minimum ping interval");
 DEFINE_int32(grpc_keepalive_permit, 1, "grpc keep alive permit");
-DEFINE_uint32(grpc_max_recv_msg_size, 256,
-              "grpc server max receive message size in MB");
+DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
+              "grpc server max receive message size (0 = gRPC default).");
 DEFINE_uint32(grpc_max_send_msg_size, 0,
-              "grpc server max send message size in MB");
+              "grpc server max send message size (0 = gRPC default).");
 
 namespace stratum {
 namespace hal {
@@ -198,14 +198,13 @@ Hal::~Hal() {
     for (const auto& url : external_stratum_urls) {
       builder.AddListeningPort(url, server_credentials);
     }
-    constexpr uint32 MB = 1024 * 1024;
     if (FLAGS_grpc_max_recv_msg_size > 0) {
-      builder.SetMaxReceiveMessageSize(FLAGS_grpc_max_recv_msg_size * MB);
+      builder.SetMaxReceiveMessageSize(FLAGS_grpc_max_recv_msg_size);
       builder.AddChannelArgument<int>(GRPC_ARG_MAX_METADATA_SIZE,
-                                      FLAGS_grpc_max_recv_msg_size * MB);
+                                      FLAGS_grpc_max_recv_msg_size);
     }
-    if (FLAGS_grpc_max_send_msg_size) {
-      builder.SetMaxSendMessageSize(FLAGS_grpc_max_send_msg_size * MB);
+    if (FLAGS_grpc_max_send_msg_size > 0) {
+      builder.SetMaxSendMessageSize(FLAGS_grpc_max_send_msg_size);
     }
     builder.RegisterService(config_monitoring_service_.get());
     builder.RegisterService(p4_service_.get());

--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -198,7 +198,7 @@ Hal::~Hal() {
     for (const auto& url : external_stratum_urls) {
       builder.AddListeningPort(url, server_credentials);
     }
-    constexpr int MB = 1024 * 1024;
+    constexpr uint32 MB = 1024 * 1024;
     if (FLAGS_grpc_max_recv_msg_size > 0) {
       builder.SetMaxReceiveMessageSize(FLAGS_grpc_max_recv_msg_size * MB);
       builder.AddChannelArgument<int>(GRPC_ARG_MAX_METADATA_SIZE,

--- a/stratum/hal/lib/common/hal.h
+++ b/stratum/hal/lib/common/hal.h
@@ -71,14 +71,10 @@ class Hal final {
   }
 
   // Clears the list of errors HAL and all it's services have encountered.
-  inline void ClearErrors() const {
-    return error_buffer_->ClearErrors();
-  }
+  inline void ClearErrors() const { return error_buffer_->ClearErrors(); }
 
   // Returns true if HAL or any of it's services have encountered an error.
-  inline bool ErrorExists() const {
-    return error_buffer_->ErrorExists();
-  }
+  inline bool ErrorExists() const { return error_buffer_->ErrorExists(); }
 
   // Creates the singleton instance. Expected to be called once to initialize
   // the instance.

--- a/stratum/hal/lib/common/hal_test.cc
+++ b/stratum/hal/lib/common/hal_test.cc
@@ -2,22 +2,21 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/common/hal.h"
 
+#include "absl/strings/str_join.h"
+#include "absl/strings/substitute.h"
 #include "gflags/gflags.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/common/switch_mock.h"
-#include "stratum/procmon/procmon.grpc.pb.h"
 #include "stratum/lib/security/auth_policy_checker_mock.h"
 #include "stratum/lib/security/credentials_manager_mock.h"
 #include "stratum/lib/utils.h"
+#include "stratum/procmon/procmon.grpc.pb.h"
 #include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/strings/substitute.h"
-#include "absl/strings/str_join.h"
 
 DECLARE_string(external_stratum_urls);
 DECLARE_bool(warmboot);
@@ -88,7 +87,7 @@ class HalTest : public ::testing::Test {
     procmon_service_ = new FakeProcmonService();
     ::grpc::ServerBuilder builder;
     builder.AddListeningPort(FLAGS_procmon_service_addr,
-                            ::grpc::InsecureServerCredentials());
+                             ::grpc::InsecureServerCredentials());
     builder.RegisterService(procmon_service_);
     procmon_server_ = builder.BuildAndStart().release();
     ASSERT_NE(procmon_server_, nullptr);
@@ -348,8 +347,8 @@ TEST_F(HalTest, ColdbootSetupFailureWhenChassisConfigPushFails) {
   FillTestForwardingPipelineConfigsAndSave(&forwarding_pipeline_configs);
 
   EXPECT_CALL(*switch_mock_, PushChassisConfig(EqualsProto(chassis_config)))
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
 
   // Call and validate results.
   FLAGS_warmboot = false;
@@ -377,8 +376,8 @@ TEST_F(HalTest, ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
           kNodeId1,
           EqualsProto(
               forwarding_pipeline_configs.node_id_to_config().at(kNodeId1))))
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
   EXPECT_CALL(
       *switch_mock_,
       PushForwardingPipelineConfig(
@@ -439,8 +438,8 @@ TEST_F(HalTest, WarmbootSetupFailureWhenUnfreezeFails) {
   FillTestForwardingPipelineConfigsAndSave(&forwarding_pipeline_configs);
 
   EXPECT_CALL(*switch_mock_, Unfreeze())
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
 
   // Call and validate results.
   FLAGS_warmboot = true;
@@ -469,8 +468,8 @@ TEST_F(HalTest, ColdbootTeardownSuccess) {
 
 TEST_F(HalTest, ColdbootTeardownFailureWhenSwitchInterfaceShutdownFails) {
   EXPECT_CALL(*switch_mock_, Shutdown())
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
   EXPECT_CALL(*auth_policy_checker_mock_, Shutdown())
       .WillOnce(Return(::util::OkStatus()));
 
@@ -488,8 +487,8 @@ TEST_F(HalTest, ColdbootTeardownFailureWhenSwitchInterfaceShutdownFails) {
 TEST_F(HalTest, ColdbootTeardownFailureWhenAuthPolicyCheckerShutdownFails) {
   EXPECT_CALL(*switch_mock_, Shutdown()).WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*auth_policy_checker_mock_, Shutdown())
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
 
   // Call and validate results.
   FLAGS_warmboot = false;
@@ -517,8 +516,8 @@ TEST_F(HalTest, WarmbootTeardownSuccess) {
 
 TEST_F(HalTest, WarmbootTeardownFailure) {
   EXPECT_CALL(*switch_mock_, Shutdown())
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
   EXPECT_CALL(*auth_policy_checker_mock_, Shutdown())
       .WillOnce(Return(::util::OkStatus()));
 

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -33,7 +33,7 @@ CredentialsManager::GenerateExternalFacingServerCredentials() const {
 }
 
 ::util::StatusOr<std::unique_ptr<CredentialsManager>>
-    CredentialsManager::CreateInstance() {
+CredentialsManager::CreateInstance() {
   auto instance_ = absl::WrapUnique(new CredentialsManager());
   RETURN_IF_ERROR(instance_->Initialize());
   return std::move(instance_);
@@ -54,21 +54,19 @@ CredentialsManager::GenerateExternalFacingServerCredentials() const {
     status.Update(ReadFileToString(FLAGS_server_key, &server_private_key_));
     status.Update(ReadFileToString(FLAGS_server_cert, &server_cert_));
     if (!status.ok()) {
-      RETURN_ERROR().without_logging() << "Unable to load credentials: "
-                                       << status.error_message();
+      RETURN_ERROR().without_logging()
+          << "Unable to load credentials: " << status.error_message();
     }
     auto credentials_reload_interface_ =
-        std::make_shared<CredentialsReloadInterface>(pem_root_certs_,
-                                                     server_private_key_,
-                                                     server_cert_);
+        std::make_shared<CredentialsReloadInterface>(
+            pem_root_certs_, server_private_key_, server_cert_);
     auto credential_reload_config_ =
         std::make_shared<TlsCredentialReloadConfig>(
             credentials_reload_interface_);
 
     tls_opts_ = std::make_shared<TlsCredentialsOptions>(
-        GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE,
-        GRPC_TLS_SERVER_VERIFICATION, nullptr,
-        credential_reload_config_, nullptr);
+        GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE, GRPC_TLS_SERVER_VERIFICATION,
+        nullptr, credential_reload_config_, nullptr);
     server_credentials_ = TlsServerCredentials(*tls_opts_);
   }
   return ::util::OkStatus();
@@ -89,7 +87,7 @@ CredentialsReloadInterface::CredentialsReloadInterface(
       server_private_key_(server_private_key),
       server_cert_(server_cert) {}
 
-int CredentialsReloadInterface::Schedule(TlsCredentialReloadArg *arg) {
+int CredentialsReloadInterface::Schedule(TlsCredentialReloadArg* arg) {
   absl::WriterMutexLock l(&credential_lock_);
   if (arg == nullptr) {
     arg->set_status(GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_FAIL);
@@ -110,7 +108,7 @@ int CredentialsReloadInterface::Schedule(TlsCredentialReloadArg *arg) {
   return 0;
 }
 
-void CredentialsReloadInterface::Cancel(TlsCredentialReloadArg *arg) {
+void CredentialsReloadInterface::Cancel(TlsCredentialReloadArg* arg) {
   if (arg == nullptr) return;
   arg->set_status(GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_FAIL);
   arg->set_error_details("Cancelled.");

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -38,9 +38,9 @@ class CredentialsReloadInterface : public TlsCredentialReloadInterface {
                              std::string server_cert);
 
   // Public methods from TlsCredentialReloadInterface
-  int Schedule(TlsCredentialReloadArg *arg) override
+  int Schedule(TlsCredentialReloadArg* arg) override
       LOCKS_EXCLUDED(credential_lock_);
-  void Cancel(TlsCredentialReloadArg *arg) override;
+  void Cancel(TlsCredentialReloadArg* arg) override;
 
   // Loads new credentials
   ::util::Status LoadNewCredential(const std::string ca_cert,
@@ -50,7 +50,7 @@ class CredentialsReloadInterface : public TlsCredentialReloadInterface {
 
   // CredentialsReloadInterface is neither copyable nor movable.
   CredentialsReloadInterface(const CredentialsReloadInterface&) = delete;
-  CredentialsReloadInterface &operator=(const CredentialsReloadInterface&) =
+  CredentialsReloadInterface& operator=(const CredentialsReloadInterface&) =
       delete;
 
  private:
@@ -79,7 +79,7 @@ class CredentialsManager {
 
   // CredentialsManager is neither copyable nor movable.
   CredentialsManager(const CredentialsManager&) = delete;
-  CredentialsManager &operator=(const CredentialsManager&) = delete;
+  CredentialsManager& operator=(const CredentialsManager&) = delete;
 
   // Loads new credentials
   ::util::Status LoadNewCredential(const std::string ca_cert,


### PR DESCRIPTION
This PR fixes the code style in Hal and the CredentialsManager.

The flags `-grpc_max_recv_msg_size` and `-grpc_max_send_msg_size` are in bytes now.