### PR TITLE
Fix handling of table entries with counterdata

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -270,7 +270,6 @@ struct RegisterClearThreadData {
 ::util::Status BfrtTableManager::BuildTableActionData(
     const ::p4::v1::Action& action,
     BfSdeInterface::TableDataInterface* table_data) {
-  RETURN_IF_ERROR(table_data->Reset(action.action_id()));
   for (const auto& param : action.params()) {
     RETURN_IF_ERROR(table_data->SetParam(param.param_id(), param.value()));
   }
@@ -280,6 +279,12 @@ struct RegisterClearThreadData {
 ::util::Status BfrtTableManager::BuildTableData(
     const ::p4::v1::TableEntry& table_entry,
     BfSdeInterface::TableDataInterface* table_data) {
+  if (table_entry.has_counter_data()) {
+    RETURN_IF_ERROR(
+        table_data->SetCounterData(table_entry.counter_data().byte_count(),
+                                   table_entry.counter_data().packet_count()));
+  }
+
   switch (table_entry.action().type_case()) {
     case ::p4::v1::TableAction::kAction:
       return BuildTableActionData(table_entry.action().action(), table_data);
@@ -293,12 +298,6 @@ struct RegisterClearThreadData {
     default:
       RETURN_ERROR(ERR_UNIMPLEMENTED)
           << "Unsupported action type: " << table_entry.action().type_case();
-  }
-
-  if (table_entry.has_counter_data()) {
-    RETURN_IF_ERROR(
-        table_data->SetCounterData(table_entry.counter_data().byte_count(),
-                                   table_entry.counter_data().packet_count()));
   }
 }
 

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -615,9 +615,17 @@ struct RegisterClearThreadData {
       // 2.
       wanted_tables.push_back(table_entry);
     }
-    for (const auto& table_entry : wanted_tables) {
+    // TODO(max): can wildcard reads request counter_data?
+    if (table_entry.has_counter_data()) {
+      for (const auto& wanted_table_entry : wanted_tables) {
+        RETURN_IF_ERROR(bf_sde_interface_->SynchronizeCounters(
+            device_, session, wanted_table_entry.table_id(),
+            absl::Milliseconds(FLAGS_bfrt_table_sync_timeout_ms)));
+      }
+    }
+    for (const auto& wanted_table_entry : wanted_tables) {
       RETURN_IF_ERROR_WITH_APPEND(
-          ReadAllTableEntries(session, table_entry, writer))
+          ReadAllTableEntries(session, wanted_table_entry, writer))
               .with_logging()
           << "Failed to read all table entries for request "
           << table_entry.ShortDebugString() << ".";

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.h
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.h
@@ -91,8 +91,8 @@ class BfrtTableManager {
       const ::p4::v1::Action& action,
       BfSdeInterface::TableDataInterface* table_data);
 
-  // Builds a SDE table data from the given P4 table entry. Does not reset the
-  // table data object first.
+  // Builds a SDE table data from the given P4 table entry. The table data
+  // object is reset, even in case of failure.
   ::util::Status BuildTableData(const ::p4::v1::TableEntry& table_entry,
                                 BfSdeInterface::TableDataInterface* table_data);
 

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.h
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.h
@@ -91,6 +91,8 @@ class BfrtTableManager {
       const ::p4::v1::Action& action,
       BfSdeInterface::TableDataInterface* table_data);
 
+  // Builds a SDE table data from the given P4 table entry. Does not reset the
+  // table data object first.
   ::util::Status BuildTableData(const ::p4::v1::TableEntry& table_entry,
                                 BfSdeInterface::TableDataInterface* table_data);
 


### PR DESCRIPTION
On write we did not apply the counter data values.

On wildcard read we did not sync the table beforehand, reporting stale values.

P4RT snippet:

```
te = table_entry['FabricIngress.acl.acl'](action='FabricIngress.acl.copy_to_cpu')
te.match['ig_port'] = '260'
te.priority = 10
te.counter_data.byte_count = 1000
te.counter_data.packet_count = 50
te.insert()
te.read(lambda e: print(e))
# send some traffic
all_te = table_entry['FabricIngress.acl.acl']
all_te.counter_data
all_te.read(lambda e: print(e))
```
