### PR TITLE
Update P4Runtime to 1.3.0

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -10,8 +10,8 @@ load(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:workspace_rule.bzl", "remote_workspace")
 
-P4RUNTIME_VER = "1.2.0"
-P4RUNTIME_SHA = "0fce7e06c63e60a8cddfe56f3db3d341953560c054d4c09ffda0e84476124f5a"
+P4RUNTIME_VER = "1.3.0"
+P4RUNTIME_SHA = "20b187a965fab78df9b8253da14166b8666938a82a2aeea16c6f9abaa934bdcb"
 
 GNMI_COMMIT = "39cb2fffed5c9a84970bde47b3d39c8c716dc17a"
 GNMI_SHA = "3701005f28044065608322c179625c8898beadb80c89096b3d8aae1fbac15108"


### PR DESCRIPTION
Release: https://github.com/p4lang/p4runtime/releases/tag/v1.3.0

Changelog:
#### Changes in v1.3.0

* Add IANA assigned TCP port, 9559, to P4Runtime server discussion.
* Move "Security considerations" section to P4Runtime server discussion.
* Deprecate `watch` field (int32) in favor of `watch_port` (bytes). This allows
  using the watch port feature with the `p4runtime_translation` feature.
* Replace master, slave, master arbitration with more inclusive language:
  primary, backup, and client arbitration
* Clarify that source locations for annotations are optional in the P4Info
  message.

Diff: https://github.com/p4lang/p4runtime/compare/v1.2.0...v1.3.0