### PR TITLE
Apply formatting tools to udev related files

### DIFF
--- a/.circleci/check-cpp-format.sh
+++ b/.circleci/check-cpp-format.sh
@@ -155,6 +155,14 @@ stratum/hal/lib/phal/tai/tai_switch_configurator.h
 stratum/hal/lib/phal/tai/taish_client.cc
 stratum/hal/lib/phal/tai/taish_client.h
 stratum/hal/lib/phal/test_util.h
+stratum/hal/lib/phal/udev_event_handler_mock.h
+stratum/hal/lib/phal/udev_event_handler_test.cc
+stratum/hal/lib/phal/udev_event_handler.cc
+stratum/hal/lib/phal/udev_event_handler.h
+stratum/hal/lib/phal/udev_interface.h
+stratum/hal/lib/phal/udev_mock.h
+stratum/hal/lib/phal/udev.cc
+stratum/hal/lib/phal/udev.h
 stratum/hal/lib/pi/pi_node.cc
 stratum/hal/lib/pi/pi_node.h
 stratum/hal/stub/embedded/main.cc

--- a/stratum/hal/lib/phal/udev.cc
+++ b/stratum/hal/lib/phal/udev.cc
@@ -2,11 +2,10 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/phal/udev.h"
 
-#include "stratum/lib/macros.h"
 #include "absl/memory/memory.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/udev.h
+++ b/stratum/hal/lib/phal/udev.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_UDEV_H_
 #define STRATUM_HAL_LIB_PHAL_UDEV_H_
 
@@ -12,11 +11,11 @@
 #include <string>
 #include <utility>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/phal/udev_interface.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/udev_event_handler.cc
+++ b/stratum/hal/lib/phal/udev_event_handler.cc
@@ -2,15 +2,15 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-#include <utility>
-
 #include "stratum/hal/lib/phal/udev_event_handler.h"
 
+#include <utility>
+
+#include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
+#include "stratum/glue/gtl/map_util.h"
 #include "stratum/hal/lib/common/constants.h"
 #include "stratum/lib/macros.h"
-#include "absl/synchronization/mutex.h"
-#include "stratum/glue/gtl/map_util.h"
 
 DEFINE_int32(udev_polling_interval_ms, 200,
              "Polling interval for checking udev events in the udev thread.");

--- a/stratum/hal/lib/phal/udev_event_handler.h
+++ b/stratum/hal/lib/phal/udev_event_handler.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_UDEV_EVENT_HANDLER_H_
 #define STRATUM_HAL_LIB_PHAL_UDEV_EVENT_HANDLER_H_
 

--- a/stratum/hal/lib/phal/udev_event_handler_mock.h
+++ b/stratum/hal/lib/phal/udev_event_handler_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_UDEV_EVENT_HANDLER_MOCK_H_
 #define STRATUM_HAL_LIB_PHAL_UDEV_EVENT_HANDLER_MOCK_H_
 
 #include <string>
 
-#include "stratum/hal/lib/phal/udev_event_handler.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/phal/udev_event_handler.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/udev_event_handler_test.cc
+++ b/stratum/hal/lib/phal/udev_event_handler_test.cc
@@ -2,8 +2,12 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/phal/udev_event_handler.h"
+
+#include "absl/memory/memory.h"
+#include "absl/synchronization/mutex.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/status_test_util.h"
@@ -11,10 +15,6 @@
 #include "stratum/hal/lib/phal/udev_event_handler_mock.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/test_utils/matchers.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {
@@ -326,16 +326,16 @@ TEST_F(ConcurrentUdevEventHandlerTest, ManyConcurrentCallbacksExecute) {
   std::vector<pthread_t> test_threads;
   for (int i = 0; i < kNumTestThreads; i++) {
     pthread_t test_thread;
-    ASSERT_EQ(
-        0, pthread_create(&test_thread, nullptr,
-                          +[](void* t) -> void* {
-                            if (!static_cast<ConcurrentUdevEventHandlerTest*>(t)
-                                     ->TriggerSomeCallbacks()
-                                     .ok())
-                              return t;  // Error, non-zero return.
-                            return nullptr;
-                          },
-                          this));
+    ASSERT_EQ(0, pthread_create(
+                     &test_thread, nullptr,
+                     +[](void* t) -> void* {
+                       if (!static_cast<ConcurrentUdevEventHandlerTest*>(t)
+                                ->TriggerSomeCallbacks()
+                                .ok())
+                         return t;  // Error, non-zero return.
+                       return nullptr;
+                     },
+                     this));
     test_threads.push_back(test_thread);
   }
   {

--- a/stratum/hal/lib/phal/udev_interface.h
+++ b/stratum/hal/lib/phal/udev_interface.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_UDEV_INTERFACE_H_
 #define STRATUM_HAL_LIB_PHAL_UDEV_INTERFACE_H_
 

--- a/stratum/hal/lib/phal/udev_mock.h
+++ b/stratum/hal/lib/phal/udev_mock.h
@@ -2,15 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_UDEV_MOCK_H_
 #define STRATUM_HAL_LIB_PHAL_UDEV_MOCK_H_
 
-#include <utility>
 #include <string>
+#include <utility>
 
-#include "stratum/hal/lib/phal/udev_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/phal/udev_interface.h"
 
 namespace stratum {
 namespace hal {


### PR DESCRIPTION
This PR applies our formatting tools to the udev related files in `stratum/hal/phal`.

No functional changes.