### PR TITLE
Implement simple port shaping on Tofino

### DIFF
--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -331,6 +331,57 @@ in the `singleton_ports` config.
 writing P4Runtime entities and packets. In the future, we may support P4Runtime
 port translation which would allow you to use the user-provide SDN port ID.*
 
+#### Tofino specific configuration (experimental)
+
+Some parts of the ChassisConfig do not apply to all platforms. These are
+organized in the `VendorConfig` part of the configuration file. For Tofino, we
+support the following extensions:
+
+##### Port shaping
+
+Port shaping can be configured on a port-by-port basis with limits in either
+bits per second (bps) or packets per second (pps), by adding the relevant
+entries in the `node_id_to_port_shaping_config` map of the `TofinoConfig`
+message. The following snippet shows singleton port 1 being configured with a
+byte (bps) shaping rate of 1 Gbit/s and a burst size of 16 KB:
+
+```
+nodes {
+  id: 1
+  slot: 1
+  index: 1
+}
+singleton_ports {
+  id: 1
+  name: "1/0"
+  slot: 1
+  port: 1
+  speed_bps: 40000000000
+  config_params {
+    admin_state: ADMIN_STATE_ENABLED
+  }
+  node: 1
+}
+vendor_config {
+  tofino_config {
+    node_id_to_port_shaping_config {
+      key: 1  # node id reference
+      value {
+        per_port_shaping_configs {
+          key: 1  # singleton port id reference
+          value {
+            byte_shaping {
+              max_rate_bps: 1000000000 # 1G
+              max_burst_bytes: 16384 # 2x MTU
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Running with BSP or on Tofino model
 
 ```bash

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -442,11 +442,10 @@ BFChassisManager::~BFChassisManager() = default;
       break;
     case TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig::
         kByteShaping:
-      // The SDE expects the rate in kbps.
       RETURN_IF_ERROR(bf_sde_interface_->SetPortShapingRate(
           unit, sdk_port_id, false,
           shaping_config.byte_shaping().max_burst_bytes(),
-          shaping_config.byte_shaping().max_rate_bps() / 1000));
+          shaping_config.byte_shaping().max_rate_bps()));
       break;
     default:
       RETURN_ERROR(ERR_INVALID_PARAM)

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -830,9 +830,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     if (config.shaping_config) {
       RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, unit, sdk_port_id,
                                              *config.shaping_config));
-      RETURN_IF_ERROR(bf_sde_interface_->EnablePortShaping(unit, sdk_port_id,
-                                                           TRI_STATE_TRUE));
-      *config_new->shaping_config = *config.shaping_config;
+      config_new->shaping_config = config.shaping_config;
     }
 
     return ::util::OkStatus();
@@ -855,6 +853,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
+  LOG(INFO) << "Resetting port configs for node " << node_id << ".";
   auto* port_id_to_config =
       gtl::FindOrNull(node_id_to_port_id_to_port_config_, node_id);
   CHECK_RETURN_IF_FALSE(port_id_to_config != nullptr)

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -224,8 +224,6 @@ BFChassisManager::~BFChassisManager() = default;
   if (config_old.shaping_config) {
     RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, unit, sdk_port_id,
                                            *config_old.shaping_config));
-    RETURN_IF_ERROR(bf_sde_interface_->EnablePortShaping(unit, sdk_port_id,
-                                                         TRI_STATE_TRUE));
     config_changed = true;
   }
 

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.h
@@ -108,6 +108,9 @@ class BFChassisManager {
     absl::optional<FecMode> fec_mode;  // empty if port add failed
     // empty if loopback mode configuration failed
     absl::optional<LoopbackState> loopback_mode;
+    // empty if no shaping config given
+    absl::optional<TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig>
+        shaping_config;
 
     PortConfig() : admin_state(ADMIN_STATE_UNKNOWN) {}
   };
@@ -152,6 +155,12 @@ class BFChassisManager {
                                   const SingletonPort& singleton_port,
                                   const PortConfig& config_old,
                                   PortConfig* config);
