### PR TITLE
Add tool to canonicalize Tofino port ids and apply it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,4 +408,6 @@ workflows:
       - publish-docker-stratum-replay:
           requires:
             - publish-docker-build
-      - publish-docker-chassis-config-migrator
+      - publish-docker-chassis-config-migrator:
+          requires:
+            - publish-docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,35 @@ jobs:
       - *clean_bazel_cache
       - *save_bazel_cache
 
+  publish-docker-chassis-config-migrator:
+    docker:
+      - image: stratumproject/build:build
+    environment:
+      - DOCKER_SCOPE: stratum/hal/config
+      - DOCKER_FILE: Dockerfile
+      - DOCKER_IMG: stratumproject/chassis-config-migrator
+      - CC: clang
+      - CXX: clang++
+    steps:
+      - setup_remote_docker
+      - checkout
+      - *restore_bazel_cache
+      - *set_bazelrc
+      - run:
+          name: Build chassis-config-migrator
+          command: |
+            bazel build //stratum/hal/config:chassis_config_migrator
+            cp bazel-bin/stratum/hal/config/chassis_config_migrator $DOCKER_SCOPE
+      - *docker_login
+      - *docker_build
+      - run:
+          name: Test chassis-config-migrator Docker image
+          command: |
+            docker run $DOCKER_IMG -version
+      - *docker_push
+      - *clean_bazel_cache
+      - *save_bazel_cache
+
   cpp-format-check:
     docker:
       - image: stratumproject/build:build
@@ -379,3 +408,4 @@ workflows:
       - publish-docker-stratum-replay:
           requires:
             - publish-docker-build
+      - publish-docker-chassis-config-migrator

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -315,7 +315,11 @@ Previously, the port `id` was required to match the BF device port ID for Stratu
 to function. Stratum now reads BF device port ID from the SDK using the `node`,
 `port`, and `channel` params provided in the `singleton_ports` config, which means
 the port `id` can now be set to a user-selected value. The `id` is required, and
-it must be positive and unique across all ports in the config.
+it must be positive and unique across all ports in the config. For consistency we
+use the following schema to derive the default port IDs in our configs:
+
+- Non-channelized ports: ID = front panel port number
+- Channelized ports: ID = front panel port * 100 + channel
 
 The BF device port ID (SDK port ID) can be read using gNMI:
 `/interfaces/interface[name=<name>]/state/ifindex`

