### PR TITLE
Compress the Debian packages

### DIFF
--- a/stratum/docs/extenting_stratum_bcm.md
+++ b/stratum/docs/extenting_stratum_bcm.md
@@ -235,7 +235,7 @@ In general, most features will require changes to multiple areas of Stratum:
 
 - p4c-fpm Compiler
 
-    Here you decide how your feature will be exposed in P4 code. Hide unnecessary details about implementation details in both Statum and the underlying SDK.
+    Here you decide how your feature will be exposed in P4 code. Hide unnecessary details about implementation details in both Stratum and the underlying SDK.
     - New header fields in `p4_table_defs.proto` and `p4_table_map.proto`
         - E.g. `P4FieldType::P4_FIELD_TYPE_MPLS_LABEL`
     - New Pipeline stages in `p4_annotation.proto`

--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -153,6 +153,7 @@ pkg_tar(
 
 pkg_tar(
     name = "stratum_bf_data",
+    extension = "tar.bz2",
     deps = [
         ":stratum_binaries",
         ":stratum_common_data",
@@ -161,6 +162,7 @@ pkg_tar(
 
 pkg_tar(
     name = "stratum_bfrt_data",
+    extension = "tar.bz2",
     deps = [
         ":stratum_bfrt_binaries",
         ":stratum_common_data",

--- a/stratum/hal/bin/bcm/standalone/BUILD
+++ b/stratum/hal/bin/bcm/standalone/BUILD
@@ -135,7 +135,8 @@ pkg_tar(
 )
 
 pkg_tar(
-    name = "statum_bcm_sdklt_all",
+    name = "stratum_bcm_sdklt_all",
+    extension = "tar.bz2",
     deps = [
         ":stratum_bcm_etc",
         ":stratum_bcm_sdklt_bin",
@@ -144,7 +145,8 @@ pkg_tar(
 )
 
 pkg_tar(
-    name = "statum_bcm_opennsa_all",
+    name = "stratum_bcm_opennsa_all",
+    extension = "tar.bz2",
     deps = [
         ":stratum_bcm_etc",
         ":stratum_bcm_opennsa_bin",
@@ -159,7 +161,7 @@ pkg_deb(
         "stratum-bcm-sdk6",
         "stratum-bcm-sdklt",
     ],
-    data = ":statum_bcm_opennsa_all",
+    data = ":stratum_bcm_opennsa_all",
     depends = [
         "kmod",
         "libboost-thread1.62.0",
@@ -181,7 +183,7 @@ pkg_deb(
         "stratum-bcm-opennsa",
         "stratum-bcm-sdk6",
     ],
-    data = ":statum_bcm_sdklt_all",
+    data = ":stratum_bcm_sdklt_all",
     depends = [
         "kmod",
         "libboost-thread1.62.0",

--- a/stratum/p4c_backends/fpm/BUILD
+++ b/stratum/p4c_backends/fpm/BUILD
@@ -1926,6 +1926,7 @@ pkg_tar(
 
 pkg_tar(
     name = "fpm_p4c_data",
+    extension = "tar.xz",
     deps = [
         ":fpm_p4c_bin",
         ":fpm_p4c_includes",


### PR DESCRIPTION
We should compress the files when packing them into Debian packages to reduce file and container sizes.

Bz2 seems to sit in the sweet spot of speed and compression (19%). Keep in mind that this workflow is also used when doing rapid development, thus should be fast. Therefore xz (13%) is not chosen.

Anecdata:

```
0.36 ms    74M Jan 15 04:22 bazel-bin/stratum/hal/bin/barefoot/stratum_bf_data.tar
5.727 s    14M Jan 15 04:23 bazel-bin/stratum/hal/bin/barefoot/stratum_bf_data.tar.bz2 
9.993 s    15M Jan 15 04:23 bazel-bin/stratum/hal/bin/barefoot/stratum_bf_data.tar.gz
23.546 s  9.4M Jan 15 04:21 bazel-bin/stratum/hal/bin/barefoot/stratum_bf_data.tar.xz
```