### PR TITLE
Pass error message from PI status to ::util::Status

### DIFF
--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -35,7 +35,7 @@ namespace {
     if (results->size() != 0)
       return MAKE_ERROR(ERR_INTERNAL) << "Expected empty results vector.";
     results->resize(updates_size);
-    return ::util::Status();
+    return ::util::OkStatus();
   }
   ::util::Status status(::util::Status::canonical_space(), from.code(),
                         from.message());
@@ -50,10 +50,11 @@ namespace {
 
 ::util::Status toUtilStatus(const DeviceMgr::Status& from) {
   if (from.code() == Code::OK) {
-    return ::util::Status();
+    return ::util::OkStatus();
+  } else {
+    return ::util::Status(::util::Status::canonical_space(), from.code(),
+                          from.message());
   }
-  return ::util::Status(::util::Status::canonical_space(), from.code(),
-                        from.message());
 }
 
 }  // namespace

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -25,7 +25,7 @@ namespace pi {
 namespace {
 
 // Utility functions to convert between grpc::Status and Stratum
-// Util::Status. This is a bit silly because Util::Status will be converted back
+// util::Status. This is a bit silly because util::Status will be converted back
 // to grpc::Status in the P4Service.
 
 ::util::Status toUtilStatus(const DeviceMgr::Status& from,
@@ -37,7 +37,8 @@ namespace {
     results->resize(updates_size);
     return ::util::Status();
   }
-  ::util::Status status(::util::Status::canonical_space(), from.code(), "");
+  ::util::Status status(::util::Status::canonical_space(), from.code(),
+                        from.message());
   for (const auto& detail : from.details()) {
     ::p4::v1::Error error;
     detail.UnpackTo(&error);
@@ -51,7 +52,8 @@ namespace {
   if (from.code() == Code::OK) {
     return ::util::Status();
   }
-  return ::util::Status(::util::Status::canonical_space(), from.code(), "");
+  return ::util::Status(::util::Status::canonical_space(), from.code(),
+                        from.message());
 }
 
 }  // namespace


### PR DESCRIPTION
Currently errors from PI look mostly like this:

```
E20210106 08:49:35.132390   122 bf_switch.cc:135] Return Error: pi_node->PushForwardingPipelineConfig(config) failed with generic::unknown:
E20210106 08:49:35.133188   122 p4_service.cc:411] generic::unknown: Error without message at stratum/hal/lib/common/p4_service.cc:411
```

This is because PI uses UNKNOWN error codes instead of the more descriptive ones: https://github.com/p4lang/PI/blob/e0d7e1f43cf1593abbd2b6e6c46285309d4f3870/proto/frontend/src/device_mgr.cpp#L80-L82
The returned errors still contain a message string, but we drop that and replace it with an empty one in the conversion (`toUtilStatus`). This PR addresses the message.