--- a/stratum/hal/config/BUILD
+++ b/stratum/hal/config/BUILD
@@ -61,8 +61,8 @@ pkg_tar(
 )
 
 stratum_cc_binary(
-    name = "tofino_chassis_config_migrator",
-    srcs = ["tofino_chassis_config_migrator.cc"],
+    name = "chassis_config_migrator",
+    srcs = ["chassis_config_migrator.cc"],
     data = [":platform_configs"],
     deps = [
         "//stratum/glue:init_google",

--- a/stratum/hal/config/BUILD
+++ b/stratum/hal/config/BUILD
@@ -5,11 +5,10 @@
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
-    "stratum_package",
-    "stratum_cc_test",
+    "stratum_cc_binary",
 )
 load(":platform_config_test.bzl", "platform_config_test")
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(default_visibility = STRATUM_INTERNAL)
 
@@ -39,7 +38,7 @@ platform_config_test("x86-64-stordis-bf2556x-1t-r0")
 platform_config_test("x86-64-stordis-bf6064x-t-r0")
 
 filegroup(
-    name="platform_configs",
+    name = "platform_configs",
     srcs = glob([
         "*/base_bcm_chassis_map.pb.txt",
         "*/chassis_config.pb.txt",
@@ -55,8 +54,20 @@ filegroup(
 
 pkg_tar(
     name = "platform_configs_tar",
-    extension = "tar.xz",
-    strip_prefix = ".",  # needed to preserve sub-directory structure: https://github.com/bazelbuild/rules_pkg/issues/82
     srcs = [":platform_configs"],
+    extension = "tar.xz",
     mode = "0644",
+    strip_prefix = ".",  # needed to preserve sub-directory structure: https://github.com/bazelbuild/rules_pkg/issues/82
+)
+
+stratum_cc_binary(
+    name = "tofino_chassis_config_migrator",
+    srcs = ["tofino_chassis_config_migrator.cc"],
+    data = [":platform_configs"],
+    deps = [
+        "//stratum/glue:init_google",
+        "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/lib:utils",
+        "@com_google_absl//absl/strings",
+    ],
 )

--- a/stratum/hal/config/Dockerfile
+++ b/stratum/hal/config/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+FROM bitnami/minideb:stretch
+ADD ./chassis_config_migrator /
+
+LABEL maintainer="Stratum dev <stratum-dev@lists.stratumproject.org>"
+LABEL description="Docker-based distribution of the Stratum chassis config migration tool"
+
+ENTRYPOINT [ "/chassis_config_migrator" ]

--- a/stratum/hal/config/barefoot-tofino-model/chassis_config.pb.txt
+++ b/stratum/hal/config/barefoot-tofino-model/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 1
+  id: 100
   name: "veth1"
   slot: 1
   port: 1
@@ -21,7 +21,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 2
+  id: 101
   name: "veth3"
   slot: 1
   port: 1
@@ -33,7 +33,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 3
+  id: 102
   name: "veth5"
   slot: 1
   port: 1
@@ -45,7 +45,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 103
   name: "veth7"
   slot: 1
   port: 1
@@ -57,7 +57,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 5
+  id: 200
   name: "veth9"
   slot: 1
   port: 2
@@ -69,7 +69,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 6
+  id: 201
   name: "veth11"
   slot: 1
   port: 2
@@ -81,7 +81,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 7
+  id: 202
   name: "veth13"
   slot: 1
   port: 2
@@ -93,7 +93,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 203
   name: "veth15"
   slot: 1
   port: 2
@@ -105,7 +105,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 9
+  id: 300
   name: "veth17"
   slot: 1
   port: 3
@@ -117,7 +117,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 10
+  id: 301
   name: "veth19"
   slot: 1
   port: 3
@@ -129,7 +129,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 11
+  id: 302
   name: "veth21"
   slot: 1
   port: 3
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 303
   name: "veth23"
   slot: 1
   port: 3
@@ -153,7 +153,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 13
+  id: 400
   name: "veth25"
   slot: 1
   port: 4
@@ -165,7 +165,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 14
+  id: 401
   name: "veth27"
   slot: 1
   port: 4
@@ -177,7 +177,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 15
+  id: 402
   name: "veth29"
   slot: 1
   port: 4
@@ -189,7 +189,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 403
   name: "veth31"
   slot: 1
   port: 4
@@ -201,7 +201,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 17
+  id: 500
   name: "veth33"
   slot: 1
   port: 5

--- a/stratum/hal/config/chassis_config_migrator.cc
+++ b/stratum/hal/config/chassis_config_migrator.cc
@@ -27,7 +27,7 @@ Chassis configuration migration and validation tool.
 
 Combine with xargs for bulk migration:
 ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
-  xargs -n 1 bazel run //stratum/hal/config:tofino_chassis_config_migrator -- \
+  xargs -n 1 bazel run //stratum/hal/config:chassis_config_migrator -- \
     -chassis_config_file
 )USAGE";
 

--- a/stratum/hal/config/tofino_chassis_config_migrator.cc
+++ b/stratum/hal/config/tofino_chassis_config_migrator.cc
@@ -1,0 +1,73 @@
+// Copyright 2021-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string>
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
+#include "gflags/gflags.h"
+#include "stratum/glue/init_google.h"
+#include "stratum/glue/logging.h"
+#include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/lib/macros.h"
+#include "stratum/lib/utils.h"
+
+DEFINE_string(chassis_config_file, "",
+              "Path to chassis configuration to migrate.");
+
+namespace stratum {
+namespace hal {
+namespace config {
+
+const char kUsage[] =
+    R"USAGE(usage: --chassis_config_file=<path>
+
+Chassis configuration migration tool.
+
+Combine with xargs for mass migration:
+ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
+  xargs -n 1 bazel run //stratum/hal/config:tofino_chassis_config_migrator -- \
+    -chassis_config_file
+)USAGE";
+
+::util::Status Main(int argc, char** argv) {
+  ::gflags::SetUsageMessage(kUsage);
+  InitGoogle(argv[0], &argc, &argv, true);
+  stratum::InitStratumLogging();
+
+  CHECK_RETURN_IF_FALSE(!FLAGS_chassis_config_file.empty())
+      << "No chassis config given.";
+  ChassisConfig config;
+  RETURN_IF_ERROR(ReadProtoFromTextFile(FLAGS_chassis_config_file, &config));
+  if (config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO &&
+      config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO2) {
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Chassis config is not for Tofino platform";
+  }
+  for (auto& singleton_port : *config.mutable_singleton_ports()) {
+    std::vector<std::string> parts = absl::StrSplit(singleton_port.name(), '/');
+    CHECK_RETURN_IF_FALSE(parts.size() == 2)
+        << "Can't parse port name " << singleton_port.name() << ".";
+    int new_port_id;
+    CHECK_RETURN_IF_FALSE(absl::SimpleAtoi(parts[0], &new_port_id));
+
+    singleton_port.set_id(new_port_id);
+  }
+  RETURN_IF_ERROR(WriteProtoToTextFile(config, FLAGS_chassis_config_file));
+
+  return ::util::OkStatus();
+}
+
+}  // namespace config
+}  // namespace hal
+}  // namespace stratum
+
+int main(int argc, char** argv) {
+  ::util::Status status = stratum::hal::config::Main(argc, argv);
+  if (status.ok()) {
+    return 0;
+  } else {
+    LOG(ERROR) << status;
+    return status.error_code();
+  }
+}

--- a/stratum/hal/config/x86-64-accton-wedge100bf-32qs-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-32qs-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 260
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -373,7 +373,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 66
+  id: 33
   name: "33/2"
   slot: 1
   port: 33

--- a/stratum/hal/config/x86-64-accton-wedge100bf-32qs-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-32qs-r0/chassis_config.pb.txt
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 33
+  id: 3300
   name: "33/0"
   slot: 1
   port: 33
@@ -373,7 +373,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 33
+  id: 3302
   name: "33/2"
   slot: 1
   port: 33

--- a/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 128
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 32
   name: "32/0"
   slot: 1
   port: 32

--- a/stratum/hal/config/x86-64-accton-wedge100bf-65x-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-65x-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 188
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 260
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 416
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 420
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 424
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 428
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 432
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 436
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 440
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 444
+  id: 56
   name: "56/0"
   slot: 1
   port: 56
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 384
+  id: 57
   name: "57/0"
   slot: 1
   port: 57
@@ -636,7 +636,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 388
+  id: 58
   name: "58/0"
   slot: 1
   port: 58
@@ -647,7 +647,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 392
+  id: 59
   name: "59/0"
   slot: 1
   port: 59
@@ -658,7 +658,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 396
+  id: 60
   name: "60/0"
   slot: 1
   port: 60
@@ -669,7 +669,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 400
+  id: 61
   name: "61/0"
   slot: 1
   port: 61
@@ -680,7 +680,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 404
+  id: 62
   name: "62/0"
   slot: 1
   port: 62
@@ -691,7 +691,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 408
+  id: 63
   name: "63/0"
   slot: 1
   port: 63
@@ -702,7 +702,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 412
+  id: 64
   name: "64/0"
   slot: 1
   port: 64
@@ -713,7 +713,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 65
   name: "65/0"
   slot: 1
   port: 65

--- a/stratum/hal/config/x86-64-delta-ag9064v1-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-delta-ag9064v1-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 48
+  id: 1
   name: "1/0"
   slot: 1
   port: 48
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 2
   name: "2/0"
   slot: 1
   port: 52
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 444
+  id: 3
   name: "3/0"
   slot: 1
   port: 444
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 440
+  id: 4
   name: "4/0"
   slot: 1
   port: 440
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 428
+  id: 5
   name: "5/0"
   slot: 1
   port: 428
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 424
+  id: 6
   name: "6/0"
   slot: 1
   port: 424
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 412
+  id: 7
   name: "7/0"
   slot: 1
   port: 412
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 408
+  id: 8
   name: "8/0"
   slot: 1
   port: 408
@@ -97,10 +97,9 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 9
   name: "9/0"
   slot: 1
-  port: 0
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -108,7 +107,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 10
   name: "10/0"
   slot: 1
   port: 4
@@ -119,7 +118,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 11
   name: "11/0"
   slot: 1
   port: 16
@@ -130,7 +129,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 12
   name: "12/0"
   slot: 1
   port: 20
@@ -141,7 +140,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 13
   name: "13/0"
   slot: 1
   port: 32
@@ -152,7 +151,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 14
   name: "14/0"
   slot: 1
   port: 36
@@ -163,7 +162,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 396
+  id: 15
   name: "15/0"
   slot: 1
   port: 396
@@ -174,7 +173,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 392
+  id: 16
   name: "16/0"
   slot: 1
   port: 392
@@ -185,7 +184,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 17
   name: "17/0"
   slot: 1
   port: 256
@@ -196,7 +195,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 260
+  id: 18
   name: "18/0"
   slot: 1
   port: 260
@@ -207,7 +206,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 19
   name: "19/0"
   slot: 1
   port: 188
@@ -218,7 +217,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 20
   name: "20/0"
   slot: 1
   port: 184
@@ -229,7 +228,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 21
   name: "21/0"
   slot: 1
   port: 172
@@ -240,7 +239,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 22
   name: "22/0"
   slot: 1
   port: 168
@@ -251,7 +250,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 23
   name: "23/0"
   slot: 1
   port: 156
@@ -262,7 +261,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 24
   name: "24/0"
   slot: 1
   port: 152
@@ -273,7 +272,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 25
   name: "25/0"
   slot: 1
   port: 140
@@ -284,7 +283,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 26
   name: "26/0"
   slot: 1
   port: 136
@@ -295,7 +294,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 27
   name: "27/0"
   slot: 1
   port: 272
@@ -306,7 +305,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 28
   name: "28/0"
   slot: 1
   port: 276
@@ -317,7 +316,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 29
   name: "29/0"
   slot: 1
   port: 288
@@ -328,7 +327,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 30
   name: "30/0"
   slot: 1
   port: 292
@@ -339,7 +338,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 31
   name: "31/0"
   slot: 1
   port: 304
@@ -350,7 +349,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 32
   name: "32/0"
   slot: 1
   port: 308
@@ -361,7 +360,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 33
   name: "33/0"
   slot: 1
   port: 60
@@ -372,7 +371,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 34
   name: "34/0"
   slot: 1
   port: 56
@@ -383,7 +382,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 432
+  id: 35
   name: "35/0"
   slot: 1
   port: 432
@@ -394,7 +393,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 436
+  id: 36
   name: "36/0"
   slot: 1
   port: 436
@@ -405,7 +404,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 416
+  id: 37
   name: "37/0"
   slot: 1
   port: 416
@@ -416,7 +415,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 420
+  id: 38
   name: "38/0"
   slot: 1
   port: 420
@@ -427,7 +426,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 400
+  id: 39
   name: "39/0"
   slot: 1
   port: 400
@@ -438,7 +437,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 404
+  id: 40
   name: "40/0"
   slot: 1
   port: 404
@@ -449,7 +448,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 41
   name: "41/0"
   slot: 1
   port: 12
@@ -460,7 +459,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 42
   name: "42/0"
   slot: 1
   port: 8
@@ -471,7 +470,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 43
   name: "43/0"
   slot: 1
   port: 28
@@ -482,7 +481,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 44
   name: "44/0"
   slot: 1
   port: 24
@@ -493,7 +492,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 45
   name: "45/0"
   slot: 1
   port: 44
@@ -504,7 +503,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 46
   name: "46/0"
   slot: 1
   port: 40
@@ -515,7 +514,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 384
+  id: 47
   name: "47/0"
   slot: 1
   port: 384
@@ -526,7 +525,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 388
+  id: 48
   name: "48/0"
   slot: 1
   port: 388
@@ -537,7 +536,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 49
   name: "49/0"
   slot: 1
   port: 268
@@ -548,7 +547,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 50
   name: "50/0"
   slot: 1
   port: 264
@@ -559,7 +558,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 51
   name: "51/0"
   slot: 1
   port: 176
@@ -570,7 +569,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 52
   name: "52/0"
   slot: 1
   port: 180
@@ -581,7 +580,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 53
   name: "53/0"
   slot: 1
   port: 160
@@ -592,7 +591,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 54
   name: "54/0"
   slot: 1
   port: 164
@@ -603,7 +602,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 55
   name: "55/0"
   slot: 1
   port: 144
@@ -614,7 +613,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 56
   name: "56/0"
   slot: 1
   port: 148
@@ -625,7 +624,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 57
   name: "57/0"
   slot: 1
   port: 128
@@ -636,7 +635,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 58
   name: "58/0"
   slot: 1
   port: 132
@@ -647,7 +646,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 59
   name: "59/0"
   slot: 1
   port: 284
@@ -658,7 +657,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 60
   name: "60/0"
   slot: 1
   port: 280
@@ -669,7 +668,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 61
   name: "61/0"
   slot: 1
   port: 300
@@ -680,7 +679,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 62
   name: "62/0"
   slot: 1
   port: 296
@@ -691,7 +690,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 63
   name: "63/0"
   slot: 1
   port: 316
@@ -702,7 +701,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 64
   name: "64/0"
   slot: 1
   port: 312
@@ -713,7 +712,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 65
   name: "65/0"
   slot: 1
   port: 64

--- a/stratum/hal/config/x86-64-delta-ag9064v1-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-delta-ag9064v1-r0/chassis_config.pb.txt
@@ -12,7 +12,7 @@ singleton_ports {
   id: 1
   name: "1/0"
   slot: 1
-  port: 48
+  port: 1
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -23,7 +23,7 @@ singleton_ports {
   id: 2
   name: "2/0"
   slot: 1
-  port: 52
+  port: 2
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -34,7 +34,7 @@ singleton_ports {
   id: 3
   name: "3/0"
   slot: 1
-  port: 444
+  port: 3
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -45,7 +45,7 @@ singleton_ports {
   id: 4
   name: "4/0"
   slot: 1
-  port: 440
+  port: 4
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -56,7 +56,7 @@ singleton_ports {
   id: 5
   name: "5/0"
   slot: 1
-  port: 428
+  port: 5
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -67,7 +67,7 @@ singleton_ports {
   id: 6
   name: "6/0"
   slot: 1
-  port: 424
+  port: 6
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -78,7 +78,7 @@ singleton_ports {
   id: 7
   name: "7/0"
   slot: 1
-  port: 412
+  port: 7
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -89,7 +89,7 @@ singleton_ports {
   id: 8
   name: "8/0"
   slot: 1
-  port: 408
+  port: 8
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -100,6 +100,7 @@ singleton_ports {
   id: 9
   name: "9/0"
   slot: 1
+  port: 9
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -110,7 +111,7 @@ singleton_ports {
   id: 10
   name: "10/0"
   slot: 1
-  port: 4
+  port: 10
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -121,7 +122,7 @@ singleton_ports {
   id: 11
   name: "11/0"
   slot: 1
-  port: 16
+  port: 11
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -132,7 +133,7 @@ singleton_ports {
   id: 12
   name: "12/0"
   slot: 1
-  port: 20
+  port: 12
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -143,7 +144,7 @@ singleton_ports {
   id: 13
   name: "13/0"
   slot: 1
-  port: 32
+  port: 13
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -154,7 +155,7 @@ singleton_ports {
   id: 14
   name: "14/0"
   slot: 1
-  port: 36
+  port: 14
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -165,7 +166,7 @@ singleton_ports {
   id: 15
   name: "15/0"
   slot: 1
-  port: 396
+  port: 15
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -176,7 +177,7 @@ singleton_ports {
   id: 16
   name: "16/0"
   slot: 1
-  port: 392
+  port: 16
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -187,7 +188,7 @@ singleton_ports {
   id: 17
   name: "17/0"
   slot: 1
-  port: 256
+  port: 17
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -198,7 +199,7 @@ singleton_ports {
   id: 18
   name: "18/0"
   slot: 1
-  port: 260
+  port: 18
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -209,7 +210,7 @@ singleton_ports {
   id: 19
   name: "19/0"
   slot: 1
-  port: 188
+  port: 19
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -220,7 +221,7 @@ singleton_ports {
   id: 20
   name: "20/0"
   slot: 1
-  port: 184
+  port: 20
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -231,7 +232,7 @@ singleton_ports {
   id: 21
   name: "21/0"
   slot: 1
-  port: 172
+  port: 21
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -242,7 +243,7 @@ singleton_ports {
   id: 22
   name: "22/0"
   slot: 1
-  port: 168
+  port: 22
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -253,7 +254,7 @@ singleton_ports {
   id: 23
   name: "23/0"
   slot: 1
-  port: 156
+  port: 23
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -264,7 +265,7 @@ singleton_ports {
   id: 24
   name: "24/0"
   slot: 1
-  port: 152
+  port: 24
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -275,7 +276,7 @@ singleton_ports {
   id: 25
   name: "25/0"
   slot: 1
-  port: 140
+  port: 25
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -286,7 +287,7 @@ singleton_ports {
   id: 26
   name: "26/0"
   slot: 1
-  port: 136
+  port: 26
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -297,7 +298,7 @@ singleton_ports {
   id: 27
   name: "27/0"
   slot: 1
-  port: 272
+  port: 27
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -308,7 +309,7 @@ singleton_ports {
   id: 28
   name: "28/0"
   slot: 1
-  port: 276
+  port: 28
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -319,7 +320,7 @@ singleton_ports {
   id: 29
   name: "29/0"
   slot: 1
-  port: 288
+  port: 29
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -330,7 +331,7 @@ singleton_ports {
   id: 30
   name: "30/0"
   slot: 1
-  port: 292
+  port: 30
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -341,7 +342,7 @@ singleton_ports {
   id: 31
   name: "31/0"
   slot: 1
-  port: 304
+  port: 31
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -352,7 +353,7 @@ singleton_ports {
   id: 32
   name: "32/0"
   slot: 1
-  port: 308
+  port: 32
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -363,7 +364,7 @@ singleton_ports {
   id: 33
   name: "33/0"
   slot: 1
-  port: 60
+  port: 33
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -374,7 +375,7 @@ singleton_ports {
   id: 34
   name: "34/0"
   slot: 1
-  port: 56
+  port: 34
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -385,7 +386,7 @@ singleton_ports {
   id: 35
   name: "35/0"
   slot: 1
-  port: 432
+  port: 35
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -396,7 +397,7 @@ singleton_ports {
   id: 36
   name: "36/0"
   slot: 1
-  port: 436
+  port: 36
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -407,7 +408,7 @@ singleton_ports {
   id: 37
   name: "37/0"
   slot: 1
-  port: 416
+  port: 37
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -418,7 +419,7 @@ singleton_ports {
   id: 38
   name: "38/0"
   slot: 1
-  port: 420
+  port: 38
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -429,7 +430,7 @@ singleton_ports {
   id: 39
   name: "39/0"
   slot: 1
-  port: 400
+  port: 39
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -440,7 +441,7 @@ singleton_ports {
   id: 40
   name: "40/0"
   slot: 1
-  port: 404
+  port: 40
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -451,7 +452,7 @@ singleton_ports {
   id: 41
   name: "41/0"
   slot: 1
-  port: 12
+  port: 41
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -462,7 +463,7 @@ singleton_ports {
   id: 42
   name: "42/0"
   slot: 1
-  port: 8
+  port: 42
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -473,7 +474,7 @@ singleton_ports {
   id: 43
   name: "43/0"
   slot: 1
-  port: 28
+  port: 43
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -484,7 +485,7 @@ singleton_ports {
   id: 44
   name: "44/0"
   slot: 1
-  port: 24
+  port: 44
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -495,7 +496,7 @@ singleton_ports {
   id: 45
   name: "45/0"
   slot: 1
-  port: 44
+  port: 45
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -506,7 +507,7 @@ singleton_ports {
   id: 46
   name: "46/0"
   slot: 1
-  port: 40
+  port: 46
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -517,7 +518,7 @@ singleton_ports {
   id: 47
   name: "47/0"
   slot: 1
-  port: 384
+  port: 47
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -528,7 +529,7 @@ singleton_ports {
   id: 48
   name: "48/0"
   slot: 1
-  port: 388
+  port: 48
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -539,7 +540,7 @@ singleton_ports {
   id: 49
   name: "49/0"
   slot: 1
-  port: 268
+  port: 49
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -550,7 +551,7 @@ singleton_ports {
   id: 50
   name: "50/0"
   slot: 1
-  port: 264
+  port: 50
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -561,7 +562,7 @@ singleton_ports {
   id: 51
   name: "51/0"
   slot: 1
-  port: 176
+  port: 51
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -572,7 +573,7 @@ singleton_ports {
   id: 52
   name: "52/0"
   slot: 1
-  port: 180
+  port: 52
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -583,7 +584,7 @@ singleton_ports {
   id: 53
   name: "53/0"
   slot: 1
-  port: 160
+  port: 53
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -594,7 +595,7 @@ singleton_ports {
   id: 54
   name: "54/0"
   slot: 1
-  port: 164
+  port: 54
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -605,7 +606,7 @@ singleton_ports {
   id: 55
   name: "55/0"
   slot: 1
-  port: 144
+  port: 55
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -616,7 +617,7 @@ singleton_ports {
   id: 56
   name: "56/0"
   slot: 1
-  port: 148
+  port: 56
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -627,7 +628,7 @@ singleton_ports {
   id: 57
   name: "57/0"
   slot: 1
-  port: 128
+  port: 57
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -638,7 +639,7 @@ singleton_ports {
   id: 58
   name: "58/0"
   slot: 1
-  port: 132
+  port: 58
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -649,7 +650,7 @@ singleton_ports {
   id: 59
   name: "59/0"
   slot: 1
-  port: 284
+  port: 59
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -660,7 +661,7 @@ singleton_ports {
   id: 60
   name: "60/0"
   slot: 1
-  port: 280
+  port: 60
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -671,7 +672,7 @@ singleton_ports {
   id: 61
   name: "61/0"
   slot: 1
-  port: 300
+  port: 61
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -682,7 +683,7 @@ singleton_ports {
   id: 62
   name: "62/0"
   slot: 1
-  port: 296
+  port: 62
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -693,7 +694,7 @@ singleton_ports {
   id: 63
   name: "63/0"
   slot: 1
-  port: 316
+  port: 63
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -704,7 +705,7 @@ singleton_ports {
   id: 64
   name: "64/0"
   slot: 1
-  port: 312
+  port: 64
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED
@@ -715,7 +716,7 @@ singleton_ports {
   id: 65
   name: "65/0"
   slot: 1
-  port: 64
+  port: 65
   speed_bps: 100000000000
   config_params {
     admin_state: ADMIN_STATE_ENABLED

--- a/stratum/hal/config/x86-64-inventec-d10056-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-inventec-d10056-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 129
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 131
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 130
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 137
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 139
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 138
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 153
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 155
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 154
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 169
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 171
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 170
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 185
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 187
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 186
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 53
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 55
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 54
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 37
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 39
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 38
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 21
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 22
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 23
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 13
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 15
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 14
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 6
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 7
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 5
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 2
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 3
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 1
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 10
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 9
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 11
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 56
   name: "56/0"
   slot: 1
   port: 56

--- a/stratum/hal/config/x86-64-inventec-d10064-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-inventec-d10064-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 188
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 260
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 444
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 440
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 436
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 432
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 428
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 424
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 420
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 416
+  id: 56
   name: "56/0"
   slot: 1
   port: 56
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 412
+  id: 57
   name: "57/0"
   slot: 1
   port: 57
@@ -636,7 +636,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 408
+  id: 58
   name: "58/0"
   slot: 1
   port: 58
@@ -647,7 +647,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 404
+  id: 59
   name: "59/0"
   slot: 1
   port: 59
@@ -658,7 +658,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 400
+  id: 60
   name: "60/0"
   slot: 1
   port: 60
@@ -669,7 +669,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 396
+  id: 61
   name: "61/0"
   slot: 1
   port: 61
@@ -680,7 +680,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 392
+  id: 62
   name: "62/0"
   slot: 1
   port: 62
@@ -691,7 +691,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 388
+  id: 63
   name: "63/0"
   slot: 1
   port: 63
@@ -702,7 +702,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 384
+  id: 64
   name: "64/0"
   slot: 1
   port: 64
@@ -713,7 +713,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 65
   name: "65/0"
   slot: 1
   port: 65

--- a/stratum/hal/config/x86-64-inventec-d5254-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-inventec-d5254-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 132
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 133
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 134
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 135
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 141
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 142
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 143
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 157
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 158
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 159
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 173
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 174
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 175
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 189
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 190
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 191
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 49
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 50
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 51
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 33
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 34
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 35
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 17
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 18
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 19
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 1
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 2
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 3
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 5
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 6
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 7
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 13
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 14
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 15
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 29
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 30
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 31
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 54
   name: "54/0"
   slot: 1
   port: 54

--- a/stratum/hal/config/x86-64-inventec-d5264q28b-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-inventec-d5264q28b-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 188
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 260
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 444
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 440
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 436
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 432
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 428
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 424
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 420
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 416
+  id: 56
   name: "56/0"
   slot: 1
   port: 56
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 412
+  id: 57
   name: "57/0"
   slot: 1
   port: 57
@@ -636,7 +636,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 408
+  id: 58
   name: "58/0"
   slot: 1
   port: 58
@@ -647,7 +647,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 404
+  id: 59
   name: "59/0"
   slot: 1
   port: 59
@@ -658,7 +658,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 400
+  id: 60
   name: "60/0"
   slot: 1
   port: 60
@@ -669,7 +669,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 396
+  id: 61
   name: "61/0"
   slot: 1
   port: 61
@@ -680,7 +680,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 392
+  id: 62
   name: "62/0"
   slot: 1
   port: 62
@@ -691,7 +691,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 388
+  id: 63
   name: "63/0"
   slot: 1
   port: 63
@@ -702,7 +702,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 384
+  id: 64
   name: "64/0"
   slot: 1
   port: 64
@@ -713,7 +713,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 65
   name: "65/0"
   slot: 1
   port: 65

--- a/stratum/hal/config/x86-64-netberg-aurora-610-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-netberg-aurora-610-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 133
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 135
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 134
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 141
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 143
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 142
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 157
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 159
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 158
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 173
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 175
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 174
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 189
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 191
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 190
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 49
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 51
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 50
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 33
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 35
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 34
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 17
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 18
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 19
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 9
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 11
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 10
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 2
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 3
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 1
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 6
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 7
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 5
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 14
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 13
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 15
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 56
   name: "56/0"
   slot: 1
   port: 56

--- a/stratum/hal/config/x86-64-netberg-aurora-710-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-netberg-aurora-710-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 132
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 32
   name: "32/0"
   slot: 1
   port: 32

--- a/stratum/hal/config/x86-64-netberg-aurora-750-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-netberg-aurora-750-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 432
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 436
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 420
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 416
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 404
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 400
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 384
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 388
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 444
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 440
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 424
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 428
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 408
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 412
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 392
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 396
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 260
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 56
   name: "56/0"
   slot: 1
   port: 56
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 57
   name: "57/0"
   slot: 1
   port: 57
@@ -636,7 +636,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 58
   name: "58/0"
   slot: 1
   port: 58
@@ -647,7 +647,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 59
   name: "59/0"
   slot: 1
   port: 59
@@ -658,7 +658,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 60
   name: "60/0"
   slot: 1
   port: 60
@@ -669,7 +669,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 61
   name: "61/0"
   slot: 1
   port: 61
@@ -680,7 +680,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 62
   name: "62/0"
   slot: 1
   port: 62
@@ -691,7 +691,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 63
   name: "63/0"
   slot: 1
   port: 63
@@ -702,7 +702,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 64
   name: "64/0"
   slot: 1
   port: 64
@@ -713,7 +713,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 65
   name: "65/0"
   slot: 1
   port: 65

--- a/stratum/hal/config/x86-64-stordis-bf2556x-1t-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-stordis-bf2556x-1t-r0/chassis_config.pb.txt
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 57
+  id: 5700
   name: "57/0"
   slot: 1
   port: 57
@@ -638,7 +638,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 57
+  id: 5701
   name: "57/1"
   slot: 1
   port: 57
@@ -651,7 +651,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 57
+  id: 5702
   name: "57/2"
   slot: 1
   port: 57
@@ -663,7 +663,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 57
+  id: 5703
   name: "57/3"
   slot: 1
   port: 57

--- a/stratum/hal/config/x86-64-stordis-bf2556x-1t-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-stordis-bf2556x-1t-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 0
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 1
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 2
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 3
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 5
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 6
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 7
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 13
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 14
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 15
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 29
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 30
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 31
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 45
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 46
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 47
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 61
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 62
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 63
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 177
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 178
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 179
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 161
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 162
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 163
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 145
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 146
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 147
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 137
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 138
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 139
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 129
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 130
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 131
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 133
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 134
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 135
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 48
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 56
   name: "56/0"
   slot: 1
   port: 56
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 57
   name: "57/0"
   slot: 1
   port: 57
@@ -638,7 +638,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 65
+  id: 57
   name: "57/1"
   slot: 1
   port: 57
@@ -651,7 +651,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 66
+  id: 57
   name: "57/2"
   slot: 1
   port: 57
@@ -663,7 +663,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 67
+  id: 57
   name: "57/3"
   slot: 1
   port: 57

--- a/stratum/hal/config/x86-64-stordis-bf6064x-t-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-stordis-bf6064x-t-r0/chassis_config.pb.txt
@@ -9,7 +9,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 48
+  id: 1
   name: "1/0"
   slot: 1
   port: 1
@@ -20,7 +20,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 52
+  id: 2
   name: "2/0"
   slot: 1
   port: 2
@@ -31,7 +31,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 444
+  id: 3
   name: "3/0"
   slot: 1
   port: 3
@@ -42,7 +42,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 440
+  id: 4
   name: "4/0"
   slot: 1
   port: 4
@@ -53,7 +53,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 428
+  id: 5
   name: "5/0"
   slot: 1
   port: 5
@@ -64,7 +64,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 424
+  id: 6
   name: "6/0"
   slot: 1
   port: 6
@@ -75,7 +75,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 412
+  id: 7
   name: "7/0"
   slot: 1
   port: 7
@@ -86,7 +86,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 408
+  id: 8
   name: "8/0"
   slot: 1
   port: 8
@@ -97,7 +97,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 0
+  id: 9
   name: "9/0"
   slot: 1
   port: 9
@@ -108,7 +108,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 10
   name: "10/0"
   slot: 1
   port: 10
@@ -119,7 +119,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 16
+  id: 11
   name: "11/0"
   slot: 1
   port: 11
@@ -130,7 +130,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 20
+  id: 12
   name: "12/0"
   slot: 1
   port: 12
@@ -141,7 +141,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 32
+  id: 13
   name: "13/0"
   slot: 1
   port: 13
@@ -152,7 +152,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 36
+  id: 14
   name: "14/0"
   slot: 1
   port: 14
@@ -163,7 +163,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 396
+  id: 15
   name: "15/0"
   slot: 1
   port: 15
@@ -174,7 +174,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 392
+  id: 16
   name: "16/0"
   slot: 1
   port: 16
@@ -185,7 +185,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 256
+  id: 17
   name: "17/0"
   slot: 1
   port: 17
@@ -196,7 +196,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 260
+  id: 18
   name: "18/0"
   slot: 1
   port: 18
@@ -207,7 +207,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 188
+  id: 19
   name: "19/0"
   slot: 1
   port: 19
@@ -218,7 +218,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 184
+  id: 20
   name: "20/0"
   slot: 1
   port: 20
@@ -229,7 +229,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 172
+  id: 21
   name: "21/0"
   slot: 1
   port: 21
@@ -240,7 +240,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 168
+  id: 22
   name: "22/0"
   slot: 1
   port: 22
@@ -251,7 +251,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 156
+  id: 23
   name: "23/0"
   slot: 1
   port: 23
@@ -262,7 +262,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 152
+  id: 24
   name: "24/0"
   slot: 1
   port: 24
@@ -273,7 +273,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 140
+  id: 25
   name: "25/0"
   slot: 1
   port: 25
@@ -284,7 +284,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 136
+  id: 26
   name: "26/0"
   slot: 1
   port: 26
@@ -295,7 +295,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 272
+  id: 27
   name: "27/0"
   slot: 1
   port: 27
@@ -306,7 +306,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 276
+  id: 28
   name: "28/0"
   slot: 1
   port: 28
@@ -317,7 +317,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 288
+  id: 29
   name: "29/0"
   slot: 1
   port: 29
@@ -328,7 +328,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 292
+  id: 30
   name: "30/0"
   slot: 1
   port: 30
@@ -339,7 +339,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 304
+  id: 31
   name: "31/0"
   slot: 1
   port: 31
@@ -350,7 +350,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 308
+  id: 32
   name: "32/0"
   slot: 1
   port: 32
@@ -361,7 +361,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 60
+  id: 33
   name: "33/0"
   slot: 1
   port: 33
@@ -372,7 +372,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 56
+  id: 34
   name: "34/0"
   slot: 1
   port: 34
@@ -383,7 +383,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 432
+  id: 35
   name: "35/0"
   slot: 1
   port: 35
@@ -394,7 +394,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 436
+  id: 36
   name: "36/0"
   slot: 1
   port: 36
@@ -405,7 +405,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 416
+  id: 37
   name: "37/0"
   slot: 1
   port: 37
@@ -416,7 +416,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 420
+  id: 38
   name: "38/0"
   slot: 1
   port: 38
@@ -427,7 +427,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 400
+  id: 39
   name: "39/0"
   slot: 1
   port: 39
@@ -438,7 +438,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 404
+  id: 40
   name: "40/0"
   slot: 1
   port: 40
@@ -449,7 +449,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 12
+  id: 41
   name: "41/0"
   slot: 1
   port: 41
@@ -460,7 +460,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 8
+  id: 42
   name: "42/0"
   slot: 1
   port: 42
@@ -471,7 +471,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 28
+  id: 43
   name: "43/0"
   slot: 1
   port: 43
@@ -482,7 +482,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 24
+  id: 44
   name: "44/0"
   slot: 1
   port: 44
@@ -493,7 +493,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 44
+  id: 45
   name: "45/0"
   slot: 1
   port: 45
@@ -504,7 +504,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 40
+  id: 46
   name: "46/0"
   slot: 1
   port: 46
@@ -515,7 +515,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 384
+  id: 47
   name: "47/0"
   slot: 1
   port: 47
@@ -526,7 +526,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 388
+  id: 48
   name: "48/0"
   slot: 1
   port: 48
@@ -537,7 +537,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 268
+  id: 49
   name: "49/0"
   slot: 1
   port: 49
@@ -548,7 +548,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 264
+  id: 50
   name: "50/0"
   slot: 1
   port: 50
@@ -559,7 +559,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 176
+  id: 51
   name: "51/0"
   slot: 1
   port: 51
@@ -570,7 +570,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 180
+  id: 52
   name: "52/0"
   slot: 1
   port: 52
@@ -581,7 +581,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 160
+  id: 53
   name: "53/0"
   slot: 1
   port: 53
@@ -592,7 +592,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 164
+  id: 54
   name: "54/0"
   slot: 1
   port: 54
@@ -603,7 +603,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 144
+  id: 55
   name: "55/0"
   slot: 1
   port: 55
@@ -614,7 +614,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 148
+  id: 56
   name: "56/0"
   slot: 1
   port: 56
@@ -625,7 +625,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 128
+  id: 57
   name: "57/0"
   slot: 1
   port: 57
@@ -636,7 +636,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 132
+  id: 58
   name: "58/0"
   slot: 1
   port: 58
@@ -647,7 +647,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 284
+  id: 59
   name: "59/0"
   slot: 1
   port: 59
@@ -658,7 +658,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 280
+  id: 60
   name: "60/0"
   slot: 1
   port: 60
@@ -669,7 +669,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 300
+  id: 61
   name: "61/0"
   slot: 1
   port: 61
@@ -680,7 +680,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 296
+  id: 62
   name: "62/0"
   slot: 1
   port: 62
@@ -691,7 +691,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 316
+  id: 63
   name: "63/0"
   slot: 1
   port: 63
@@ -702,7 +702,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 312
+  id: 64
   name: "64/0"
   slot: 1
   port: 64
@@ -713,7 +713,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 64
+  id: 65
   name: "65/0"
   slot: 1
   port: 65


### PR DESCRIPTION
This PR canonicalizes the Tofino port IDs in our chassis configs to match the port name and port field (`"10/0"` -> `10`).
It also adds a tool to do this in an automated fashion:

```bash
ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
  xargs -n 1 bazel run //stratum/hal/config:chassis_config_migrator -- \
    -chassis_config_file
```

TODOs:

- [x] Try loading the configs once
- [x] ~~Move code to tools~~ We don't want to make this too official
- [x] Publish docker container

Closes #379