### PR TITLE
Add TAI as Debian package dependency, if enabled

### DIFF
--- a/stratum/hal/bin/bcm/standalone/BUILD
+++ b/stratum/hal/bin/bcm/standalone/BUILD
@@ -166,7 +166,10 @@ pkg_deb(
         "libedit2",
         "libjudydebian1",
         "libssl1.1",
-    ],
+    ] + select({
+        "//stratum/hal/lib/phal:with_tai": ["cassini-tai"],
+        "//conditions:default": [],
+    }),
     description = "Stratum for Broadcom switches using OpenNSA.",
     homepage = "https://stratumproject.org/",
     maintainer = "The Stratum Project",
@@ -189,7 +192,10 @@ pkg_deb(
         "libjudydebian1",
         "libssl1.1",
         "libyaml-0-2",
-    ],
+    ] + select({
+        "//stratum/hal/lib/phal:with_tai": ["cassini-tai"],
+        "//conditions:default": [],
+    }),
     description = "Stratum for Broadcom switches using SDKLT.",
     homepage = "https://stratumproject.org/",
     maintainer = "The Stratum Project",


### PR DESCRIPTION
I think this commit removed it accidentally: https://github.com/stratum/stratum/commit/ff762d8cec73ac6f779b8f230088348030c653be#diff-4a60e1cf5aa2f74e522a0b1b161ba8ae7d4296a92751ddc63ffe74dc34eeff9d