### PR TITLE
Add labels to Docker containers in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,11 @@ docker_build: &docker_build
     command: |
       docker pull $DOCKER_IMG || true
       cd $DOCKER_SCOPE
-      GIT_URL=${GIT_URL:-$(git config --get remote.origin.url)}
-      GIT_REF=$(git describe --tags --no-match --always --abbrev=40 --dirty | sed -E 's/^.*-g([0-9a-f]{40}-?.*)$/\1/')
-      GIT_SHA=$(git describe --tags --match XXXXXXX --always --abbrev=40 --dirty)
       docker build -f $DOCKER_FILE -t $DOCKER_IMG \
         --cache-from $DOCKER_IMG \
-        --label org.opencontainers.image.source=$GIT_URL  \
-        --label org.opencontainers.image.version=$GIT_REF \
-        --label org.opencontainers.image.revision=$GIT_SHA \
+        --label org.opencontainers.image.source=$CIRCLE_REPOSITORY_URL  \
+        --label org.opencontainers.image.version=$CIRCLE_SHA1 \
+        --label org.opencontainers.image.revision=$CIRCLE_SHA1 \
         --label build-timestamp=$(date +%FT%T%z) \
         --label build-machine=circle-ci \
         .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,17 @@ docker_build: &docker_build
     command: |
       docker pull $DOCKER_IMG || true
       cd $DOCKER_SCOPE
-      docker build -f $DOCKER_FILE -t $DOCKER_IMG --cache-from $DOCKER_IMG --label vcs-ref=$CIRCLE_SHA1 .
+      GIT_URL=${GIT_URL:-$(git config --get remote.origin.url)}
+      GIT_REF=$(git describe --tags --no-match --always --abbrev=40 --dirty | sed -E 's/^.*-g([0-9a-f]{40}-?.*)$/\1/')
+      GIT_SHA=$(git describe --tags --match XXXXXXX --always --abbrev=40 --dirty)
+      docker build -f $DOCKER_FILE -t $DOCKER_IMG \
+        --cache-from $DOCKER_IMG \
+        --label org.opencontainers.image.source=$GIT_URL  \
+        --label org.opencontainers.image.version=$GIT_REF \
+        --label org.opencontainers.image.revision=$GIT_SHA \
+        --label build-timestamp=$(date +%FT%T%z) \
+        --label build-machine=circle-ci \
+        .
 docker_push: &docker_push
   run:
     name: Push Docker image
@@ -350,10 +360,10 @@ workflows:
       - bazel-style-check
   docker-publish:
     jobs:
-      - publish-docker-build:
-          filters:
-            branches:
-              only: master
+      - publish-docker-build #:
+          #filters:
+          #  branches:
+          #    only: master
       - publish-docker-mininet:
           requires:
             - publish-docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,10 +357,10 @@ workflows:
       - bazel-style-check
   docker-publish:
     jobs:
-      - publish-docker-build #:
-          #filters:
-          #  branches:
-          #    only: master
+      - publish-docker-build:
+          filters:
+            branches:
+              only: master
       - publish-docker-mininet:
           requires:
             - publish-docker-build


### PR DESCRIPTION
This PR adds metadata labels to all Docker images built and published on CircleCI.

Example:

```
> docker image inspect --format='{{json .ContainerConfig.Labels}}' stratumproject/build:build | jq
{
  "build-machine": "circle-ci",
  "build-timestamp": "2020-12-16T22:35:10+0000",
  "description": "This Docker image sets up a development environment for Stratum",
  "maintainer": "Stratum dev <stratum-dev@lists.stratumproject.org>",
  "org.opencontainers.image.revision": "0f37ac125bfd00f0ce3d9a365f05a32ed756a29f",
  "org.opencontainers.image.source": "git@github.com:stratum/stratum.git",
  "org.opencontainers.image.version": "0f37ac125bfd00f0ce3d9a365f05a32ed756a29f"
}
```