### PR TITLE
Remove SDE dep from bf_switch

### DIFF
--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -37,7 +37,6 @@ stratum_cc_library(
         "//stratum/lib:macros",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_googleapis//google/rpc:status_cc_proto",
-        "@local_barefoot_bin//:bfsde",
     ],
 )
 


### PR DESCRIPTION
Since the SDE wrapper we don't depend on the SDE directly anymore. This is a leftover.