+
+  // Helper to apply a port shaping config to a single port.
+  ::util::Status ApplyPortShapingConfig(
+      uint64 node_id, int unit, uint32 sdk_port_id,
+      const TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig&
+          shaping_config);
 
   // Determines the mode of operation:
   // - OPERATION_MODE_STANDALONE: when Stratum stack runs independently and

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -177,6 +177,14 @@ class BfSdeInterface {
   // Disable a port.
   virtual ::util::Status DisablePort(int device, int port) = 0;
 
+  // Set the port shaping properties on a port.
+  virtual ::util::Status SetPortShapingRate(int device, int port, bool in_pps,
+                                            uint32 burst_size, uint32 rate) = 0;
+
+  // Enable port shaping on a port.
+  virtual ::util::Status EnablePortShaping(int device, int port,
+                                           TriState enable) = 0;
+
   // Get the operational state of a port.
   virtual ::util::StatusOr<PortState> GetPortState(int device, int port) = 0;
 

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -178,8 +178,11 @@ class BfSdeInterface {
   virtual ::util::Status DisablePort(int device, int port) = 0;
 
   // Set the port shaping properties on a port.
+  // If in_pps is true, the burst size and rate is measured in packets and pps.
+  // Else, it's in bytes and kbps.
   virtual ::util::Status SetPortShapingRate(int device, int port, bool in_pps,
-                                            uint32 burst_size, uint32 rate) = 0;
+                                            uint32 burst_size,
+                                            uint32 rate_per_second) = 0;
 
   // Enable port shaping on a port.
   virtual ::util::Status EnablePortShaping(int device, int port,

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -178,11 +178,11 @@ class BfSdeInterface {
   virtual ::util::Status DisablePort(int device, int port) = 0;
 
   // Set the port shaping properties on a port.
-  // If in_pps is true, the burst size and rate is measured in packets and pps.
-  // Else, it's in bytes and kbps.
-  virtual ::util::Status SetPortShapingRate(int device, int port, bool in_pps,
-                                            uint32 burst_size,
-                                            uint32 rate_per_second) = 0;
+  // If is_in_pps is true, the burst size and rate are measured in packets and
+  // pps. Else, they're in bytes and bps.
+  virtual ::util::Status SetPortShapingRate(int device, int port,
+                                            bool is_in_pps, uint32 burst_size,
+                                            uint64 rate_per_second) = 0;
 
   // Enable port shaping on a port.
   virtual ::util::Status EnablePortShaping(int device, int port,

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -80,8 +80,8 @@ class BfSdeMock : public BfSdeInterface {
   MOCK_METHOD2(EnablePort, ::util::Status(int device, int port));
   MOCK_METHOD2(DisablePort, ::util::Status(int device, int port));
   MOCK_METHOD5(SetPortShapingRate,
-               ::util::Status(int device, int port, bool in_pps,
-                              uint32 burst_size, uint32 rate_per_second));
+               ::util::Status(int device, int port, bool is_in_pps,
+                              uint32 burst_size, uint64 rate_per_second));
   MOCK_METHOD3(EnablePortShaping,
                ::util::Status(int device, int port, TriState enable));
   MOCK_METHOD3(SetPortAutonegPolicy,

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -81,7 +81,7 @@ class BfSdeMock : public BfSdeInterface {
   MOCK_METHOD2(DisablePort, ::util::Status(int device, int port));
   MOCK_METHOD5(SetPortShapingRate,
                ::util::Status(int device, int port, bool in_pps,
-                              uint32 burst_size, uint32 rate));
+                              uint32 burst_size, uint32 rate_per_second));
   MOCK_METHOD3(EnablePortShaping,
                ::util::Status(int device, int port, TriState enable));
   MOCK_METHOD3(SetPortAutonegPolicy,

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -79,6 +79,11 @@ class BfSdeMock : public BfSdeInterface {
   MOCK_METHOD2(DeletePort, ::util::Status(int device, int port));
   MOCK_METHOD2(EnablePort, ::util::Status(int device, int port));
   MOCK_METHOD2(DisablePort, ::util::Status(int device, int port));
+  MOCK_METHOD5(SetPortShapingRate,
+               ::util::Status(int device, int port, bool in_pps,
+                              uint32 burst_size, uint32 rate));
+  MOCK_METHOD3(EnablePortShaping,
+               ::util::Status(int device, int port, TriState enable));
   MOCK_METHOD3(SetPortAutonegPolicy,
                ::util::Status(int device, int port, TriState autoneg));
   MOCK_METHOD3(SetPortMtu, ::util::Status(int device, int port, int32 mtu));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -924,6 +924,26 @@ BfSdeWrapper::BfSdeWrapper() : port_status_event_writer_(nullptr) {}
   return ::util::OkStatus();
 }
 
+::util::Status BfSdeWrapper::SetPortShapingRate(int device, int port,
+                                                bool in_pps, uint32 burst_size,
+                                                uint32 rate) {
+  RETURN_IF_BFRT_ERROR(
+      p4_pd_tm_set_port_shaping_rate(device, port, in_pps, burst_size, rate));
+
+  return ::util::OkStatus();
+}
+
+::util::Status BfSdeWrapper::EnablePortShaping(int device, int port,
+                                               TriState enable) {
+  if (enable == TriState::TRI_STATE_TRUE) {
+    RETURN_IF_BFRT_ERROR(p4_pd_tm_enable_port_shaping(device, port));
+  } else if (enable == TriState::TRI_STATE_FALSE) {
+    RETURN_IF_BFRT_ERROR(p4_pd_tm_disable_port_shaping(device, port));
+  }
+
+  return ::util::OkStatus();
+}
+
 ::util::Status BfSdeWrapper::SetPortAutonegPolicy(int device, int port,
                                                   TriState autoneg) {
   ASSIGN_OR_RETURN(auto autoneg_v, AutonegHalToBf(autoneg));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -929,7 +929,7 @@ BfSdeWrapper::BfSdeWrapper() : port_status_event_writer_(nullptr) {}
                                                 uint32 burst_size,
                                                 uint64 rate_per_second) {
   if (!is_in_pps) {
-    rate_per_second /= 1000;  // The SDE expects the bitrate in kpps.
+    rate_per_second /= 1000;  // The SDE expects the bitrate in kbps.
   }
 
   RETURN_IF_BFRT_ERROR(p4_pd_tm_set_port_shaping_rate(

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -926,9 +926,9 @@ BfSdeWrapper::BfSdeWrapper() : port_status_event_writer_(nullptr) {}
 
 ::util::Status BfSdeWrapper::SetPortShapingRate(int device, int port,
                                                 bool in_pps, uint32 burst_size,
-                                                uint32 rate) {
-  RETURN_IF_BFRT_ERROR(
-      p4_pd_tm_set_port_shaping_rate(device, port, in_pps, burst_size, rate));
+                                                uint32 rate_per_second) {
+  RETURN_IF_BFRT_ERROR(p4_pd_tm_set_port_shaping_rate(
+      device, port, in_pps, burst_size, rate_per_second));
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -925,10 +925,15 @@ BfSdeWrapper::BfSdeWrapper() : port_status_event_writer_(nullptr) {}
 }
 
 ::util::Status BfSdeWrapper::SetPortShapingRate(int device, int port,
-                                                bool in_pps, uint32 burst_size,
-                                                uint32 rate_per_second) {
+                                                bool is_in_pps,
+                                                uint32 burst_size,
+                                                uint64 rate_per_second) {
+  if (!is_in_pps) {
+    rate_per_second /= 1000;  // The SDE expects the bitrate in kpps.
+  }
+
   RETURN_IF_BFRT_ERROR(p4_pd_tm_set_port_shaping_rate(
-      device, port, in_pps, burst_size, rate_per_second));
+      device, port, is_in_pps, burst_size, rate_per_second));
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -157,9 +157,9 @@ class BfSdeWrapper : public BfSdeInterface {
   ::util::Status DeletePort(int device, int port) override;
   ::util::Status EnablePort(int device, int port) override;
   ::util::Status DisablePort(int device, int port) override;
-  ::util::Status SetPortShapingRate(int device, int port, bool in_pps,
+  ::util::Status SetPortShapingRate(int device, int port, bool is_in_pps,
                                     uint32 burst_size,
-                                    uint32 rate_per_second) override;
+                                    uint64 rate_per_second) override;
   ::util::Status EnablePortShaping(int device, int port,
                                    TriState enable) override;
   ::util::Status SetPortAutonegPolicy(int device, int port,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -158,7 +158,8 @@ class BfSdeWrapper : public BfSdeInterface {
   ::util::Status EnablePort(int device, int port) override;
   ::util::Status DisablePort(int device, int port) override;
   ::util::Status SetPortShapingRate(int device, int port, bool in_pps,
-                                    uint32 burst_size, uint32 rate) override;
+                                    uint32 burst_size,
+                                    uint32 rate_per_second) override;
   ::util::Status EnablePortShaping(int device, int port,
                                    TriState enable) override;
   ::util::Status SetPortAutonegPolicy(int device, int port,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -157,6 +157,10 @@ class BfSdeWrapper : public BfSdeInterface {
   ::util::Status DeletePort(int device, int port) override;
   ::util::Status EnablePort(int device, int port) override;
   ::util::Status DisablePort(int device, int port) override;
+  ::util::Status SetPortShapingRate(int device, int port, bool in_pps,
+                                    uint32 burst_size, uint32 rate) override;
+  ::util::Status EnablePortShaping(int device, int port,
+                                   TriState enable) override;
   ::util::Status SetPortAutonegPolicy(int device, int port,
                                       TriState autoneg) override;
   ::util::Status SetPortMtu(int device, int port, int32 mtu) override;

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -260,21 +260,6 @@ message PortConfigParams {
     PORT_MODULATION_NRZ = 1;
     PORT_MODULATION_PAM4 = 2;
   }
-  // Per port shaping config.
-  message ShapingConfig {
-    message PacketShape {
-      int32 rate_pps = 1;
-      int32 burst_size_packets = 2;
-    }
-    message ByteShape {
-      int32 rate_kbits = 1;
-      int32 burst_size_bytes = 2;
-    }
-    oneof shaping {
-      PacketShape packet_shaping = 1;
-      ByteShape byte_shaping = 2;
-    }
-  }
   // The configured admin state for this port.
   AdminState admin_state = 1;
   // The per port MTU (aka max frame size) for this port.
@@ -291,8 +276,6 @@ message PortConfigParams {
   uint64 mac_address = 7;
   // The configured loopback state for this port.
   LoopbackState loopback_mode = 8;
-  // The port shaping configuration for this port.
-  ShapingConfig shaping_config = 9;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,
@@ -666,7 +649,7 @@ message GoogleConfig {
   // chassis map.
   string bcm_chassis_map_id = 1;
   // Maps from the index of the nodes (1-based) to all the configs related to
-  // hat specific node.
+  // that specific node.
   map<uint64, BcmKnetConfig> node_id_to_knet_config = 2;
   map<uint64, BcmRxConfig> node_id_to_rx_config = 3;
   map<uint64, BcmTxConfig> node_id_to_tx_config = 4;
@@ -675,8 +658,35 @@ message GoogleConfig {
   map<uint64, BcmRtag7HashConfig> node_id_to_rtag7_hash_config = 7;
 }
 
+// Config specific to Tofino chassis.
+message TofinoConfig {
+  message BfPortShapingConfig {
+    message BfPerPortShapingConfig {
+      message PacketShape {
+        uint64 max_rate_pps = 1;
+        uint32 max_burst_packets = 2;
+      }
+      message ByteShape {
+        uint64 max_rate_bps = 1;
+        uint32 max_burst_bytes = 2;
+      }
+      oneof shaping {
+        PacketShape packet_shaping = 1;
+        ByteShape byte_shaping = 2;
+      }
+    }
+    // Map from port id to its shaping config given by BfPerPortShapingConfig.
+    map<uint32, BfPerPortShapingConfig> per_port_shaping_configs = 1;
+  }
+
+  // Maps from the index of the nodes (1-based) to all the configs related to
+  // that specific node.
+  map<uint64, BfPortShapingConfig> node_id_to_port_shaping_config = 1;
+}
+
 message VendorConfig {
   GoogleConfig google_config = 1;
+  TofinoConfig tofino_config = 2;
 }
 
 //------------------------------------------------------------------------------

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -260,6 +260,21 @@ message PortConfigParams {
     PORT_MODULATION_NRZ = 1;
     PORT_MODULATION_PAM4 = 2;
   }
+  // Per port shaping config.
+  message ShapingConfig {
+    message PacketShape {
+      int32 rate_pps = 1;
+      int32 burst_size_packets = 2;
+    }
+    message ByteShape {
+      int32 rate_kbits = 1;
+      int32 burst_size_bytes = 2;
+    }
+    oneof shaping {
+      PacketShape packet_shaping = 1;
+      ByteShape byte_shaping = 2;
+    }
+  }
   // The configured admin state for this port.
   AdminState admin_state = 1;
   // The per port MTU (aka max frame size) for this port.
@@ -276,6 +291,8 @@ message PortConfigParams {
   uint64 mac_address = 7;
   // The configured loopback state for this port.
   LoopbackState loopback_mode = 8;
+  // The port shaping configuration for this port.
+  ShapingConfig shaping_config = 9;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,


### PR DESCRIPTION
This PR adds support for configuring port shaping on Tofino switches. Initially we expose this feature via the ChassisConfig only, but might extend this to gNMI in the future.

Example config:

```
nodes {
...
}
vendor_config {
  tofino_config {
    node_id_to_port_shaping_config {
      key: 1
      value {
        per_port_shaping_configs {
          key: 9
          value {
            byte_shaping {
              max_rate_bps: 10000000000 # 10G
              max_burst_bytes: 16384 # 2x jumbo frame
            }
          }
        }
      }
    }
  }
}
singleton_ports {
...
```


TODOs:

- [x] Data plane verification test
- [x] Save shaping config into internal port config map
- [x] Clean up shaping config on updates
- [x] Example in readme