### PR TITLE
Stamp binaries with version information

### DIFF
--- a/.circleci/workspace_status.sh
+++ b/.circleci/workspace_status.sh
@@ -10,6 +10,9 @@
 # KEY1 VALUE1
 # KEY2 VALUE2
 #
+# Keys starting with "STABLE_" will go into the stable status file. Others in
+# the volatile.
+#
 # If the script exits with non-zero code, it's considered as a failure
 # and the output will be discarded.
 set -e -o pipefail
@@ -17,11 +20,18 @@ set -e -o pipefail
 # The upstream git URL
 git_url=$(git config --get remote.origin.url)
 echo "GIT_URL ${git_url}"
+echo "STABLE_GIT_URL ${git_url}"
 
 # The git commit checksum, with "-dirty" if modified
 git_sha=$(git describe --tags --match XXXXXXX --always --abbrev=40 --dirty)
 echo "GIT_SHA ${git_sha}"
+echo "STABLE_GIT_SHA ${git_sha}"
 
 # Tag name, or GIT_SHA if not on a tag
 git_ref=$(git describe --tags --no-match --always --abbrev=40 --dirty | sed -E 's/^.*-g([0-9a-f]{40}-?.*)$/\1/')
 echo "GIT_REF ${git_ref}"
+echo "STABLE_GIT_REF ${git_ref}"
+
+echo "STABLE_TS" $(date +%FT%T%z)
+
+echo "BUILD_SCM_REVISION" $(git rev-parse HEAD)

--- a/stratum/lib/BUILD
+++ b/stratum/lib/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache v2
 load(
     "//bazel:rules.bzl",
     "stratum_cc_library",
+    "stratum_cc_binary",
     "stratum_cc_test",
     "STRATUM_INTERNAL",
 )
@@ -123,4 +124,34 @@ stratum_cc_test(
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
     ],
+)
+
+genrule(
+  name = "version_variables_impl",
+  outs = ["version_variables.cc"],
+  cmd = """echo '#include "stratum/lib/version_variables.h"' >> $@;
+            git_ref=$$(grep STABLE_GIT_REF bazel-out/stable-status.txt \\
+            | sed 's/^STABLE_GIT_REF //');
+            echo 'const char kGitRef[] = "'$$git_ref'";' >> $@;
+            BUILD_TIMESTAMP=$$(grep BUILD_TIMESTAMP bazel-out/volatile-status.txt \\
+            | sed 's/^BUILD_TIMESTAMP //');
+            echo 'const char kBuildTimestamp[] = "'$$BUILD_TIMESTAMP'";' >> $@;
+            STABLE_TS=$$(grep STABLE_TS bazel-out/stable-status.txt \\
+            | sed 's/^STABLE_TS //');
+            echo 'const char kBuildTimestampHuman[] = "'$$STABLE_TS'";' >> $@;
+            """,
+  stamp = 1,
+)
+
+cc_library(
+  name = "version_variables",
+  srcs = ["version_variables.cc"],
+  hdrs = ["version_variables.h"],
+  linkstamp = "version_variables_linkstamp.cc",
+)
+
+cc_binary(
+    name = "stamping_example_main",
+    srcs = ["stamping_example_main.cc"],
+    deps = [":version_variables"],
 )

--- a/stratum/lib/stamping_example_main.cc
+++ b/stratum/lib/stamping_example_main.cc
@@ -1,0 +1,14 @@
+// Copyright 2021-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+
+#include "stratum/lib/version_variables.h"
+
+int main() {
+  printf("kBuildTimestamp: %s\n", kBuildTimestamp);
+  printf("kBuildTimestamp2: %i\n", kBuildTimestamp2);
+  printf("kBuildTimestampHuman: %s\n", kBuildTimestampHuman);
+  printf("kGitRef: %s\n", kGitRef);
+  printf("kBuildScmRevision: %s\n", kBuildScmRevision);
+}

--- a/stratum/lib/version_variables.h
+++ b/stratum/lib/version_variables.h
@@ -1,0 +1,18 @@
+// Copyright 2021-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_LIB_VERSION_VARIABLES_H_
+#define STRATUM_LIB_VERSION_VARIABLES_H_
+
+// from volatile-status.txt
+extern const char kGitRef[];
+extern const char kBuildTimestamp[];
+
+// from stable-status.txt
+extern const char kBuildTimestampHuman[];
+
+// linkstamp
+extern const char kBuildScmRevision[];
+extern const int kBuildTimestamp2;
+
+#endif  // STRATUM_LIB_VERSION_VARIABLES_H_

--- a/stratum/lib/version_variables_linkstamp.cc
+++ b/stratum/lib/version_variables_linkstamp.cc
@@ -1,0 +1,9 @@
+// Copyright 2021-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// The only supported variables for link stamping.
+extern const char kBuildScmRevision[];
+const char kBuildScmRevision[] = BUILD_SCM_REVISION;
+
+extern const int kBuildTimestamp2;
+const int kBuildTimestamp2 = BUILD_TIMESTAMP;


### PR DESCRIPTION
Findings so far:

Variables can be added to `bazel-out/stable-status.txt` by naming them `STABLE_FOO`.

Changes to `bazel-out/volatile-status.txt` do NOT trigger rebuilds by design. We can add a timestamp to `bazel-out/stable-status.txt`, but that seems to be against the intended purpose.

Linkstamping on `cc_library` only works with `BUILD_SCM_REVISION` and `BUILD_TIMESTAMP`.

Linkstamping can be controlled on the `cc_binary` with `stamp = 1` or on the CLI (`--stamp`), but only affects linkstamping variables:
```
> bazel run //stratum/lib:stamping_example_main
kBuildTimestamp: 1610156461
kBuildTimestamp2: 0
kBuildTimestampHuman: 2021-01-08T17:41:01-0800
kGitRef: 403c08bd1191737f8696b8a939a0cc5567828ba9-dirty
kBuildScmRevision: 0

> bazel run --stamp //stratum/lib:stamping_example_main
kBuildTimestamp: 1610156456
kBuildTimestamp2: 1610156456
kBuildTimestampHuman: 2021-01-08T17:40:56-0800
kGitRef: 403c08bd1191737f8696b8a939a0cc5567828ba9-dirty
kBuildScmRevision: 403c08bd1191737f8696b8a939a0cc5567828ba9
```

Other, unrelated targets seem to unaffected by stamping (and are thus cached), but we need to confirm this!

Links:
https://groups.google.com/g/bazel-discuss/c/9kqLmOq_m_U
https://stackoverflow.com/a/47630130
https://github.com/bazelbuild/bazel/issues/1758
https://github.com/envoyproxy/envoy/blob/master/source/common/version/BUILD#L13-L47
https://github.com/bazelbuild/bazel/blob/082d58de852ebaa640bcf13cf419cbb94eec2b26/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java#L316
https://github.com/bazelbuild/bazel/issues/4863