### PR TITLE
Add SignalWaiter utility class

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -127,7 +127,7 @@ def stratum_deps():
             build_file = "@//bazel:external/gnoi.BUILD",
             sha256 = GNOI_SHA,
             patch_cmds = [
-                "find . -name *.proto | xargs sed -i 's#github.com/openconfig/##g'",
+                "find . -name *.proto | xargs sed -i '' 's#github.com/openconfig/##g'",
                 "mkdir -p gnoi",
                 "mv bgp cert common diag file interface layer2 mpls otdr system test types wavelength_router gnoi/",
             ],

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -127,7 +127,7 @@ def stratum_deps():
             build_file = "@//bazel:external/gnoi.BUILD",
             sha256 = GNOI_SHA,
             patch_cmds = [
-                "find . -name *.proto | xargs sed -i '' 's#github.com/openconfig/##g'",
+                "find . -name *.proto | xargs sed -i 's#github.com/openconfig/##g'",
                 "mkdir -p gnoi",
                 "mv bgp cert common diag file interface layer2 mpls otdr system test types wavelength_router gnoi/",
             ],

--- a/stratum/lib/BUILD
+++ b/stratum/lib/BUILD
@@ -46,6 +46,36 @@ stratum_cc_test(
     ],
 )
 
+stratum_cc_library(
+    name = "signal_waiter",
+    srcs = ["signal_waiter.cc"],
+    hdrs = ["signal_waiter.h"],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "//stratum/glue:logging",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/public/lib:error",
+    ],
+)
+
+stratum_cc_test(
+    name = "signal_waiter_test",
+    srcs = ["signal_waiter_test.cc"],
+    deps = [
+        ":test_main",
+        ":signal_waiter",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/glue/status:status_test_util",
+        "//stratum/lib/test_utils:matchers",
+        "//stratum/public/lib:error",
+    ],
+)
+
 cc_library(
     name = "test_main",
     testonly = 1,

--- a/stratum/lib/signal_waiter.cc
+++ b/stratum/lib/signal_waiter.cc
@@ -1,0 +1,72 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/lib/signal_waiter.h"
+
+#include "stratum/glue/logging.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/public/lib/error.h"
+
+namespace stratum {
+namespace hal {
+
+namespace {
+
+// Signal received callback which is registered as the handler for signals using
+// signal() system call.
+void SignalRcvCallback(int value) { SignalWaiter::HandleSignal(value); }
+
+}  // namespace
+
+// Initialize static member.
+SignalWaiter SignalWaiter::instance_;
+
+SignalWaiter::SignalWaiter(const std::vector<int> signals) : signals_(signals) {
+  CHECK_ERR(sem_init(&sem_, 0, 0));
+  // Register the signal handlers and save the old handlers as well.
+  for (const int s : signals) {
+    sighandler_t h = signal(s, SignalRcvCallback);
+    if (h == SIG_ERR) {
+      LOG(FATAL) << "Failed to register signal: " << strsignal(s) << " (" << s
+                 << ").";
+    }
+    old_signal_handlers_[s] = h;
+  }
+}
+
+SignalWaiter::~SignalWaiter() {
+  // Register the old handlers for all the signals.
+  for (const auto& e : old_signal_handlers_) {
+    signal(e.first, e.second);
+  }
+  old_signal_handlers_.clear();
+
+  CHECK_ERR(sem_destroy(&sem_));
+}
+
+// Reminder: async-signal-safe function calls only!
+::util::Status SignalWaiter::HandleSignal(int value) {
+  const auto& s = instance_.signals_;
+  if (std::find(s.begin(), s.end(), value) == s.end()) {
+    RETURN_ERROR(ERR_INTERNAL)
+        << "Tried to handle unregistered signal: " << strsignal(value) << " ("
+        << value << ").";
+  }
+
+  // Wake up one thread waiting for a signal.
+  CHECK_ERR(sem_post(&instance_.sem_));
+  return ::util::OkStatus();
+}
+
+void SignalWaiter::WaitForSignal() {
+  while (sem_wait(&instance_.sem_) != 0) {
+    // Fail if not EINTR; otherwise continue waiting.
+    PCHECK(errno == EINTR);
+  }
+
+  // Wake up another thread that is waiting for a signal.
+  CHECK_ERR(sem_post(&instance_.sem_));
+}
+
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/lib/signal_waiter.cc
+++ b/stratum/lib/signal_waiter.cc
@@ -39,7 +39,6 @@ SignalWaiter::~SignalWaiter() {
   for (const auto& e : old_signal_handlers_) {
     signal(e.first, e.second);
   }
-  old_signal_handlers_.clear();
 
   CHECK_ERR(sem_destroy(&sem_));
 }

--- a/stratum/lib/signal_waiter.h
+++ b/stratum/lib/signal_waiter.h
@@ -1,0 +1,67 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_LIB_SIGNAL_WAITER_H_
+#define STRATUM_LIB_SIGNAL_WAITER_H_
+
+#include <semaphore.h>
+#include <signal.h>
+
+#include <atomic>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "stratum/glue/status/status.h"
+
+namespace stratum {
+namespace hal {
+
+// Class 'SignalWaiter' is a utility class that waits allows calling threads to
+// wait on a set of signals. This class is initialized statically on program
+// start and registers handlers to listen for SIGINT, SIGTERM, and SIGUSR2.
+// Users can also call HandleSignal() to deliver a signal to waiters instead of
+// kill() or pthread_kill().
+class SignalWaiter final {
+ public:
+  // Called by the signal handler when it receives a signal.
+  // This function is async-signal-safe and can only call other
+  // async-signal-safe functions.
+  static ::util::Status HandleSignal(int value);
+
+  // Blocking call to wait for one of the signals. Returns when one of the
+  // signals is received.
+  static void WaitForSignal();
+
+  // SignalWaiter is neither copyable nor movable.
+  SignalWaiter(const SignalWaiter&) = delete;
+  SignalWaiter& operator=(const SignalWaiter&) = delete;
+
+  // Static instance that gets created at program start.
+  static SignalWaiter instance_;
+
+ private:
+  // Private constructor and destructor.
+  SignalWaiter(const std::vector<int> signals = {SIGINT, SIGTERM, SIGUSR2});
+  ~SignalWaiter();
+
+  // Semaphore that is used to block threads that call WaitForSignal(). The
+  // semaphore is initialized locked (value 0). Waiting threads call sem_wait(),
+  // and the signal handler calls sem_post(). The semaphone remains unlocked
+  // (value >= 1) after a signal has been handled.
+  sem_t sem_;
+
+  // Vector of signals for which we registered handlers.
+  std::vector<int> signals_;
+
+  // Map from signals for which we registered handlers to their old handlers.
+  // This map is used to restore the signal handlers to their previous state
+  // in the class destructor.
+  absl::flat_hash_map<int, sighandler_t> old_signal_handlers_;
+
+  friend class SignalWaiterTest;
+};
+
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_LIB_SIGNAL_WAITER_H_

--- a/stratum/lib/signal_waiter_test.cc
+++ b/stratum/lib/signal_waiter_test.cc
@@ -29,10 +29,10 @@ class SignalWaiterTest : public ::testing::Test {
     int sem_value = GetSemaphoreValue();
     EXPECT_LE(1, sem_value);
     LOG(INFO) << "Ended test with semaphore value: " << sem_value;
-    Reset();
+    ResetSem();
   }
 
-  void Reset() {
+  void ResetSem() {
     CHECK_ERR(sem_destroy(&SignalWaiter::instance_.sem_));
     CHECK_ERR(sem_init(&SignalWaiter::instance_.sem_, 0, 0));
   }

--- a/stratum/lib/signal_waiter_test.cc
+++ b/stratum/lib/signal_waiter_test.cc
@@ -1,0 +1,245 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/lib/signal_waiter.h"
+
+#include <pthread.h>
+#include <signal.h>
+
+#include <string>
+
+#include "absl/time/clock.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/logging.h"
+#include "stratum/glue/status/status_test_util.h"
+
+namespace stratum {
+namespace hal {
+
+class SignalWaiterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int sem_value = GetSemaphoreValue();
+    ASSERT_EQ(0, sem_value);
+    LOG(INFO) << "Starting test with semaphore value: " << sem_value;
+  }
+
+  void TearDown() override {
+    int sem_value = GetSemaphoreValue();
+    EXPECT_LE(1, sem_value);
+    LOG(INFO) << "Ended test with semaphore value: " << sem_value;
+    Reset();
+  }
+
+  void Reset() {
+    CHECK_ERR(sem_destroy(&SignalWaiter::instance_.sem_));
+    CHECK_ERR(sem_init(&SignalWaiter::instance_.sem_, 0, 0));
+  }
+
+  int GetSemaphoreValue() {
+    int sem_value;
+    CHECK_ERR(sem_getvalue(&SignalWaiter::instance_.sem_, &sem_value));
+    return sem_value;
+  }
+
+  void ConstructWaiter(const std::vector<int> signals) {
+    SignalWaiter waiter(signals);
+  }
+};
+
+TEST_F(SignalWaiterTest, SignalBeforeWait) {
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  SignalWaiter::WaitForSignal();
+}
+
+TEST_F(SignalWaiterTest, SignalBeforeDoubleWait) {
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  SignalWaiter::WaitForSignal();
+  SignalWaiter::WaitForSignal();
+}
+
+TEST_F(SignalWaiterTest, DoubleSignalBeforeWait) {
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  SignalWaiter::WaitForSignal();
+  EXPECT_EQ(2, GetSemaphoreValue());
+}
+
+TEST_F(SignalWaiterTest, DoubleSignalBeforeDoubleWait) {
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  SignalWaiter::WaitForSignal();
+  SignalWaiter::WaitForSignal();
+  EXPECT_EQ(2, GetSemaphoreValue());
+}
+
+TEST_F(SignalWaiterTest, InvalidSignal) {
+  ::util::Status status = SignalWaiter::HandleSignal(SIGUSR1);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(0, GetSemaphoreValue());
+  // Send a registered signal because the test framework expects one.
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+}
+
+namespace {
+
+constexpr absl::Duration kShutdownThreadSleep = ::absl::Seconds(3);
+const int kWaitReturn = 0x3333;
+const int kSignalReturn = 0x4444;
+
+void* TestWaitThread(void*) {
+  // Disable SA_RESTART on SIGUSR2
+  struct sigaction sa;
+  CHECK_ERR(sigaction(SIGUSR2, NULL, &sa));
+  sa.sa_flags = sa.sa_flags & ~SA_RESTART;
+  CHECK_ERR(sigaction(SIGUSR2, &sa, NULL));
+
+  LOG(INFO) << "Waiting...";
+  SignalWaiter::WaitForSignal();
+  return new int{kWaitReturn};
+}
+
+void* TestSignalThread(void* arg) {
+  const int* signal = static_cast<int*>(arg);
+  ::absl::SleepFor(kShutdownThreadSleep);  // some sleep to emulate a task.
+  SignalWaiter::HandleSignal(*signal);
+  return new int{kSignalReturn};
+}
+
+void JoinThread(const pthread_t& tid, int expected) {
+  void* void_val;
+  ASSERT_EQ(0, pthread_join(tid, &void_val));
+  int* int_val = static_cast<int*>(void_val);
+  EXPECT_EQ(expected, *int_val);
+  delete int_val;
+}
+
+}  // namespace
+
+TEST_F(SignalWaiterTest, WaitInThread) {
+  pthread_t tid;
+  ASSERT_EQ(0, pthread_create(&tid, nullptr, &TestWaitThread, nullptr));
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  JoinThread(tid, kWaitReturn);
+}
+
+TEST_F(SignalWaiterTest, DoubleWaitInThread) {
+  pthread_t tid1;
+  pthread_t tid2;
+  ASSERT_EQ(0, pthread_create(&tid1, nullptr, &TestWaitThread, nullptr));
+  ASSERT_EQ(0, pthread_create(&tid2, nullptr, &TestWaitThread, nullptr));
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+
+  JoinThread(tid1, kWaitReturn);
+  JoinThread(tid2, kWaitReturn);
+}
+
+TEST_F(SignalWaiterTest, SignalInThread) {
+  int signal = SIGINT;
+  pthread_t tid;
+  const absl::Time start = absl::Now();
+
+  ASSERT_EQ(0, pthread_create(&tid, nullptr, &TestSignalThread, &signal));
+  SignalWaiter::WaitForSignal();
+
+  const absl::Time end = absl::Now();
+  // Make sure we waited at least 90% of the time
+  EXPECT_LE(kShutdownThreadSleep * .9, end - start);
+
+  JoinThread(tid, kSignalReturn);
+}
+
+TEST_F(SignalWaiterTest, SignalAndWaitInThreads) {
+  int signal = SIGINT;
+  pthread_t signal_tid;
+  pthread_t wait_tid;
+  ASSERT_EQ(0,
+            pthread_create(&signal_tid, nullptr, &TestSignalThread, &signal));
+  ASSERT_EQ(0, pthread_create(&wait_tid, nullptr, &TestWaitThread, nullptr));
+
+  JoinThread(signal_tid, kSignalReturn);
+  JoinThread(wait_tid, kWaitReturn);
+}
+
+TEST_F(SignalWaiterTest, SignalUsingPthreadKillUsr2) {
+  pthread_t tid;
+  ASSERT_EQ(0, pthread_create(&tid, nullptr, &TestWaitThread, nullptr));
+  ::absl::SleepFor(kShutdownThreadSleep);  // give the thread a chance to start.
+
+  ASSERT_EQ(0, pthread_kill(tid, SIGUSR2));
+
+  JoinThread(tid, kWaitReturn);
+}
+
+TEST_F(SignalWaiterTest, SignalUsingPthreadKillInt) {
+  pthread_t tid;
+  ASSERT_EQ(0, pthread_create(&tid, nullptr, &TestWaitThread, nullptr));
+  ::absl::SleepFor(kShutdownThreadSleep);  // give the thread a chance to start.
+
+  ASSERT_EQ(0, pthread_kill(tid, SIGINT));
+
+  JoinThread(tid, kWaitReturn);
+}
+
+TEST_F(SignalWaiterTest, SignalUsingKillTerm) {
+  pthread_t tid;
+  ASSERT_EQ(0, pthread_create(&tid, nullptr, &TestWaitThread, nullptr));
+
+  ASSERT_EQ(0, kill(getpid(), SIGTERM));
+
+  JoinThread(tid, kWaitReturn);
+}
+
+namespace {
+
+void TestCallback(int value) {
+  LOG(INFO) << "Got signal " << strsignal(value) << " (" << value << ").";
+}
+
+}  // namespace
+
+TEST_F(SignalWaiterTest, SignalUsingKillUsr1) {
+  pthread_t tid;
+
+  signal(SIGUSR1, TestCallback);
+  ASSERT_EQ(0, pthread_create(&tid, nullptr, &TestWaitThread, nullptr));
+  ASSERT_EQ(0, kill(getpid(), SIGUSR1));
+
+  // Make sure the waiter has not stopped
+  ::absl::SleepFor(kShutdownThreadSleep);
+  ASSERT_NE(0, pthread_tryjoin_np(tid, nullptr));
+  EXPECT_EQ(0, GetSemaphoreValue());
+
+  // Send a registered signal because the test framework expects one.
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+  JoinThread(tid, kWaitReturn);
+}
+
+TEST_F(SignalWaiterTest, Constructor) {
+  // Grab the handler
+  struct sigaction sa1;
+  CHECK_ERR(sigaction(SIGUSR1, NULL, &sa1));
+
+  ConstructWaiter({SIGUSR1});
+
+  // Make sure the old handler gets put back
+  struct sigaction sa2;
+  CHECK_ERR(sigaction(SIGUSR1, NULL, &sa2));
+  EXPECT_EQ(sa1.sa_handler, sa2.sa_handler);
+
+  // Send a registered signal because the test framework expects one.
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+}
+
+TEST_F(SignalWaiterTest, ConstructorError) {
+  ::std::string error_msg("Failed to register signal: ");
+  error_msg += strsignal(SIGKILL);
+  ASSERT_DEATH(ConstructWaiter({SIGKILL}), error_msg);
+
+  // Send a registered signal because the test framework expects one.
+  EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));
+}
+
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/lib/signal_waiter_test.cc
+++ b/stratum/lib/signal_waiter_test.cc
@@ -235,7 +235,7 @@ TEST_F(SignalWaiterTest, Constructor) {
 TEST_F(SignalWaiterTest, ConstructorError) {
   ::std::string error_msg("Failed to register signal: ");
   error_msg += strsignal(SIGKILL);
-  ASSERT_DEATH(ConstructWaiter({SIGKILL}), error_msg);
+  EXPECT_DEATH(ConstructWaiter({SIGKILL}), error_msg);
 
   // Send a registered signal because the test framework expects one.
   EXPECT_OK(SignalWaiter::HandleSignal(SIGINT));

--- a/stratum/lib/signal_waiter_test.cc
+++ b/stratum/lib/signal_waiter_test.cc
@@ -29,10 +29,10 @@ class SignalWaiterTest : public ::testing::Test {
     int sem_value = GetSemaphoreValue();
     EXPECT_LE(1, sem_value);
     LOG(INFO) << "Ended test with semaphore value: " << sem_value;
-    ResetSem();
+    ResetSemaphore();
   }
 
-  void ResetSem() {
+  void ResetSemaphore() {
     CHECK_ERR(sem_destroy(&SignalWaiter::instance_.sem_));
     CHECK_ERR(sem_init(&SignalWaiter::instance_.sem_, 0, 0));
   }


### PR DESCRIPTION
This class is initialized statically on program start and registers handlers to listen for SIGINT, SIGTERM, and SIGUSR2.

Calls to WaitForSignal()  block until one of the signals is received.

Users can also call HandleSignal() to deliver a signal to waiters instead of kill() or pthread_kill().

TODO
- [ ] Consider unlocking sem_ in destructor
- [ ] Add signal callback register function that automatically spins up in a thread
- [ ] Should we detach threads when spinning up a waiter? Cleaning them up would happen automatically when they return.
