### PR TITLE
Apply formatting tools to glue/net_util files

### DIFF
--- a/stratum/glue/net_util/BUILD
+++ b/stratum/glue/net_util/BUILD
@@ -2,14 +2,15 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
     "stratum_cc_test",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -40,11 +41,11 @@ stratum_cc_test(
     srcs = ["bits_test.cc"],
     deps = [
         ":bits",
-        "@com_google_googletest//:gtest_main",
+        "//stratum/glue:integral_types",
+        "//stratum/glue:logging",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/numeric:int128",
-        "//stratum/glue:logging",
-        "//stratum/glue:integral_types",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -58,11 +59,11 @@ stratum_cc_library(
     ],
     deps = [
         ":bits",
+        "//stratum/glue:integral_types",
+        "//stratum/glue:logging",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/numeric:int128",
         "@com_google_absl//absl/strings",
-        "//stratum/glue:logging",
-        "//stratum/glue:integral_types",
     ],
 )
 
@@ -72,14 +73,14 @@ stratum_cc_test(
     srcs = ["ipaddress_test.cc"],
     deps = [
         ":ipaddress",
-        "@com_google_googletest//:gtest_main",
+        "//stratum/glue:integral_types",
+        "//stratum/glue:logging",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/hash:hash_testing",
         "@com_google_absl//absl/numeric:int128",
         "@com_google_absl//absl/strings",
-        "//stratum/glue:logging",
-        "//stratum/glue:integral_types",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -97,10 +98,10 @@ stratum_cc_library(
 )
 
 cc_test(
-  name = "absl_test",
-  srcs = ["absl_test.cc"],
-  deps = [
-      "@com_google_absl//absl/strings",
-      "@com_google_googletest//:gtest_main",
-  ],
+    name = "absl_test",
+    srcs = ["absl_test.cc"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/stratum/glue/net_util/absl_test.cc
+++ b/stratum/glue/net_util/absl_test.cc
@@ -6,26 +6,26 @@
 
 #include <stdint.h>
 
-#include "gtest/gtest.h"
 #include "absl/strings/numbers.h"
+#include "gtest/gtest.h"
 
 using absl::numbers_internal::safe_strto32_base;
 
 TEST(absl, safe_strto32_base) {
-    const std::string string1 = " 1";
-    const std::string string2 = "2";
-    const std::string string3 = "3 ";
+  const std::string string1 = " 1";
+  const std::string string2 = "2";
+  const std::string string3 = "3 ";
 
-    int32_t value;
-    EXPECT_TRUE(safe_strto32_base(string1, &value, 10));
-    EXPECT_TRUE(safe_strto32_base(string1, &value, 10));
-    /*
-     FIXME Abseil public vs. Google-internal may differ in behavior on this test
-     This behavioral difference seems to be allowing StringToIPRange to accept
-     strings will trailing spaces, which the unittest indicates should be invalid.
-    */
-    // expected based on other tests
-    // EXPECT_FALSE(safe_strto32_base(string1, &value, 10));
-    // actual behavior
-    EXPECT_TRUE(safe_strto32_base(string1, &value, 10));
+  int32_t value;
+  EXPECT_TRUE(safe_strto32_base(string1, &value, 10));
+  EXPECT_TRUE(safe_strto32_base(string1, &value, 10));
+  /*
+   FIXME Abseil public vs. Google-internal may differ in behavior on this test
+   This behavioral difference seems to be allowing StringToIPRange to accept
+   strings will trailing spaces, which the unittest indicates should be invalid.
+  */
+  // expected based on other tests
+  // EXPECT_FALSE(safe_strto32_base(string1, &value, 10));
+  // actual behavior
+  EXPECT_TRUE(safe_strto32_base(string1, &value, 10));
 }

--- a/stratum/glue/net_util/bits.cc
+++ b/stratum/glue/net_util/bits.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Copyright 2002 and onwards Google Inc.
 // Author: Paul Haahr
 //
@@ -11,6 +10,7 @@
 #include "stratum/glue/net_util/bits.h"
 
 #include <assert.h>
+
 #include "absl/numeric/int128.h"
 
 namespace stratum {
@@ -19,53 +19,45 @@ namespace stratum {
 // (We could make these ints.  The tradeoff is size (eg does it overwhelm
 // the cache?) vs efficiency in referencing sub-word-sized array elements)
 const char Bits::num_bits[] = {
-  0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8 };
+    0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4,
+    2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+    2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 1, 2, 2, 3, 2, 3, 3, 4,
+    2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+    2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6,
+    4, 5, 5, 6, 5, 6, 6, 7, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+    2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 2, 3, 3, 4, 3, 4, 4, 5,
+    3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+    2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6,
+    4, 5, 5, 6, 5, 6, 6, 7, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+    4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8};
 
-int Bits::Count(const void *m, int num_bytes) {
+int Bits::Count(const void* m, int num_bytes) {
   int nbits = 0;
-  const uint8 *s = (const uint8 *) m;
-  for (int i = 0; i < num_bytes; i++)
-    nbits += num_bits[*s++];
+  const uint8* s = (const uint8*)m;
+  for (int i = 0; i < num_bytes; i++) nbits += num_bits[*s++];
   return nbits;
 }
 
-int Bits::Difference(const void *m1, const void *m2, int num_bytes) {
+int Bits::Difference(const void* m1, const void* m2, int num_bytes) {
   int nbits = 0;
-  const uint8 *s1 = (const uint8 *) m1;
-  const uint8 *s2 = (const uint8 *) m2;
-  for (int i = 0; i < num_bytes; i++)
-    nbits += num_bits[(*s1++) ^ (*s2++)];
+  const uint8* s1 = (const uint8*)m1;
+  const uint8* s2 = (const uint8*)m2;
+  for (int i = 0; i < num_bytes; i++) nbits += num_bits[(*s1++) ^ (*s2++)];
   return nbits;
 }
 
-int Bits::CappedDifference(const void *m1, const void *m2,
-                           int num_bytes, int cap) {
+int Bits::CappedDifference(const void* m1, const void* m2, int num_bytes,
+                           int cap) {
   int nbits = 0;
-  const uint8 *s1 = (const uint8 *) m1;
-  const uint8 *s2 = (const uint8 *) m2;
+  const uint8* s1 = (const uint8*)m1;
+  const uint8* s2 = (const uint8*)m2;
   for (int i = 0; i < num_bytes && nbits <= cap; i++)
     nbits += num_bits[(*s1++) ^ (*s2++)];
   return nbits;
 }
 
 int Bits::Log2Floor_Portable(uint32 n) {
-  if (n == 0)
-    return -1;
+  if (n == 0) return -1;
   int log = 0;
   uint32 value = n;
   for (int i = 4; i >= 0; --i) {
@@ -82,7 +74,7 @@ int Bits::Log2Floor_Portable(uint32 n) {
 
 int Bits::Log2Ceiling(uint32 n) {
   int floor = Log2Floor(n);
-  if ((n & (n - 1)) == 0)              // zero or a power of two
+  if ((n & (n - 1)) == 0)  // zero or a power of two
     return floor;
   else
     return floor + 1;
@@ -90,7 +82,7 @@ int Bits::Log2Ceiling(uint32 n) {
 
 int Bits::Log2Ceiling64(uint64 n) {
   int floor = Log2Floor64(n);
-  if ((n & (n - 1)) == 0)              // zero or a power of two
+  if ((n & (n - 1)) == 0)  // zero or a power of two
     return floor;
   else
     return floor + 1;
@@ -98,7 +90,7 @@ int Bits::Log2Ceiling64(uint64 n) {
 
 int Bits::Log2Ceiling128(absl::uint128 n) {
   int floor = Log2Floor128(n);
-  if ((n & (n - 1)) == 0)              // zero or a power of two
+  if ((n & (n - 1)) == 0)  // zero or a power of two
     return floor;
   else
     return floor + 1;
@@ -119,8 +111,7 @@ int Bits::FindLSBSetNonZero_Portable(uint32 n) {
 
 int Bits::CountLeadingZeros32_Portable(uint32 n) {
   int bits = 1;
-  if (n == 0)
-    return 32;
+  if (n == 0) return 32;
   if ((n >> 16) == 0) {
     bits += 16;
     n <<= 16;
@@ -141,9 +132,8 @@ int Bits::CountLeadingZeros32_Portable(uint32 n) {
 }
 
 int Bits::CountLeadingZeros64_Portable(uint64 n) {
-  return ((n >> 32)
-           ? Bits::CountLeadingZeros32_Portable(n >> 32)
-           : 32 +  Bits::CountLeadingZeros32_Portable(n));
+  return ((n >> 32) ? Bits::CountLeadingZeros32_Portable(n >> 32)
+                    : 32 + Bits::CountLeadingZeros32_Portable(n));
 }
 
 }  // namespace stratum

--- a/stratum/glue/net_util/bits.h
+++ b/stratum/glue/net_util/bits.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Copyright 2002 and onwards Google Inc.
 // Author: Paul Haahr
 //
@@ -44,10 +43,10 @@
 #include <byteswap.h>
 #endif  // __APPLE__
 
-#include "stratum/glue/logging.h"
 #include "absl/base/casts.h"
-#include "stratum/glue/integral_types.h"
 #include "absl/numeric/int128.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/logging.h"
 
 namespace stratum {
 
@@ -56,11 +55,12 @@ class Bits {
   // A traits class template for unsigned integer type sizes. Primary
   // information contained herein is corresponding (unsigned) integer type.
   // E.g. UnsignedTypeBySize<32>::Type is uint32. Used by UnsignedType.
-  template<int size /* in bytes */>
+  template <int size /* in bytes */>
   struct UnsignedTypeBySize;
 
   // Auxiliary struct for figuring out an unsigned type for a given type.
-  template<typename T> struct UnsignedType {
+  template <typename T>
+  struct UnsignedType {
     typedef typename UnsignedTypeBySize<sizeof(T)>::Type Type;
   };
 
@@ -85,8 +85,8 @@ class Bits {
 #elif defined(_LP64)
     n -= (n >> 1) & 0x5555555555555555ULL;
     n = ((n >> 2) & 0x3333333333333333ULL) + (n & 0x3333333333333333ULL);
-    return (((n + (n >> 4)) & 0xF0F0F0F0F0F0F0FULL)
-            * 0x101010101010101ULL) >> 56;
+    return (((n + (n >> 4)) & 0xF0F0F0F0F0F0F0FULL) * 0x101010101010101ULL) >>
+           56;
 #else
     return CountOnes(n >> 32) + CountOnes(n & 0xffffffff);
 #endif
@@ -129,9 +129,9 @@ class Bits {
     int32 idx, neg1 = -1;
     asm("bsr %1,%0\n\t"
         "cmovz %2,%0"
-        : "=&r"(idx)          // idx is early-clobbered
+        : "=&r"(idx)  // idx is early-clobbered
         : "ro"(n), "r"(neg1)
-        : "cc");              // bsr writes Z flag
+        : "cc");  // bsr writes Z flag
     return 31 - idx;
 #elif defined(__powerpc64__) && defined(__GNUC__)
     int32 count;
@@ -155,11 +155,11 @@ class Bits {
     return count;
 #elif defined(__x86_64__) && defined(__GNUC__)
     int64 idx, neg1 = -1;
-    asm ("bsr %1,%0\n"
-         "cmovz %2,%0\n"
-         : "=&r"(idx)          // idx is early-clobbered
-         : "ro"(n), "r"(neg1)
-         : "cc");              // bsr writes Z flag
+    asm("bsr %1,%0\n"
+        "cmovz %2,%0\n"
+        : "=&r"(idx)  // idx is early-clobbered
+        : "ro"(n), "r"(neg1)
+        : "cc");  // bsr writes Z flag
     return 63 - idx;
 #elif defined(__GNUC__)
     return CountLeadingZerosWithBuiltin<uint64>(n);
@@ -181,18 +181,18 @@ class Bits {
   static absl::uint128 ReverseBits128(absl::uint128 n);
 
   // Return the number of one bits in the byte sequence.
-  static int Count(const void *m, int num_bytes);
+  static int Count(const void* m, int num_bytes);
 
   // Return the number of different bits in the given byte sequences.
   // (i.e., the Hamming distance)
-  static int Difference(const void *m1, const void *m2, int num_bytes);
+  static int Difference(const void* m1, const void* m2, int num_bytes);
 
   // Return the number of different bits in the given byte sequences,
   // up to a maximum.  Values larger than the maximum may be returned
   // (because multiple bits are checked at a time), but the function
   // may exit early if the cap is exceeded.
-  static int CappedDifference(const void *m1, const void *m2,
-                              int num_bytes, int cap);
+  static int CappedDifference(const void* m1, const void* m2, int num_bytes,
+                              int cap);
 
   // Return floor(log2(n)) for positive integer n.  Returns -1 iff n == 0.
   static int Log2Floor(uint32 n);
@@ -225,23 +225,25 @@ class Bits {
 
   // Viewing bytes as a stream of unsigned bytes, does that stream
   // contain any byte equal to c?
-  template <class T> static bool BytesContainByte(T bytes, uint8 c);
+  template <class T>
+  static bool BytesContainByte(T bytes, uint8 c);
 
   // Viewing bytes as a stream of unsigned bytes, does that stream
   // contain any byte b < c?
-  template <class T> static bool BytesContainByteLessThan(T bytes, uint8 c);
+  template <class T>
+  static bool BytesContainByteLessThan(T bytes, uint8 c);
 
   // Viewing bytes as a stream of unsigned bytes, are all elements of that
   // stream in [lo, hi]?
-  template <class T> static bool BytesAllInRange(T bytes, uint8 lo, uint8 hi);
+  template <class T>
+  static bool BytesAllInRange(T bytes, uint8 lo, uint8 hi);
 
   // Extract 'nbits' consecutive bits from 'src'.  Position of bits are
   // specified by 'offset' from the LSB.  'T' is a scalar type (integral,
   // float or pointer) whose size is the same as one of the unsigned types.
   // The return type is an unsigned type having the same size as T.
-  template<typename T>
-  static typename UnsignedType<T>::Type GetBits(const T src,
-                                                const int offset,
+  template <typename T>
+  static typename UnsignedType<T>::Type GetBits(const T src, const int offset,
                                                 const int nbits) {
     typedef typename UnsignedType<T>::Type UnsignedT;
     const UnsignedT unsigned_src = absl::bit_cast<UnsignedT>(src);
@@ -255,11 +257,9 @@ class Bits {
   // Overwrite 'nbits' consecutive bits of 'dest.'.  Position of bits are
   // specified by an offset from the LSB.  'T' is a scalar type (integral,
   // float or pointer) whose size is the same as one of the unsigned types.
-  template<typename T>
+  template <typename T>
   static void SetBits(const typename UnsignedType<T>::Type value,
-                      const int offset,
-                      const int nbits,
-                      T* const dest) {
+                      const int offset, const int nbits, T* const dest) {
     typedef typename UnsignedType<T>::Type UnsignedT;
     const UnsignedT unsigned_dest = absl::bit_cast<UnsignedT>(*dest);
     DCHECK_GT(static_cast<int>(sizeof(UnsignedT) * 8), offset);
@@ -277,11 +277,9 @@ class Bits {
   //
   // uint32 a, b;
   // Bits::CopyBits(&a, 0, b, 12, 3);
-  template<typename DestType, typename SrcType>
-  static void CopyBits(DestType* const dest,
-                       const int dest_offset,
-                       const SrcType src,
-                       const int src_offset,
+  template <typename DestType, typename SrcType>
+  static void CopyBits(DestType* const dest, const int dest_offset,
+                       const SrcType src, const int src_offset,
                        const int nbits) {
     const typename UnsignedType<SrcType>::Type value =
         GetBits(src, src_offset, nbits);
@@ -290,16 +288,16 @@ class Bits {
 
  private:
   // We only use this for unsigned types and for 0 <= n <= sizeof(UnsignedT).
-  template<typename UnsignedT>
+  template <typename UnsignedT>
   static UnsignedT NBitsFromLSB(const int nbits) {
     const UnsignedT all_ones = ~static_cast<UnsignedT>(0);
     return nbits == 0 ? 0U : all_ones >> (sizeof(UnsignedT) * 8 - nbits);
   }
 
 #ifdef __GNUC__
-  template<typename UnsignedT>
+  template <typename UnsignedT>
   static inline int CountLeadingZerosWithBuiltin(UnsignedT n);
-  template<typename UnsignedT>
+  template <typename UnsignedT>
   static inline int PopcountWithBuiltin(UnsignedT n);
 #endif
 
@@ -322,10 +320,11 @@ class Bits {
 // A utility class for some handy bit patterns.  The names l and h
 // were chosen to match Knuth Volume 4: l is 0x010101... and h is 0x808080...;
 // half_ones is ones in the lower half only.  We assume sizeof(T) is 1 or even.
-template <class T> struct BitPattern {
-  static const T half_ones = (static_cast<T>(1) << (sizeof(T)*4)) - 1;
-  static const T l = (sizeof(T) == 1) ? 1 :
-                       (half_ones / 0xff * (half_ones + 2));
+template <class T>
+struct BitPattern {
+  static const T half_ones = (static_cast<T>(1) << (sizeof(T) * 4)) - 1;
+  static const T l =
+      (sizeof(T) == 1) ? 1 : (half_ones / 0xff * (half_ones + 2));
   static const T h = ~(l * 0x7f);
 };
 
@@ -339,13 +338,9 @@ inline int Bits::Log2Floor(uint32 n) {
   return n == 0 ? -1 : 31 ^ __builtin_clz(n);
 }
 
-inline int Bits::Log2FloorNonZero(uint32 n) {
-  return 31 ^ __builtin_clz(n);
-}
+inline int Bits::Log2FloorNonZero(uint32 n) { return 31 ^ __builtin_clz(n); }
 
-inline int Bits::FindLSBSetNonZero(uint32 n) {
-  return __builtin_ctz(n);
-}
+inline int Bits::FindLSBSetNonZero(uint32 n) { return __builtin_ctz(n); }
 
 inline int Bits::Log2Floor64(uint64 n) {
   return n == 0 ? -1 : 63 ^ __builtin_clzll(n);
@@ -355,9 +350,7 @@ inline int Bits::Log2FloorNonZero64(uint64 n) {
   return 63 ^ __builtin_clzll(n);
 }
 
-inline int Bits::FindLSBSetNonZero64(uint64 n) {
-  return __builtin_ctzll(n);
-}
+inline int Bits::FindLSBSetNonZero64(uint64 n) { return __builtin_ctzll(n); }
 #elif defined(COMPILER_MSVC)
 #include "util/bits/bits-internal-windows.h"
 #else
@@ -379,9 +372,7 @@ inline int Bits::FindLSBSetNonZero128(absl::uint128 n) {
   return 64 + Bits::FindLSBSetNonZero64(absl::Uint128High64(n));
 }
 
-inline int Bits::CountOnesInByte(unsigned char n) {
-  return num_bits[n];
-}
+inline int Bits::CountOnesInByte(unsigned char n) { return num_bits[n]; }
 
 inline uint8 Bits::ReverseBits8(unsigned char n) {
 #if defined(__aarch64__) && defined(__GNUC__)
@@ -393,7 +384,7 @@ inline uint8 Bits::ReverseBits8(unsigned char n) {
 #else
   n = ((n >> 1) & 0x55) | ((n & 0x55) << 1);
   n = ((n >> 2) & 0x33) | ((n & 0x33) << 2);
-  return ((n >> 4) & 0x0f)  | ((n & 0x0f) << 4);
+  return ((n >> 4) & 0x0f) | ((n & 0x0f) << 4);
 #endif
 }
 
@@ -421,8 +412,8 @@ inline uint64 Bits::ReverseBits64(uint64 n) {
   n = ((n >> 4) & 0x0F0F0F0F0F0F0F0FULL) | ((n & 0x0F0F0F0F0F0F0F0FULL) << 4);
   return bswap_64(n);
 #else
-  return ReverseBits32( n >> 32 ) |
-         (static_cast<uint64>(ReverseBits32(n &  0xffffffff)) << 32);
+  return ReverseBits32(n >> 32) |
+         (static_cast<uint64>(ReverseBits32(n & 0xffffffff)) << 32);
 #endif
 }
 
@@ -475,12 +466,12 @@ inline bool Bits::BytesContainByteLessThan(T bytes, uint8 c) {
   T h = BitPattern<T>::h;
   // The c <= 0x80 code is straight out of Knuth Volume 4.
   // Usually c will be manifestly constant.
-  return c <= 0x80 ?
-      ((h & (bytes - l * c) & ~bytes) != 0) :
-      ((((bytes - l * c) | (bytes ^ h)) & h) != 0);
+  return c <= 0x80 ? ((h & (bytes - l * c) & ~bytes) != 0)
+                   : ((((bytes - l * c) | (bytes ^ h)) & h) != 0);
 }
 
-template <class T> inline bool Bits::BytesContainByte(T bytes, uint8 c) {
+template <class T>
+inline bool Bits::BytesContainByte(T bytes, uint8 c) {
   // Usually c will be manifestly constant.
   return Bits::BytesContainByteLessThan<T>(bytes ^ (c * BitPattern<T>::l), 1);
 }
@@ -504,40 +495,41 @@ inline bool Bits::BytesAllInRange(T bytes, uint8 lo, uint8 hi) {
 
 // Specializations for Bits::UnsignedTypeBySize.  For unsupported type
 // sizes, a compile-time error will be generated.
-template<>
+template <>
 struct Bits::UnsignedTypeBySize<1> {
   typedef uint8 Type;
 };
 
-template<>
+template <>
 struct Bits::UnsignedTypeBySize<2> {
   typedef uint16 Type;
 };
 
-template<>
+template <>
 struct Bits::UnsignedTypeBySize<4> {
   typedef uint32 Type;
 };
 
-template<>
+template <>
 struct Bits::UnsignedTypeBySize<8> {
   typedef uint64 Type;
 };
 
 #ifdef __GNUC__
 // Select a correct gcc/llvm builtin for clz based on size.
-template<typename UnsignedT>
+template <typename UnsignedT>
 int Bits::CountLeadingZerosWithBuiltin(UnsignedT n) {
-  if (n == 0)   // __builtin_clz(0) is officially undefined.
+  if (n == 0)  // __builtin_clz(0) is officially undefined.
     return sizeof(n) * 8;
   constexpr size_t size = sizeof(n);
-  static_assert(size == sizeof(unsigned)
-                || size == sizeof(unsigned long)        // NOLINT(runtime/int)
-                || size == sizeof(unsigned long long),  // NOLINT(runtime/int)
+  static_assert(size == sizeof(unsigned) ||
+                    size == sizeof(unsigned long)  // NOLINT(runtime/int)
+                    ||
+                    size == sizeof(unsigned long long),  // NOLINT(runtime/int)
                 "No __builtin_clz for this size");
   if (size == sizeof(unsigned)) {
     return __builtin_clz(n);
-  } else if (size == sizeof(unsigned long)) {           // NOLINT(runtime/int)
+  } else if (size == sizeof(unsigned long)) {  // NOLINT(runtime/int)
     return __builtin_clzl(n);
   } else {
     return __builtin_clzll(n);
@@ -545,16 +537,17 @@ int Bits::CountLeadingZerosWithBuiltin(UnsignedT n) {
 }
 
 // Select a correct gcc/llvm builtin for popcount based on size.
-template<typename UnsignedT>
+template <typename UnsignedT>
 int Bits::PopcountWithBuiltin(UnsignedT n) {
   constexpr size_t size = sizeof(n);
-  static_assert(size == sizeof(unsigned)
-                || size == sizeof(unsigned long)        // NOLINT(runtime/int)
-                || size == sizeof(unsigned long long),  // NOLINT(runtime/int)
+  static_assert(size == sizeof(unsigned) ||
+                    size == sizeof(unsigned long)  // NOLINT(runtime/int)
+                    ||
+                    size == sizeof(unsigned long long),  // NOLINT(runtime/int)
                 "No __builtin_popcount for this size");
   if (size == sizeof(unsigned)) {
     return __builtin_popcount(n);
-  } else if (size == sizeof(unsigned long)) {           // NOLINT(runtime/int)
+  } else if (size == sizeof(unsigned long)) {  // NOLINT(runtime/int)
     return __builtin_popcountl(n);
   } else {
     return __builtin_popcountll(n);

--- a/stratum/glue/net_util/bits_test.cc
+++ b/stratum/glue/net_util/bits_test.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Copyright (C) 2002 and onwards Google, Inc.
 // Author: Paul Haahr
 //
@@ -11,22 +10,23 @@
 #include "stratum/glue/net_util/bits.h"
 
 #include <string.h>
+
 #include <algorithm>
 #include <iostream>
-#include <random>
-#include <vector>
 #include <limits>
+#include <random>
 #include <utility>
+#include <vector>
 
-#include "stratum/glue/logging.h"
+#include "absl/numeric/int128.h"
 #include "gtest/gtest.h"
 #include "stratum/glue/integral_types.h"
-#include "absl/numeric/int128.h"
+#include "stratum/glue/logging.h"
 
 namespace stratum {
 
 int32 num_iterations = 10000;  // Number of test iterations to run.
-int32 max_bytes = 100;  // Maximum number of bytes to use in tests.
+int32 max_bytes = 100;         // Maximum number of bytes to use in tests.
 
 static const int kMaxBytes = 128;
 static const int kNumReverseBitsRandomTests = 10;
@@ -36,7 +36,7 @@ class BitsTest : public testing::Test {
   BitsTest() {}
 
  protected:
-  template<typename T>
+  template <typename T>
   static void CheckUnsignedType() {
     typedef typename Bits::UnsignedType<T>::Type UnsignedT;
     EXPECT_EQ(sizeof(T), sizeof(UnsignedT));
@@ -44,21 +44,19 @@ class BitsTest : public testing::Test {
   }
 
   // Generate a random number of type T with the same range as that of T.
-  template<typename T>
+  template <typename T>
   T RandomBits() {
     std::uniform_int_distribution<T> distribution;
     return distribution(random_);
   }
 
-  template<typename T>
+  template <typename T>
   T RandomUniform(T min, T max) {
     std::uniform_int_distribution<T> distribution(min, max - 1);
     return distribution(random_);
   }
 
-  bool RandomOneIn(int max) {
-    return RandomUniform<int>(0, max) == 0;
-  }
+  bool RandomOneIn(int max) { return RandomUniform<int>(0, max) == 0; }
 
   // generate a uniformly distributed float between 0 and 1
   float RandomFloat() {
@@ -69,26 +67,24 @@ class BitsTest : public testing::Test {
   // Wrapper for Bits::SetBits with a slightly different interface for
   // testing.  Instead of modifying a scalar, it returns a new value
   // with some bits replaced.
-  template<typename T>
-  static T SetBits(T dest,
-                   const typename Bits::UnsignedType<T>::Type src,
-                   const int offset,
-                   const int nbits) {
+  template <typename T>
+  static T SetBits(T dest, const typename Bits::UnsignedType<T>::Type src,
+                   const int offset, const int nbits) {
     Bits::SetBits(src, offset, nbits, &dest);
     return dest;
   }
 
-  template<typename DestType, typename SrcType>
+  template <typename DestType, typename SrcType>
   void RandomCopyBitsTestTwoTypes();
 
-  template<typename DestType>
+  template <typename DestType>
   void RandomCopyBitsTestDestType();
 
   std::default_random_engine random_;
 };
 
 // Randomly test Bits::CopyBits of two scalar types.
-template<typename DestType, typename SrcType>
+template <typename DestType, typename SrcType>
 void BitsTest::RandomCopyBitsTestTwoTypes() {
   const int kNumIterations = 2000;
   const int dest_bits = sizeof(DestType) * 8;
@@ -100,8 +96,8 @@ void BitsTest::RandomCopyBitsTestTwoTypes() {
     const int dest_offset = RandomBits<int>() % dest_bits;
     const SrcType src = RandomBits<SrcType>();
     const int src_offset = RandomBits<int>() % src_bits;
-    const int nbits_max = std::min(dest_bits - dest_offset,
-                                      src_bits - src_offset);
+    const int nbits_max =
+        std::min(dest_bits - dest_offset, src_bits - src_offset);
     const int nbits = RandomBits<int>() % (nbits_max + 1);
 
     Bits::CopyBits(&dest, dest_offset, src, src_offset, nbits);
@@ -113,10 +109,10 @@ void BitsTest::RandomCopyBitsTestTwoTypes() {
     typedef typename Bits::UnsignedType<DestType>::Type DestUnsignedType;
     const SrcUnsignedType unsigned_src = static_cast<SrcUnsignedType>(src);
     for (int j = 0; j < nbits; ++j) {
-      const SrcUnsignedType src_bit =
-          static_cast<SrcUnsignedType>(1) << (src_offset + j);
-      const DestUnsignedType dest_bit =
-          static_cast<DestUnsignedType>(1) << (dest_offset + j);
+      const SrcUnsignedType src_bit = static_cast<SrcUnsignedType>(1)
+                                      << (src_offset + j);
+      const DestUnsignedType dest_bit = static_cast<DestUnsignedType>(1)
+                                        << (dest_offset + j);
       if ((unsigned_src & src_bit) != 0) {
         dest2 |= dest_bit;
       } else {
@@ -129,7 +125,7 @@ void BitsTest::RandomCopyBitsTestTwoTypes() {
 }
 
 // Helper template to test all 8 scalar source types.
-template<typename DestType>
+template <typename DestType>
 void BitsTest::RandomCopyBitsTestDestType() {
   RandomCopyBitsTestTwoTypes<DestType, int8>();
   RandomCopyBitsTestTwoTypes<DestType, uint8>();
@@ -160,7 +156,7 @@ TEST_F(BitsTest, BitCountingEdgeCases) {
 
   for (int i = 0; i < 64; i++) {
     EXPECT_EQ(1, Bits::CountOnes64(1LLU << i));
-    EXPECT_EQ(63, Bits::CountOnes64(static_cast<uint64> (~(1LLU << i))));
+    EXPECT_EQ(63, Bits::CountOnes64(static_cast<uint64>(~(1LLU << i))));
   }
 
   EXPECT_EQ(0, Bits::CountOnes128(absl::uint128(0)));
@@ -367,8 +363,8 @@ TEST_F(BitsTest, BitDifferenceRandom) {
 }
 
 static bool SlowBytesContainByte(uint32 x, uint8 b) {
-  return (x & 0xff) == b || ((x >> 8) & 0xff) == b ||
-      ((x >> 16) & 0xff) == b || ((x >> 24) & 0xff) == b;
+  return (x & 0xff) == b || ((x >> 8) & 0xff) == b || ((x >> 16) & 0xff) == b ||
+         ((x >> 24) & 0xff) == b;
 }
 
 static bool SlowBytesContainByte(uint64 x, uint8 b) {
@@ -378,15 +374,15 @@ static bool SlowBytesContainByte(uint64 x, uint8 b) {
 }
 
 static bool SlowBytesContainByteLessThan(uint32 x, uint8 b) {
-  return (x & 0xff) < b || ((x >> 8) & 0xff) < b ||
-      ((x >> 16) & 0xff) < b || ((x >> 24) & 0xff) < b;
+  return (x & 0xff) < b || ((x >> 8) & 0xff) < b || ((x >> 16) & 0xff) < b ||
+         ((x >> 24) & 0xff) < b;
 }
 
 static bool SlowBytesContainByteLessThan(uint64 x, uint8 b) {
   uint32 u = x;
   uint32 v = x >> 32;
   return SlowBytesContainByteLessThan(u, b) ||
-      SlowBytesContainByteLessThan(v, b);
+         SlowBytesContainByteLessThan(v, b);
 }
 
 TEST_F(BitsTest, BytesContainByte) {
@@ -394,8 +390,8 @@ TEST_F(BitsTest, BytesContainByte) {
   for (int i = 0; i < num_iterations; i++) {
     uint32 u32 = RandomBits<uint32>();
     uint64 u64 = RandomBits<uint64>();
-    int64  s64 = u64;
-    uint8    b = RandomBits<uint8>();
+    int64 s64 = u64;
+    uint8 b = RandomBits<uint8>();
 
     EXPECT_EQ(Bits::BytesContainByte<uint32>(u32, b),
               SlowBytesContainByte(u32, b));
@@ -420,7 +416,7 @@ static bool ByteInRange(uint8 x, uint8 lo, uint8 hi) {
 // True if all bytes in x are in [lo, hi].
 static bool SlowBytesAllInRange(uint32 x, uint8 lo, uint8 hi) {
   return ByteInRange(x, lo, hi) && ByteInRange(x >> 8, lo, hi) &&
-      ByteInRange(x >> 16, lo, hi) && ByteInRange(x >> 24, lo, hi);
+         ByteInRange(x >> 16, lo, hi) && ByteInRange(x >> 24, lo, hi);
 }
 
 // True if all bytes in x are in [lo, hi].
@@ -435,9 +431,9 @@ TEST_F(BitsTest, BytesAllInRange) {
   for (int i = 0; i < num_iterations; i++) {
     uint32 u32 = RandomBits<uint32>();
     uint64 u64 = RandomBits<uint64>();
-    int64  s64 = u64;
-    uint8   lo = RandomBits<uint32>() >> 13;
-    uint8   hi = RandomBits<uint32>() >> 13;
+    int64 s64 = u64;
+    uint8 lo = RandomBits<uint32>() >> 13;
+    uint8 hi = RandomBits<uint32>() >> 13;
     if (i > 5 && lo > hi) {
       std::swap(lo, hi);
     }
@@ -546,10 +542,10 @@ TEST_F(BitsTest, Log2EdgeCases) {
     EXPECT_EQ(i, Bits::Log2Ceiling(n));
     if (n > 2) {
       EXPECT_EQ(i - 1, Bits::Log2Floor(n - 1));
-      EXPECT_EQ(i,     Bits::Log2Floor(n + 1));
+      EXPECT_EQ(i, Bits::Log2Floor(n + 1));
       EXPECT_EQ(i - 1, Bits::Log2FloorNonZero(n - 1));
-      EXPECT_EQ(i,     Bits::Log2FloorNonZero(n + 1));
-      EXPECT_EQ(i,     Bits::Log2Ceiling(n - 1));
+      EXPECT_EQ(i, Bits::Log2FloorNonZero(n + 1));
+      EXPECT_EQ(i, Bits::Log2Ceiling(n - 1));
       EXPECT_EQ(i + 1, Bits::Log2Ceiling(n + 1));
     }
   }
@@ -561,10 +557,10 @@ TEST_F(BitsTest, Log2EdgeCases) {
     EXPECT_EQ(i, Bits::Log2Ceiling64(n));
     if (n > 2) {
       EXPECT_EQ(i - 1, Bits::Log2Floor64(n - 1));
-      EXPECT_EQ(i,     Bits::Log2Floor64(n + 1));
+      EXPECT_EQ(i, Bits::Log2Floor64(n + 1));
       EXPECT_EQ(i - 1, Bits::Log2FloorNonZero64(n - 1));
-      EXPECT_EQ(i,     Bits::Log2FloorNonZero64(n + 1));
-      EXPECT_EQ(i,     Bits::Log2Ceiling64(n - 1));
+      EXPECT_EQ(i, Bits::Log2FloorNonZero64(n + 1));
+      EXPECT_EQ(i, Bits::Log2Ceiling64(n - 1));
       EXPECT_EQ(i + 1, Bits::Log2Ceiling64(n + 1));
     }
   }
@@ -575,8 +571,8 @@ TEST_F(BitsTest, Log2EdgeCases) {
     EXPECT_EQ(i, Bits::Log2Ceiling128(n));
     if (n > 2) {
       EXPECT_EQ(i - 1, Bits::Log2Floor128(n - 1));
-      EXPECT_EQ(i,     Bits::Log2Floor128(n + 1));
-      EXPECT_EQ(i,     Bits::Log2Ceiling128(n - 1));
+      EXPECT_EQ(i, Bits::Log2Floor128(n + 1));
+      EXPECT_EQ(i, Bits::Log2Ceiling128(n - 1));
       EXPECT_EQ(i + 1, Bits::Log2Ceiling128(n + 1));
     }
   }
@@ -776,21 +772,23 @@ TEST(Bits, Port32) {
       const uint32 v = (static_cast<uint32>(1) << shift) + delta;
       EXPECT_EQ(Bits::Log2Floor_Portable(v), Bits::Log2Floor(v)) << v;
       if (v != 0) {
-        EXPECT_EQ(Bits::Log2FloorNonZero_Portable(v),
-                  Bits::Log2FloorNonZero(v)) << v;
+        EXPECT_EQ(Bits::Log2FloorNonZero_Portable(v), Bits::Log2FloorNonZero(v))
+            << v;
         EXPECT_EQ(Bits::FindLSBSetNonZero_Portable(v),
-                  Bits::FindLSBSetNonZero(v)) << v;
+                  Bits::FindLSBSetNonZero(v))
+            << v;
         EXPECT_EQ(Bits::CountLeadingZeros32_Portable(v),
-                  Bits::CountLeadingZeros32(v)) << v;
+                  Bits::CountLeadingZeros32(v))
+            << v;
       }
     }
   }
   static const uint32 M32 = kuint32max;
   EXPECT_EQ(Bits::Log2Floor_Portable(M32), Bits::Log2Floor(M32)) << M32;
-  EXPECT_EQ(Bits::Log2FloorNonZero_Portable(M32),
-            Bits::Log2FloorNonZero(M32)) << M32;
-  EXPECT_EQ(Bits::FindLSBSetNonZero_Portable(M32),
-            Bits::FindLSBSetNonZero(M32)) << M32;
+  EXPECT_EQ(Bits::Log2FloorNonZero_Portable(M32), Bits::Log2FloorNonZero(M32))
+      << M32;
+  EXPECT_EQ(Bits::FindLSBSetNonZero_Portable(M32), Bits::FindLSBSetNonZero(M32))
+      << M32;
   EXPECT_EQ(32, Bits::CountLeadingZeros32_Portable(static_cast<uint32>(0)));
   EXPECT_EQ(0, Bits::CountLeadingZeros32_Portable(~static_cast<uint32>(0)));
 }
@@ -802,20 +800,25 @@ TEST(Bits, Port64) {
       EXPECT_EQ(Bits::Log2Floor64_Portable(v), Bits::Log2Floor64(v)) << v;
       if (v != 0) {
         EXPECT_EQ(Bits::Log2FloorNonZero64_Portable(v),
-                  Bits::Log2FloorNonZero64(v)) << v;
+                  Bits::Log2FloorNonZero64(v))
+            << v;
         EXPECT_EQ(Bits::FindLSBSetNonZero64_Portable(v),
-                  Bits::FindLSBSetNonZero64(v)) << v;
+                  Bits::FindLSBSetNonZero64(v))
+            << v;
         EXPECT_EQ(Bits::CountLeadingZeros64_Portable(v),
-                  Bits::CountLeadingZeros64(v)) << v;
+                  Bits::CountLeadingZeros64(v))
+            << v;
       }
     }
   }
   static const uint64 M64 = kuint64max;
   EXPECT_EQ(Bits::Log2Floor64_Portable(M64), Bits::Log2Floor64(M64)) << M64;
   EXPECT_EQ(Bits::Log2FloorNonZero64_Portable(M64),
-            Bits::Log2FloorNonZero64(M64)) << M64;
+            Bits::Log2FloorNonZero64(M64))
+      << M64;
   EXPECT_EQ(Bits::FindLSBSetNonZero64_Portable(M64),
-            Bits::FindLSBSetNonZero64(M64)) << M64;
+            Bits::FindLSBSetNonZero64(M64))
+      << M64;
   EXPECT_EQ(64, Bits::CountLeadingZeros64_Portable(static_cast<uint64>(0)));
   EXPECT_EQ(0, Bits::CountLeadingZeros64_Portable(~static_cast<uint64>(0)));
 }
@@ -828,7 +831,7 @@ TEST(CountOnes, InByte) {
       expected += (c & (1 << pos)) ? 1 : 0;
     }
     EXPECT_EQ(expected, Bits::CountOnesInByte(c))
-      << std::hex << static_cast<int>(c);
+        << std::hex << static_cast<int>(c);
   }
 }
 
@@ -982,7 +985,7 @@ BENCHMARK_WITH_ARG(BM_FindMSBSetNonZero64, 63);
 template <class T>
 static T ExpectedReverseBits(T n) {
   T r = 0;
-  for (size_t i = 0; i < sizeof(T) << 3 ; ++i) {
+  for (size_t i = 0; i < sizeof(T) << 3; ++i) {
     r = (r << 1) | (n & 1);
     n >>= 1;
   }
@@ -1061,8 +1064,7 @@ TEST_F(BitsTest, ReverseBitsIn128BitWord) {
     const absl::uint128 r = Bits::ReverseBits128(n);
     EXPECT_EQ(n, Bits::ReverseBits128(r)) << n;
     EXPECT_EQ(ExpectedReverseBits<absl::uint128>(n), r) << n;
-    EXPECT_EQ(Bits::CountOnes128(n),
-              Bits::CountOnes128(r)) << n;
+    EXPECT_EQ(Bits::CountOnes128(n), Bits::CountOnes128(r)) << n;
   }
 }
 

--- a/stratum/glue/net_util/ipaddress.cc
+++ b/stratum/glue/net_util/ipaddress.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Definition of classes IPAddress and SocketAddress.
 
 #include "stratum/glue/net_util/ipaddress.h"
@@ -14,6 +13,7 @@
 #include <netdb.h>
 #include <stdio.h>  // for snprintf
 #include <sys/socket.h>
+
 #include <iosfwd>
 #include <limits>
 #include <string>
@@ -50,21 +50,15 @@ const int kMaxNetmaskIPv6 = 128;
 // ToCharBuf() (below) depends on this.
 static_assert(INET_ADDRSTRLEN <= INET6_ADDRSTRLEN, "ipv6 larger than ipv4");
 
-IPAddress IPAddress::Any4() {
-  return HostUInt32ToIPAddress(INADDR_ANY);
-}
+IPAddress IPAddress::Any4() { return HostUInt32ToIPAddress(INADDR_ANY); }
 
 IPAddress IPAddress::Loopback4() {
   return HostUInt32ToIPAddress(INADDR_LOOPBACK);
 }
 
-IPAddress IPAddress::Any6() {
-  return IPAddress(in6addr_any);
-}
+IPAddress IPAddress::Any6() { return IPAddress(in6addr_any); }
 
-IPAddress IPAddress::Loopback6() {
-  return IPAddress(in6addr_loopback);
-}
+IPAddress IPAddress::Loopback6() { return IPAddress(in6addr_loopback); }
 
 IPAddress UInt128ToIPAddress(const absl::uint128& bigint) {
   in6_addr addr6;
@@ -89,10 +83,8 @@ bool IsAnyIPAddress(const IPAddress& ip) {
       LOG(DFATAL) << "Calling IsAnyIPAddress() on an empty IPAddress";
       break;
     default:
-      LOG(DFATAL)
-          << "Calling IsAnyIPAddress() on an IPAddress "
-          << "with unknown address family "
-          << ip.address_family();
+      LOG(DFATAL) << "Calling IsAnyIPAddress() on an IPAddress "
+                  << "with unknown address family " << ip.address_family();
   }
   return false;
 }
@@ -104,8 +96,7 @@ enum class LoopbackMode {
   DO_NOT_INCLUDE_ENTIRE_IPV4_LOOPBACK_NETWORK,
 };
 
-bool IsLoopbackIPAddress(const IPAddress& ip,
-                         const LoopbackMode mode) {
+bool IsLoopbackIPAddress(const IPAddress& ip, const LoopbackMode mode) {
   switch (ip.address_family()) {
     case AF_INET:
       if (mode == LoopbackMode::INCLUDE_ENTIRE_IPV4_LOOPBACK_NETWORK) {
@@ -119,10 +110,8 @@ bool IsLoopbackIPAddress(const IPAddress& ip,
       LOG(DFATAL) << "Calling IsLoopbackIPAddress() on an empty IPAddress";
       break;
     default:
-      LOG(DFATAL)
-          << "Calling IsLoopbackIPAddress() on an IPAddress "
-          << "with unknown address family "
-          << ip.address_family();
+      LOG(DFATAL) << "Calling IsLoopbackIPAddress() on an IPAddress "
+                  << "with unknown address family " << ip.address_family();
   }
   return false;
 }
@@ -144,13 +133,12 @@ bool IsLoopbackIPAddress(const IPAddress& ip) {
 void IPAddress::ToCharBuf(char* buffer) const {
   switch (address_family_) {
     case AF_INET: {
-      CHECK(inet_ntop(AF_INET, &addr_.addr4, buffer, INET_ADDRSTRLEN)
-            != NULL);
+      CHECK(inet_ntop(AF_INET, &addr_.addr4, buffer, INET_ADDRSTRLEN) != NULL);
       break;
     }
     case AF_INET6:
-      CHECK(inet_ntop(AF_INET6, &addr_.addr6, buffer, INET6_ADDRSTRLEN)
-            != NULL);
+      CHECK(inet_ntop(AF_INET6, &addr_.addr6, buffer, INET6_ADDRSTRLEN) !=
+            NULL);
       break;
     case AF_UNSPEC:
       LOG(DFATAL) << "Calling ToCharBuf() on an empty IPAddress";
@@ -170,10 +158,10 @@ std::string IPAddress::ToString() const {
 std::string IPAddress::ToPackedString() const {
   switch (address_family_) {
     case AF_INET:
-      return std::string(reinterpret_cast<const char *>(&addr_.addr4),
+      return std::string(reinterpret_cast<const char*>(&addr_.addr4),
                          sizeof(addr_.addr4));
     case AF_INET6:
-      return std::string(reinterpret_cast<const char *>(&addr_.addr6),
+      return std::string(reinterpret_cast<const char*>(&addr_.addr6),
                          sizeof(addr_.addr6));
     case AF_UNSPEC:
       LOG(DFATAL) << "Calling ToPackedString() on an empty IPAddress";
@@ -288,8 +276,9 @@ std::string IPAddressToURIString(const IPAddress& ip) {
 }
 
 std::string IPAddressToPTRString(const IPAddress& ip) {
-  char ptr_name[sizeof("0.1.2.3.4.5.6.7.8.9.a.b.c.d.e.f."
-                       "0.1.2.3.4.5.6.7.8.9.a.b.c.d.e.f.ip6.arpa")];
+  char
+      ptr_name[sizeof("0.1.2.3.4.5.6.7.8.9.a.b.c.d.e.f."
+                      "0.1.2.3.4.5.6.7.8.9.a.b.c.d.e.f.ip6.arpa")];
   memset(ptr_name, 0, sizeof(ptr_name));
 
   switch (ip.address_family()) {
@@ -300,33 +289,25 @@ std::string IPAddressToPTRString(const IPAddress& ip) {
       a2 = static_cast<int>((addr >> 16) & 0xff);
       a3 = static_cast<int>((addr >> 8) & 0xff);
       a4 = static_cast<int>(addr & 0xff);
-      snprintf(ptr_name, sizeof(ptr_name), "%d.%d.%d.%d.in-addr.arpa",
-               a4, a3, a2, a1);
+      snprintf(ptr_name, sizeof(ptr_name), "%d.%d.%d.%d.in-addr.arpa", a4, a3,
+               a2, a1);
       return ptr_name;
     }
     case AF_INET6: {
       const struct in6_addr addr = ip.ipv6_address();
-      const unsigned char * bytes =
-          reinterpret_cast<const unsigned char *>(addr.s6_addr);
+      const unsigned char* bytes =
+          reinterpret_cast<const unsigned char*>(addr.s6_addr);
       snprintf(ptr_name, sizeof(ptr_name),
                "%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x."
                "%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.ip6.arpa",
-               bytes[15] & 0xf, bytes[15] >> 4,
-               bytes[14] & 0xf, bytes[14] >> 4,
-               bytes[13] & 0xf, bytes[13] >> 4,
-               bytes[12] & 0xf, bytes[12] >> 4,
-               bytes[11] & 0xf, bytes[11] >> 4,
-               bytes[10] & 0xf, bytes[10] >> 4,
-               bytes[9] & 0xf, bytes[9] >> 4,
-               bytes[8] & 0xf, bytes[8] >> 4,
-               bytes[7] & 0xf, bytes[7] >> 4,
-               bytes[6] & 0xf, bytes[6] >> 4,
-               bytes[5] & 0xf, bytes[5] >> 4,
-               bytes[4] & 0xf, bytes[4] >> 4,
-               bytes[3] & 0xf, bytes[3] >> 4,
-               bytes[2] & 0xf, bytes[2] >> 4,
-               bytes[1] & 0xf, bytes[1] >> 4,
-               bytes[0] & 0xf, bytes[0] >> 4);
+               bytes[15] & 0xf, bytes[15] >> 4, bytes[14] & 0xf, bytes[14] >> 4,
+               bytes[13] & 0xf, bytes[13] >> 4, bytes[12] & 0xf, bytes[12] >> 4,
+               bytes[11] & 0xf, bytes[11] >> 4, bytes[10] & 0xf, bytes[10] >> 4,
+               bytes[9] & 0xf, bytes[9] >> 4, bytes[8] & 0xf, bytes[8] >> 4,
+               bytes[7] & 0xf, bytes[7] >> 4, bytes[6] & 0xf, bytes[6] >> 4,
+               bytes[5] & 0xf, bytes[5] >> 4, bytes[4] & 0xf, bytes[4] >> 4,
+               bytes[3] & 0xf, bytes[3] >> 4, bytes[2] & 0xf, bytes[2] >> 4,
+               bytes[1] & 0xf, bytes[1] >> 4, bytes[0] & 0xf, bytes[0] >> 4);
       return ptr_name;
     }
     case AF_UNSPEC:
@@ -395,7 +376,7 @@ IPAddress ChooseRandomAddress(const struct hostent* hp) {
 }
 
 // Return a random IPAddress from the a vector of same.
-IPAddress ChooseRandomIPAddress(const std::vector<IPAddress> *ipvec) {
+IPAddress ChooseRandomIPAddress(const std::vector<IPAddress>* ipvec) {
   LOG(FATAL) << __FUNCTION__ << " not yet implemented in depot3";
 }
 
@@ -446,8 +427,7 @@ bool SocketAddressOrdering::operator()(const SocketAddress& lhs,
   return lhs.port() < rhs.port();
 }
 
-bool IPRangeOrdering::operator()(const IPRange& lhs,
-                                 const IPRange& rhs) const {
+bool IPRangeOrdering::operator()(const IPRange& lhs, const IPRange& rhs) const {
   if (!IsInitializedRange(rhs)) {
     return false;
   }
@@ -555,8 +535,8 @@ bool Get6to4IPv6Range(const IPRange& iprange4, IPRange* iprange6) {
     DCHECK_EQ(4u, sizeof(addr4));
     memcpy(&addr6.s6_addr16[1], &addr4, sizeof(addr4));
 
-    *iprange6 = IPRange::UnsafeConstruct(
-        IPAddress(addr6), iprange4.length() + 16);
+    *iprange6 =
+        IPRange::UnsafeConstruct(IPAddress(addr6), iprange4.length() + 16);
   }
   return true;
 }
@@ -578,8 +558,8 @@ bool GetIsatapIPv4Address(const IPAddress& ip6, IPAddress* ip4) {
   // prepended to the client's IPv4 address to form the 64bit
   // interface identifier.  The usual rules about U/L and G bits
   // apply as well, hence we mask those bits when testing for equality.
-  if (addr6.s6_addr16[5] != ghtons(0x5efe)
-      || (addr6.s6_addr16[4] | ghtons(0x0300)) !=  ghtons(0x0300)) {
+  if (addr6.s6_addr16[5] != ghtons(0x5efe) ||
+      (addr6.s6_addr16[4] | ghtons(0x0300)) != ghtons(0x0300)) {
     return false;
   }
 
@@ -623,14 +603,13 @@ bool GetTeredoInfo(const IPAddress& ip6, IPAddress* server, uint16* flags,
   return true;
 }
 
-bool GetEmbeddedIPv4ClientAddress(const IPAddress& ip6, IPAddress *ip4) {
+bool GetEmbeddedIPv4ClientAddress(const IPAddress& ip6, IPAddress* ip4) {
   // Return the IPv4 Compat, IPv4 Mapped, 6to4, or Teredo client address,
   // if applicable.  NOTE: ISATAP addresses are explicityly NOT returned:
   // the client addresses are not part of the routing information and
   // are, consequently, considerably more spoofable.
-  return (GetCompatIPv4Address(ip6, ip4) ||
-          GetMappedIPv4Address(ip6, ip4) ||
-          Get6to4IPv4Address(ip6, ip4)   ||
+  return (GetCompatIPv4Address(ip6, ip4) || GetMappedIPv4Address(ip6, ip4) ||
+          Get6to4IPv4Address(ip6, ip4) ||
           GetTeredoInfo(ip6, NULL, NULL, NULL, ip4));
 }
 
@@ -669,16 +648,16 @@ IPAddress DualstackIPAddress(const IPAddress& ip) {
 SocketAddress::SocketAddress(const struct sockaddr& saddr) {
   switch (saddr.sa_family) {
     case AF_INET: {
-      const struct sockaddr_in* sin
-          = reinterpret_cast<const struct sockaddr_in*>(&saddr);
+      const struct sockaddr_in* sin =
+          reinterpret_cast<const struct sockaddr_in*>(&saddr);
       CHECK_EQ(AF_INET, sin->sin_family);
       host_ = IPAddress(sin->sin_addr);
       port_ = ntohs(sin->sin_port);
       break;
     }
     case AF_INET6: {
-      const struct sockaddr_in6* sin6
-          = reinterpret_cast<const struct sockaddr_in6*>(&saddr);
+      const struct sockaddr_in6* sin6 =
+          reinterpret_cast<const struct sockaddr_in6*>(&saddr);
       CHECK_EQ(AF_INET6, sin6->sin6_family);
       host_ = IPAddress(sin6->sin6_addr);
       port_ = ntohs(sin6->sin6_port);
@@ -700,16 +679,16 @@ SocketAddress::SocketAddress(const struct sockaddr& saddr) {
 SocketAddress::SocketAddress(const struct sockaddr_storage& saddr) {
   switch (saddr.ss_family) {
     case AF_INET: {
-      const struct sockaddr_in* sin
-          = reinterpret_cast<const struct sockaddr_in*>(&saddr);
+      const struct sockaddr_in* sin =
+          reinterpret_cast<const struct sockaddr_in*>(&saddr);
       CHECK_EQ(AF_INET, sin->sin_family);
       host_ = IPAddress(sin->sin_addr);
       port_ = ntohs(sin->sin_port);
       break;
     }
     case AF_INET6: {
-      const struct sockaddr_in6* sin6
-          = reinterpret_cast<const struct sockaddr_in6*>(&saddr);
+      const struct sockaddr_in6* sin6 =
+          reinterpret_cast<const struct sockaddr_in6*>(&saddr);
       CHECK_EQ(AF_INET6, sin6->sin6_family);
       host_ = IPAddress(sin6->sin6_addr);
       port_ = ntohs(sin6->sin6_port);
@@ -846,8 +825,8 @@ bool SocketAddressToFamily(int output_family, const SocketAddress& sa,
     }
   }
   // Generate an invalid sockaddr, to prevent accidental use.
-  LOG(WARNING) << "Can't convert address family "
-               << host.address_family() << " to " << output_family;
+  LOG(WARNING) << "Can't convert address family " << host.address_family()
+               << " to " << output_family;
   memset(addr_out, 0, sizeof(sockaddr));
   addr_out->ss_family = 0xFFFF;
   if (size_out != NULL) {
@@ -856,8 +835,7 @@ bool SocketAddressToFamily(int output_family, const SocketAddress& sa,
   return false;
 }
 
-bool SocketAddressToFamilyForBind(int output_family,
-                                  const SocketAddress& sa,
+bool SocketAddressToFamilyForBind(int output_family, const SocketAddress& sa,
                                   sockaddr_storage* addr_out,
                                   socklen_t* size_out) {
   SocketAddress sa_copy(sa);
@@ -904,10 +882,8 @@ bool InternalStringToNetmaskLength(const char* str, int host_address_family,
     }
   }
 
-  if (parsed_length < 0
-          || parsed_length > kMaxNetmaskIPv6
-          || (host_address_family != AF_INET6 &&
-              parsed_length > kMaxNetmaskIPv4)) {
+  if (parsed_length < 0 || parsed_length > kMaxNetmaskIPv6 ||
+      (host_address_family != AF_INET6 && parsed_length > kMaxNetmaskIPv4)) {
     return false;
   }
 
@@ -942,9 +918,8 @@ bool InternalStringToIPRange(const std::string& str,
   // Try to parse everything after the slash as a prefix length.
   if (slash_pos != std::string::npos) {
     const std::string suffix(str.substr(slash_pos + 1));
-    return InternalStringToNetmaskLength(suffix.c_str(),
-                                         out->first.address_family(),
-                                         &out->second);
+    return InternalStringToNetmaskLength(
+        suffix.c_str(), out->first.address_family(), &out->second);
   }
 
   // There was no slash, so the range covers a single address.
@@ -992,8 +967,7 @@ IPAddress TruncateIPAndLength(const IPAddress& addr, int* length_io) {
         return addr;
       }
       CHECK_GE(length, 0);
-      if (length == 0)
-        return IPAddress::Any4();
+      if (length == 0) return IPAddress::Any4();
       uint32 ip4 = IPAddressToHostUInt32(addr);
       ip4 &= ~0U << (32 - length);
       return HostUInt32ToIPAddress(ip4);
@@ -1004,8 +978,7 @@ IPAddress TruncateIPAndLength(const IPAddress& addr, int* length_io) {
         return addr;
       }
       CHECK_GE(length, 0);
-      if (length == 0)
-        return IPAddress::Any6();
+      if (length == 0) return IPAddress::Any6();
       absl::uint128 ip6 = IPAddressToUInt128(addr);
       ip6 &= ~absl::uint128(0) << (128 - length);
       return UInt128ToIPAddress(ip6);
@@ -1033,8 +1006,7 @@ const uint8 kPackedIPRangeIPv4LengthOffset = 200;
 }  // namespace
 
 std::string IPRange::ToPackedString() const {
-  CHECK(host_.address_family() == AF_INET ||
-        host_.address_family() == AF_INET6)
+  CHECK(host_.address_family() == AF_INET || host_.address_family() == AF_INET6)
       << "Uninitialized address in IPRange.";
   // Get the host part, with unwanted suffix bits zeroed.
   const std::string packed_host = host_.ToPackedString();
@@ -1057,7 +1029,7 @@ std::string IPRange::ToPackedString() const {
   return out;
 }
 
-bool PackedStringToIPRange(const std::string& str, IPRange *out) {
+bool PackedStringToIPRange(const std::string& str, IPRange* out) {
   if (str.empty()) {
     return false;
   }
@@ -1091,8 +1063,8 @@ bool PackedStringToIPRange(const std::string& str, IPRange *out) {
 
   // Drop the address into a zero-padded buffer, and convert to IPAddress.
   std::string packed_host(sizeof_addr, '\0');
-  packed_host.replace(0, available_host_bytes,
-                      str.data() + 1, available_host_bytes);
+  packed_host.replace(0, available_host_bytes, str.data() + 1,
+                      available_host_bytes);
   const IPAddress host = PackedStringToIPAddressOrDie(packed_host);
 
   // Verify that the input has no bits set beyond the prefix length.
@@ -1118,7 +1090,7 @@ bool IPAddressIntervalToSubnets(const IPAddress& first_addr,
   }
 
   IPAddressOrdering less;
-  for (IPAddress cur_addr = first_addr; !less(last_addr, cur_addr); ) {
+  for (IPAddress cur_addr = first_addr; !less(last_addr, cur_addr);) {
     // Find the least specific IP subnet of cur_addr whose endpoints are still
     // covered by the interval [cur_addr, last_addr].
     IPRange cur_subnet(cur_addr);
@@ -1163,9 +1135,8 @@ IPAddress NthAddressInRange(const IPRange& range, absl::uint128 index) {
       return UInt128ToIPAddress(addr + index);
     }
     default:
-      LOG(FATAL)
-          << __FUNCTION__ << " of IPRange with invalid address family: "
-          << range.host().address_family();
+      LOG(FATAL) << __FUNCTION__ << " of IPRange with invalid address family: "
+                 << range.host().address_family();
   }
 }
 
@@ -1269,8 +1240,7 @@ bool NetMaskToMaskLength(const IPAddress& address, int* result) {
       uint32 ipv4 = IPAddressToHostUInt32(address);
       length = ipv4 != 0 ? 32 - Bits::FindLSBSetNonZero(ipv4) : 0;
       // Verify this is a valid netmask.
-      if ((~ipv4 & (~ipv4 + 1)) != 0)
-        return false;
+      if ((~ipv4 & (~ipv4 + 1)) != 0) return false;
       break;
     }
 
@@ -1278,8 +1248,7 @@ bool NetMaskToMaskLength(const IPAddress& address, int* result) {
       absl::uint128 ipv6 = IPAddressToUInt128(address);
       length = ipv6 != 0 ? 128 - Bits::FindLSBSetNonZero128(ipv6) : 0;
       // Verify this is a valid netmask.
-      if ((~ipv6 & (~ipv6 + 1)) != 0)
-        return false;
+      if ((~ipv6 & (~ipv6 + 1)) != 0) return false;
       break;
     }
 
@@ -1287,33 +1256,28 @@ bool NetMaskToMaskLength(const IPAddress& address, int* result) {
       return false;
   }
 
-  if (result)
-    *result = length;
+  if (result) *result = length;
   return true;
 }
 
 bool MaskLengthToIPAddress(int family, int length, IPAddress* address) {
   switch (family) {
     case AF_INET: {
-      if (length < 0 || length > 32)
-        return false;
+      if (length < 0 || length > 32) return false;
 
       // <<32 on an uint32 is undefined, LL is important.
       uint32 mask = 0xffffffffLL << (32 - length);
-      if (address)
-        *address = HostUInt32ToIPAddress(mask);
+      if (address) *address = HostUInt32ToIPAddress(mask);
       return true;
     }
 
     case AF_INET6: {
-      if (length < 0 || length > 128)
-        return false;
+      if (length < 0 || length > 128) return false;
 
       // uint28 << 128 is undefined, so case on length.
       absl::uint128 mask =
-                  length == 0 ? 0 : absl::kuint128max << (128 - length);
-      if (address)
-        *address = UInt128ToIPAddress(mask);
+          length == 0 ? 0 : absl::kuint128max << (128 - length);
+      if (address) *address = UInt128ToIPAddress(mask);
       return true;
     }
   }

--- a/stratum/glue/net_util/ipaddress.h
+++ b/stratum/glue/net_util/ipaddress.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Various classes for storing Internet addresses:
 //
 //  * IPAddress:      An IPv4 or IPv6 address. Fundamentally represents a host
@@ -31,11 +30,12 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/socket.h>
+
 #include <ostream>
 #include <string>
 #include <unordered_map>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/base/port.h"
 #include "absl/numeric/int128.h"
@@ -80,18 +80,15 @@ class IPAddress {
   // serialization, of IsAnyIPAddress() and friends.
   //
   // Also see the default constructor for SocketAddress, below.
-  IPAddress() : address_family_(AF_UNSPEC) {
-  }
+  IPAddress() : address_family_(AF_UNSPEC) {}
 
   // Constructors from standard BSD socket address structures.
   // For conversions from uint32 (for legacy Google3 code) and from strings,
   // see under "Free utility functions", below.
-  explicit IPAddress(const in_addr& addr)
-      : address_family_(AF_INET) {
+  explicit IPAddress(const in_addr& addr) : address_family_(AF_INET) {
     addr_.addr4 = addr;
   }
-  explicit IPAddress(const in6_addr& addr)
-      : address_family_(AF_INET6) {
+  explicit IPAddress(const in6_addr& addr) : address_family_(AF_INET6) {
     addr_.addr6 = addr;
   }
 
@@ -100,9 +97,7 @@ class IPAddress {
   // recent (>= 4.1) gcc is just as fast as using an output parameter.
 
   // The address family; either AF_UNSPEC, AF_INET or AF_INET6.
-  int address_family() const {
-    return address_family_;
-  }
+  int address_family() const { return address_family_; }
 
   // The address as an in_addr structure; CHECK-fails if address_family() is
   // not AF_INET (ie. the held address is not an IPv4 address).
@@ -130,7 +125,7 @@ class IPAddress {
   // Returns the same as ToString().
   // <buffer> must have room for at least INET6_ADDRSTRLEN bytes,
   // including the final NUL.
-  void ToCharBuf(char *buffer) const;
+  void ToCharBuf(char* buffer) const;
 
   // Returns the address as a sequence of bytes in network-byte-order.
   // This is suitable for writing onto the wire or into a protocol buffer
@@ -150,9 +145,7 @@ class IPAddress {
   // are defined. For using IPAddress elements as keys in STL containers,
   // see IPAddressOrdering, below.
   bool operator==(const IPAddress& other) const;
-  bool operator!=(const IPAddress& other) const {
-    return !(*this == other);
-  }
+  bool operator!=(const IPAddress& other) const { return !(*this == other); }
 
   // POD type, so no DISALLOW_COPY_AND_ASSIGN:
   // IPAddress(const IPAddress&) = default;
@@ -162,19 +155,19 @@ class IPAddress {
   friend H AbslHashValue(H h, const IPAddress& a) {
     auto state = H::combine(std::move(h), a.address_family_);
     switch (a.address_family_) {
-    case AF_INET:
-      return H::combine(std::move(state), a.addr_.addr4.s_addr);
-    case AF_INET6:
-      state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[0]);
-      state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[1]);
-      state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[2]);
-      state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[3]);
-      return state;
-    case AF_UNSPEC:
-      // Additional hash input to differentiate AF_UNSPEC from IPAddress::Any4
-      return H::combine(std::move(state), "AF_UNSPEC");
-    default:
-      LOG(FATAL) << "Unknown address family " << a.address_family_;
+      case AF_INET:
+        return H::combine(std::move(state), a.addr_.addr4.s_addr);
+      case AF_INET6:
+        state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[0]);
+        state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[1]);
+        state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[2]);
+        state = H::combine(std::move(state), a.addr_.addr6.s6_addr32[3]);
+        return state;
+      case AF_UNSPEC:
+        // Additional hash input to differentiate AF_UNSPEC from IPAddress::Any4
+        return H::combine(std::move(state), "AF_UNSPEC");
+      default:
+        LOG(FATAL) << "Unknown address family " << a.address_family_;
     }
   }
 
@@ -210,14 +203,11 @@ class SocketAddress {
   //
   // Note that you can also arrive at the empty state by construction
   // from a struct sockaddr, below.
-  SocketAddress()
-      : port_(0) {
-  }
+  SocketAddress() : port_(0) {}
 
   // Constructor with IP address and port (in host byte order).
   SocketAddress(const IPAddress& host, uint16 port)
-      : host_(host), port_(port) {
-  }
+      : host_(host), port_(port) {}
 
   // Constructors from standard BSD socket address structures.
   explicit SocketAddress(const struct sockaddr_in& sin)
@@ -245,9 +235,7 @@ class SocketAddress {
   // recent (>= 4.1) gcc is just as fast as using an output parameter.
 
   // The individual parts of the socket address.
-  IPAddress host() const {
-    return host_;
-  }
+  IPAddress host() const { return host_; }
 
   // Port in host byte order.
   uint16 port() const {
@@ -359,7 +347,7 @@ IPAddress TruncateIPAndLength(const IPAddress& addr, int* length_io);
 // with a suitable ToString() method).  See also //strings/join.h.
 // TODO(unknown): Replace with calls to something better in //strings:join, once
 // something better is available.
-template<typename T>
+template <typename T>
 struct ToStringJoinFormatter {
   void operator()(std::string* out, const T& t) const {
     out->append(t.ToString());
@@ -383,8 +371,7 @@ class IPRange {
   //
   // In particular, no guarantees are made about the behavior of the
   // of string conversions and serialization, or any other accessors.
-  IPRange() : length_(-1) {
-  }
+  IPRange() : length_(-1) {}
 
   // Constructs an IPRange from an address and a length. Properly zeroes out
   // bits and adjusts length as required, but CHECK-fails on negative lengths
@@ -403,8 +390,7 @@ class IPRange {
   //
   IPRange(const IPAddress& host, int length)
       : host_(net_util_internal::TruncateIPAndLength(host, &length)),
-        length_(length) {
-  }
+        length_(length) {}
 
   // Unsafe constructor from a host and prefix length.
   //
@@ -425,8 +411,7 @@ class IPRange {
 
   // Construct an IPRange from just an IPAddress, applying the
   // address-family-specific maximum netmask length.
-  explicit IPRange(const IPAddress& host)
-      : host_(host) {
+  explicit IPRange(const IPAddress& host) : host_(host) {
     switch (host.address_family()) {
       case AF_INET:
         length_ = 32;
@@ -448,12 +433,8 @@ class IPRange {
   // recent (>= 4.1) gcc is just as fast as using an output parameter.
 
   // The individual parts of the subnet.
-  IPAddress host() const {
-    return host_;
-  }
-  int length() const {
-    return length_;
-  }
+  IPAddress host() const { return host_; }
+  int length() const { return length_; }
 
   // The bounding IPAddresses in this IPRange.  The "network address"
   // is the "all zeroes" address, or lower bound.  The "broadcast address"
@@ -527,8 +508,7 @@ class IPRange {
       : host_(host), length_(length) {
     DCHECK_EQ(host_, net_util_internal::TruncateIPAndLength(host, &length))
         << "Host has bits set beyond the prefix length.";
-    DCHECK_EQ(length_, length)
-        << "Length is inconsistent with address family.";
+    DCHECK_EQ(length_, length) << "Length is inconsistent with address family.";
   }
 
   IPAddress host_;
@@ -568,7 +548,7 @@ inline IPAddress HostUInt32ToIPAddress(uint32 address) {
 //   IPAddressToHostUInt32(addr);  // Yields 0x01020304
 //
 // Will CHECK-fail if addr does not contain an IPv4 address.
-inline uint32 IPAddressToHostUInt32(const IPAddress &addr) {
+inline uint32 IPAddressToHostUInt32(const IPAddress& addr) {
   return ntohl(addr.ipv4_address().s_addr);
 }
 
@@ -673,9 +653,9 @@ bool PTRStringToIPAddress(const std::string& ptr_address,
 
 // Specific JoinFormatters for IPAddress, SocketAddress, and IPRange.
 typedef net_util_internal::ToStringJoinFormatter<IPAddress>
-        IPAddressJoinFormatter;
+    IPAddressJoinFormatter;
 typedef net_util_internal::ToStringJoinFormatter<SocketAddress>
-        SocketAddressJoinFormatter;
+    SocketAddressJoinFormatter;
 typedef net_util_internal::ToStringJoinFormatter<IPRange> IPRangeJoinFormatter;
 
 // Boolean convenience checks.
@@ -698,7 +678,7 @@ bool IsLoopbackIPAddress(const IPAddress& ip);
 IPAddress ChooseRandomAddress(const hostent* hp);
 
 // Choose a random IPAddress from vector of same.
-IPAddress ChooseRandomIPAddress(const std::vector<IPAddress> *ipvec);
+IPAddress ChooseRandomIPAddress(const std::vector<IPAddress>* ipvec);
 
 // Returns whether the address is initialized or not.
 inline bool IsInitializedAddress(const IPAddress& addr) {
@@ -709,16 +689,15 @@ inline bool IsInitializedAddress(const IPAddress& addr) {
 // IPAddress object.  A debug-fatal error is logged if the address family
 // is not of the Internet variety, i.e. not one of set(AF_INET, AF_INET6);
 // the caller is responsible for verifying IsInitializedAddress(ip).
-inline int IPAddressLength(const IPAddress &ip) {
+inline int IPAddressLength(const IPAddress& ip) {
   switch (ip.address_family()) {
     case AF_INET:
       return 32;
     case AF_INET6:
       return 128;
     default:
-      LOG(DFATAL)
-          << "IPAddressLength() of object with invalid address family: "
-          << ip.address_family();
+      LOG(DFATAL) << "IPAddressLength() of object with invalid address family: "
+                  << ip.address_family();
       return -1;
   }
 }
@@ -731,7 +710,7 @@ inline int IPAddressLength(const IPAddress &ip) {
 // addresses. Internally, the addresses are ordered lexically by
 // network byte order (so they go 0.0.0.0, 0.0.0.1, 0.0.0.2, etc.).
 struct IPAddressOrdering {
-  bool operator() (const IPAddress& lhs, const IPAddress& rhs) const;
+  bool operator()(const IPAddress& lhs, const IPAddress& rhs) const;
 };
 
 // A functor for using SocketAddress objects as members of a set<>, map<>, etc..
@@ -740,7 +719,7 @@ struct IPAddressOrdering {
 // The ordering defined by this functor is:
 // First the IPAddress, then the port number.
 struct SocketAddressOrdering {
-  bool operator() (const SocketAddress& lhs, const SocketAddress& rhs) const;
+  bool operator()(const SocketAddress& lhs, const SocketAddress& rhs) const;
 };
 
 // A functor for using IPRange objects as members of a set<>, map<>, etc..
@@ -750,7 +729,7 @@ struct SocketAddressOrdering {
 // First the network address (as defined by IPAddressOrdering),
 // then the prefix length.
 struct IPRangeOrdering {
-  bool operator() (const IPRange& lhs, const IPRange& rhs) const;
+  bool operator()(const IPRange& lhs, const IPRange& rhs) const;
 };
 
 // IPv6-specific functions for different classes of addresses. These
@@ -818,7 +797,7 @@ bool GetTeredoInfo(const IPAddress& ip6, IPAddress* server, uint16* flags,
 // false otherwise.  Due to the spoof-ability of these addresses on the
 // wire this should NEVER be used in a security context (e.g. to evaluate
 // or elevate privileges).  ISATAP addresses are explicitly excluded.
-bool GetEmbeddedIPv4ClientAddress(const IPAddress& ip6, IPAddress *ip4);
+bool GetEmbeddedIPv4ClientAddress(const IPAddress& ip6, IPAddress* ip4);
 
 inline IPAddress GetCoercedIPv4Address(const IPAddress& ip6) {
   // Do NOT implement this in depot3.
@@ -895,9 +874,9 @@ bool StringToSocketAddressWithDefaultPort(
 // Normalizes the host part of an IPv6 SocketAddress.  All other values are left
 // unchanged.  See NormalizeIPAddress for more information.
 inline SocketAddress NormalizeSocketAddress(const SocketAddress& addr) {
-  return addr.host().address_family() == AF_INET6 ?
-      SocketAddress(NormalizeIPAddress(addr.host()), addr.port()) :
-      addr;
+  return addr.host().address_family() == AF_INET6
+             ? SocketAddress(NormalizeIPAddress(addr.host()), addr.port())
+             : addr;
 }
 
 // Normalize and construct a SocketAddress from a sockaddr_* in one step.
@@ -1074,7 +1053,7 @@ inline bool IsWithinSubnet(const IPRange& haystack, const IPAddress& needle) {
 // within an IPv6 range, and vice versa.
 inline bool IsProperSubRange(const IPRange& haystack, const IPRange& needle) {
   return haystack.length() < needle.length() &&
-      IsWithinSubnet(haystack, needle.host());
+         IsWithinSubnet(haystack, needle.host());
 }
 
 // Returns true if and only if the IP range is initialized and valid, i.e. its
@@ -1088,7 +1067,7 @@ inline bool IsValidRange(const IPRange& range) {
   // memory corruption, or improper use of UnsafeConstruct().
   const int max_len = IPAddressLength(range.host());
   return 0 <= range.length() && range.length() <= max_len &&
-      range == IPRange(range.host(), range.length());
+         range == IPRange(range.host(), range.length());
 }
 
 // Computes the non-overlapping adjacent IP subnet ranges that cover the IP
@@ -1182,8 +1161,7 @@ bool IPAddressPlusN(const IPAddress& addr, int n,
 //               b7  b6  b5  b4  b3 ~b2  --  -- /6
 //               b7  b6  b5  b4 ~b3  --  --  -- /5
 //
-bool SubtractIPRange(const IPRange& range,
-                     const IPRange& sub_range,
+bool SubtractIPRange(const IPRange& range, const IPRange& sub_range,
                      std::vector<IPRange>* diff_range);
 
 // Returns a human-readable representaion of the address family.

--- a/stratum/glue/net_util/ipaddress_test.cc
+++ b/stratum/glue/net_util/ipaddress_test.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Tests for IPAddress and SocketAddress classes.
 
 #include "stratum/glue/net_util/ipaddress.h"
@@ -32,9 +31,9 @@ using absl::kuint128max;
 
 namespace stratum {
 
-#define ARRAYSIZE(a) \
+#define ARRAYSIZE(a)            \
   ((sizeof(a) / sizeof(*(a))) / \
-    static_cast<size_t>(!(sizeof(a) % sizeof(*(a)))))
+   static_cast<size_t>(!(sizeof(a) % sizeof(*(a))))) // NOLINT
 
 #define HAVE_SCOPEDMOCKLOG 0
 #define HAVE_FIXEDARRAY 0
@@ -107,17 +106,17 @@ TEST(IPAddressTest, UnsafeIPv4Strings) {
   // considered unsafe.  We explicitly do not support them
   // (thankfully inet_pton(3) is significantly more sane).
   const char* kUnsafeIPv4Strings[] = {
-    "016.016.016.016",      // 14.14.14.14
-    "016.016.016",          // 14.14.0.14
-    "016.016",              // 14.0.0.14
-    "016",                  // 0.0.0.14
-    "0x0a.0x0a.0x0a.0x0a",  // 10.10.10.10
-    "0x0a.0x0a.0x0a",       // 10.10.0.10
-    "0x0a.0x0a",            // 10.0.0.10
-    "0x0a",                 // 0.0.0.10
-    "42.42.42",             // 42.42.0.42
-    "42.42",                // 42.0.0.42
-    "42",                   // 0.0.0.42
+      "016.016.016.016",      // 14.14.14.14
+      "016.016.016",          // 14.14.0.14
+      "016.016",              // 14.0.0.14
+      "016",                  // 0.0.0.14
+      "0x0a.0x0a.0x0a.0x0a",  // 10.10.10.10
+      "0x0a.0x0a.0x0a",       // 10.10.0.10
+      "0x0a.0x0a",            // 10.0.0.10
+      "0x0a",                 // 0.0.0.10
+      "42.42.42",             // 42.42.0.42
+      "42.42",                // 42.0.0.42
+      "42",                   // 0.0.0.42
   };
 
   IPAddress ip;
@@ -451,11 +450,8 @@ void TestChooseRandomAddress4(int N) {
 
 TEST(IPAddressTest, Joining) {
   std::vector<IPAddress> v = {
-      StringToIPAddressOrDie("192.0.2.0"),
-      StringToIPAddressOrDie("2001:db8::"),
-      StringToIPAddressOrDie("0.0.0.0"),
-      StringToIPAddressOrDie("::")
-  };
+      StringToIPAddressOrDie("192.0.2.0"), StringToIPAddressOrDie("2001:db8::"),
+      StringToIPAddressOrDie("0.0.0.0"), StringToIPAddressOrDie("::")};
   EXPECT_EQ("192.0.2.0!!!2001:db8::!!!0.0.0.0!!!::",
             std::strings::Join(v, "!!!", IPAddressJoinFormatter()));
 }
@@ -470,9 +466,9 @@ void TestChooseRandomAddress6(int N) {
   for (int i = 0; i < N; i++) {
     ptrs[i] = reinterpret_cast<char*>(&ips[i]);
     ips[i].s6_addr32[0] = i;
-    ips[i].s6_addr32[1] = i*2;
-    ips[i].s6_addr32[2] = i*3;
-    ips[i].s6_addr32[3] = i*4;
+    ips[i].s6_addr32[1] = i * 2;
+    ips[i].s6_addr32[2] = i * 3;
+    ips[i].s6_addr32[3] = i * 4;
     count[i] = 0;
   }
   struct hostent host;
@@ -504,9 +500,9 @@ void TestChooseRandomIPAddress(int N) {
   for (int i = 0; i < N; i++) {
     in6_addr ip6;
     ip6.s6_addr32[0] = i;
-    ip6.s6_addr32[1] = i*2;
-    ip6.s6_addr32[2] = i*3;
-    ip6.s6_addr32[3] = i*4;
+    ip6.s6_addr32[1] = i * 2;
+    ip6.s6_addr32[2] = i * 3;
+    ip6.s6_addr32[3] = i * 4;
 
     ipvec.push_back(IPAddress(ip6));
     count[i] = 0;
@@ -745,8 +741,7 @@ TEST(IPAddressTest, Get6to4IPv6Range) {
     const int len6 = len4 + 16;
     EXPECT_TRUE(Get6to4IPv6Range(IPRange(addr4, len4), &iprange6));
     EXPECT_EQ(IPRange(addr6, len6), iprange6);
-    EXPECT_EQ(TruncateIPAddress(addr6, len6),
-              NthAddressInRange(iprange6, 0));
+    EXPECT_EQ(TruncateIPAddress(addr6, len6), NthAddressInRange(iprange6, 0));
     // Make sure reverse direction also works.
     IPAddress compare4;
     EXPECT_TRUE(Get6to4IPv4Address(NthAddressInRange(iprange6, 0), &compare4));
@@ -759,10 +754,10 @@ TEST(IPAddressTest, GetIsatapIPv4Address) {
   const std::string kBadIsatapAddress = "2001:db8::0040:5efe:cf8e:83ca";
   const std::string kTeredoAddress = "2001:0:102:203:200:5efe:506:708";
   const char* kIsatapAddresses[] = {
-    "2001:db8::5efe:cf8e:83ca",
-    "2001:db8::100:5efe:cf8e:83ca",  // Private Multicast? Not likely.
-    "2001:db8::200:5efe:cf8e:83ca",
-    "2001:db8::300:5efe:cf8e:83ca"   // Public Multicast? Also unlikely.
+      "2001:db8::5efe:cf8e:83ca",
+      "2001:db8::100:5efe:cf8e:83ca",  // Private Multicast? Not likely.
+      "2001:db8::200:5efe:cf8e:83ca",
+      "2001:db8::300:5efe:cf8e:83ca"  // Public Multicast? Also unlikely.
   };
   IPAddress addr4, addr6, compare4;
 
@@ -950,8 +945,8 @@ TEST(IPAddressTest, DISABLED_GetCoercedIPv4Address_Hashed_GeneralProperties) {
                                   coerced.ToString().c_str()));
 
     // Make sure it's in the multicast + 240reserved space.
-    uint32 high_byte = ((ntohl(coerced.ipv4_address().s_addr) >> 24)
-                        & 0x000000ff);
+    uint32 high_byte =
+        ((ntohl(coerced.ipv4_address().s_addr) >> 24) & 0x000000ff);
     EXPECT_GE(high_byte, 224u);
 
     // Make sure it's not all 1's.
@@ -1050,18 +1045,30 @@ TEST(IPAddressTest, PTRStringToIPAddress) {
   EXPECT_FALSE(PTRStringToIPAddress(" 1.0.0.127.in-addr.arpa", &ip));
   EXPECT_FALSE(PTRStringToIPAddress("+1.0.0.127.in-addr.arpa", &ip));
   EXPECT_FALSE(PTRStringToIPAddress("1.0.0.127.ip6.arpa", &ip));
-  EXPECT_FALSE(PTRStringToIPAddress("1.1.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
-                                    "1.0.0.4.0.6.8.4.1.0.0.ip6.arpa.", &ip));
-  EXPECT_FALSE(PTRStringToIPAddress("1..0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
-                                    "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa", &ip));
-  EXPECT_FALSE(PTRStringToIPAddress("1.10.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
-                                    "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa", &ip));
-  EXPECT_FALSE(PTRStringToIPAddress("1.0.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
-                                    "1.0.0.4.0.6.8.4.1...0.2.ip6.arpa", &ip));
-  EXPECT_FALSE(PTRStringToIPAddress("1.G.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
-                                    "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa", &ip));
-  EXPECT_FALSE(PTRStringToIPAddress("1.g.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
-                                    "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa", &ip));
+  EXPECT_FALSE(
+      PTRStringToIPAddress("1.1.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
+                           "1.0.0.4.0.6.8.4.1.0.0.ip6.arpa.",
+                           &ip));
+  EXPECT_FALSE(
+      PTRStringToIPAddress("1..0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
+                           "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa",
+                           &ip));
+  EXPECT_FALSE(
+      PTRStringToIPAddress("1.10.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
+                           "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa",
+                           &ip));
+  EXPECT_FALSE(
+      PTRStringToIPAddress("1.0.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
+                           "1.0.0.4.0.6.8.4.1...0.2.ip6.arpa",
+                           &ip));
+  EXPECT_FALSE(
+      PTRStringToIPAddress("1.G.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
+                           "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa",
+                           &ip));
+  EXPECT_FALSE(
+      PTRStringToIPAddress("1.g.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0."
+                           "1.0.0.4.0.6.8.4.1.0.0.2.ip6.arpa",
+                           &ip));
 }
 
 TEST(IPAddressDeathTest, IPAddressLength) {
@@ -1154,15 +1161,15 @@ TEST(IPAddressDeathTest, InvalidPackedStringConversion) {
 
 TEST(ColonlessHexToIPv6AddressTest, BogusInput) {
   const char* bogus[] = {
-    // NULL,
-    "",
-    "bogus",
-    "deadbeef",
-    "fe80000000000000000573fffea000650",  // too long by one characer
-    "fe80000000000000000573fffea0006",  // too short by one characer
-    "fe80000000000000000573fffea0006x",  // not all hex
-    "+e80000000000000000573fffea00065",  // not all hex
-    "0x80000000000000000573fffea00065",  // not all hex
+      // NULL,
+      "",
+      "bogus",
+      "deadbeef",
+      "fe80000000000000000573fffea000650",  // too long by one characer
+      "fe80000000000000000573fffea0006",    // too short by one characer
+      "fe80000000000000000573fffea0006x",   // not all hex
+      "+e80000000000000000573fffea00065",   // not all hex
+      "0x80000000000000000573fffea00065",   // not all hex
   };
 
   IPAddress dummy;
@@ -1730,7 +1737,7 @@ TEST(SocketAddressTest, SocketAddressOrdering) {
   EXPECT_EQ(6u, sock_addrs.size());
 
   std::vector<SocketAddress> sorted_sock_addrs(sock_addrs.begin(),
-                                                sock_addrs.end());
+                                               sock_addrs.end());
   ASSERT_EQ(6u, sorted_sock_addrs.size());
   EXPECT_EQ(sock_addr0, sorted_sock_addrs[0]);
   EXPECT_EQ(sock_addr3, sorted_sock_addrs[1]);
@@ -1864,8 +1871,7 @@ TEST(SocketAddressTest, IsInitializedSocketAddress) {
 
 TEST(SocketAddressDeathTest, UninitializedGenericAddress) {
   SocketAddress empty;
-  EXPECT_DEATH(empty.generic_address(),
-               "uninitialized SocketAddress");
+  EXPECT_DEATH(empty.generic_address(), "uninitialized SocketAddress");
 }
 
 TEST(SocketAddressDeathTest, EmergencyZeroPort) {
@@ -2012,8 +2018,8 @@ TEST(IPRangeTest, DottedQuadNetmasks) {
   IPRange cidr;
   IPRange dotted_quad;
   ASSERT_TRUE(StringToIPRangeAndTruncate(kSubnetString, &cidr));
-  ASSERT_TRUE(StringToIPRangeAndTruncate(kDottedQuadSubnetString,
-                                         &dotted_quad));
+  ASSERT_TRUE(
+      StringToIPRangeAndTruncate(kDottedQuadSubnetString, &dotted_quad));
   ASSERT_TRUE(cidr == dotted_quad);
 
   // Check some corner cases.
@@ -2032,12 +2038,12 @@ TEST(IPRangeTest, DottedQuadNetmasks) {
     std::string expected_host_string;
     int expected_length;
   } dotted_quad_tests[] = {
-    { "1.2.3.4/0.0.0.1", "", -1 },
-    { "1.2.3.4/1.0.0.0", "", -1 },
-    { "1.2.3.4/127.255.255.255", "", -1 },
-    { "1.2.3.4/254.255.255.255", "", -1 },
-    { "1.2.3.4/255.255.255.254", "1.2.3.4", 31 },
-    { "1.2.3.4/0.0.0.0", "0.0.0.0", 0 },
+      {"1.2.3.4/0.0.0.1", "", -1},
+      {"1.2.3.4/1.0.0.0", "", -1},
+      {"1.2.3.4/127.255.255.255", "", -1},
+      {"1.2.3.4/254.255.255.255", "", -1},
+      {"1.2.3.4/255.255.255.254", "1.2.3.4", 31},
+      {"1.2.3.4/0.0.0.0", "0.0.0.0", 0},
   };
 
   for (size_t i = 0; i < ARRAYSIZE(dotted_quad_tests); ++i) {
@@ -2052,11 +2058,10 @@ TEST(IPRangeTest, DottedQuadNetmasks) {
     }
     ASSERT_TRUE(StringToIPRangeAndTruncate(
         dotted_quad_tests[i].dotted_quad_string, &range));
-    ASSERT_TRUE(StringToIPAddress(dotted_quad_tests[i].expected_host_string,
-                                  &host));
-    EXPECT_EQ(host, range.host())
-        << dotted_quad_tests[i].dotted_quad_string
-        << " host equality expectation failed";
+    ASSERT_TRUE(
+        StringToIPAddress(dotted_quad_tests[i].expected_host_string, &host));
+    EXPECT_EQ(host, range.host()) << dotted_quad_tests[i].dotted_quad_string
+                                  << " host equality expectation failed";
     EXPECT_EQ(dotted_quad_tests[i].expected_length, range.length())
         << dotted_quad_tests[i].dotted_quad_string
         << " length equality expectation failed";
@@ -2284,8 +2289,8 @@ TEST(IPRangeTest, LowerAndUpper6) {
   ASSERT_TRUE(StringToIPAddress("::", &expected));
   EXPECT_EQ(expected, range.host());
   EXPECT_EQ(expected, range.network_address());
-  ASSERT_TRUE(StringToIPAddress("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-                                &expected));
+  ASSERT_TRUE(
+      StringToIPAddress("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", &expected));
   EXPECT_EQ(expected, range.broadcast_address());
 
   // 1:2:3:4:5:6:7:8/113
@@ -2419,19 +2424,15 @@ TEST(IPRangeTest, Truncation) {
   {
     IPAddress addr;
     ASSERT_TRUE(StringToIPAddress("129.240.2.3", &addr));
-    EXPECT_EQ("0.0.0.0/0",
-              TruncatedAddressToIPRange(addr, 0).ToString());
-    EXPECT_EQ("129.192.0.0/10",
-              TruncatedAddressToIPRange(addr, 10).ToString());
-    EXPECT_EQ("129.240.2.3/32",
-              TruncatedAddressToIPRange(addr, 32).ToString());
+    EXPECT_EQ("0.0.0.0/0", TruncatedAddressToIPRange(addr, 0).ToString());
+    EXPECT_EQ("129.192.0.0/10", TruncatedAddressToIPRange(addr, 10).ToString());
+    EXPECT_EQ("129.240.2.3/32", TruncatedAddressToIPRange(addr, 32).ToString());
   }
 
   {
     IPAddress addr;
     ASSERT_TRUE(StringToIPAddress("8001:700:300:1800::1", &addr));
-    EXPECT_EQ("::/0",
-              TruncatedAddressToIPRange(addr, 0).ToString());
+    EXPECT_EQ("::/0", TruncatedAddressToIPRange(addr, 0).ToString());
     EXPECT_EQ("8001:700:300::/48",
               TruncatedAddressToIPRange(addr, 48).ToString());
     EXPECT_EQ("8001:700:300:1800::1/128",
@@ -2440,20 +2441,15 @@ TEST(IPRangeTest, Truncation) {
 
   {
     IPAddress addr;
-    ASSERT_TRUE(StringToIPAddress("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-                                  &addr));
-    EXPECT_EQ("::/0",
-              TruncatedAddressToIPRange(addr, 0).ToString());
-    EXPECT_EQ("8000::/1",
-              TruncatedAddressToIPRange(addr, 1).ToString());
+    ASSERT_TRUE(
+        StringToIPAddress("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", &addr));
+    EXPECT_EQ("::/0", TruncatedAddressToIPRange(addr, 0).ToString());
+    EXPECT_EQ("8000::/1", TruncatedAddressToIPRange(addr, 1).ToString());
 
-    EXPECT_EQ("ffff:fffe::/31",
-              TruncatedAddressToIPRange(addr, 31).ToString());
-    EXPECT_EQ("ffff:ffff::/32",
-              TruncatedAddressToIPRange(addr, 32).ToString());
+    EXPECT_EQ("ffff:fffe::/31", TruncatedAddressToIPRange(addr, 31).ToString());
+    EXPECT_EQ("ffff:ffff::/32", TruncatedAddressToIPRange(addr, 32).ToString());
     EXPECT_EQ("ffff:ffff:8000::/33",
               TruncatedAddressToIPRange(addr, 33).ToString());
-
 
     EXPECT_EQ("ffff:ffff:ffff:fffe::/63",
               TruncatedAddressToIPRange(addr, 63).ToString());
@@ -2562,8 +2558,7 @@ TEST(IPRangeTest, PacksIPv4AndIPv6Range) {
     int max_subnet_length = (ip.address_family() == AF_INET ? 32 : 128);
     std::string packed;
     IPRange unpacked;
-    for (int subnet_length = 0;
-         subnet_length <= max_subnet_length;
+    for (int subnet_length = 0; subnet_length <= max_subnet_length;
          ++subnet_length) {
       const IPRange truncated = TruncatedAddressToIPRange(ip, subnet_length);
       packed = truncated.ToPackedString();
@@ -2582,8 +2577,8 @@ TEST(IPRangeTest, PacksIPv4AndIPv6Range) {
 
 TEST(IPRangeTest, VerifyPackedStringFormat) {
   std::string ipranges[] = {"0.0.0.0/0", "::/0"};
-  std::string expected_packed[] =
-    {std::string("\xc8", 1), std::string("\x00", 1)};
+  std::string expected_packed[] = {std::string("\xc8", 1),
+                                   std::string("\x00", 1)};
   for (size_t i = 0; i < ARRAYSIZE(ipranges); ++i) {
     IPRange iprange = StringToIPRangeOrDie(ipranges[i]);
     std::string packed;
@@ -2902,25 +2897,9 @@ TEST(IPRangeTest, Hash) {
   IPRange range34(IPAddress::Any6(), 128);
 
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
-      range0,
-      range1,
-      range2,
-      range3,
-      range4,
-      range5,
-      range6,
-      range7,
-      range10,
-      range11,
-      range20,
-      range21,
-      range22,
-      range23,
-      range30,
-      range31,
-      range32,
-      range33,
-      range34,
+      range0,  range1,  range2,  range3,  range4,  range5,  range6,
+      range7,  range10, range11, range20, range21, range22, range23,
+      range30, range31, range32, range33, range34,
   }));
 }
 
@@ -3043,8 +3022,8 @@ TEST(IPRangeTest, IsValidRange) {
 TEST(IPRangeTest, IPAddressIntervalToSubnets_UninitializedIPAddresses) {
   IPAddress first_addr, last_addr;
   std::vector<IPRange> covering_subnets;
-  EXPECT_FALSE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                          &covering_subnets));
+  EXPECT_FALSE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   EXPECT_TRUE(covering_subnets.empty());
 }
 
@@ -3052,8 +3031,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_AddressFamilyMismatch) {
   IPAddress first_addr = StringToIPAddressOrDie("4.1.0.1");
   IPAddress last_addr = StringToIPAddressOrDie("8001:700:300::11");
   std::vector<IPRange> covering_subnets;
-  EXPECT_FALSE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                          &covering_subnets));
+  EXPECT_FALSE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   EXPECT_TRUE(covering_subnets.empty());
 }
 
@@ -3061,8 +3040,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_InvalidInterval) {
   IPAddress first_addr = StringToIPAddressOrDie("4.1.0.1");
   IPAddress last_addr = StringToIPAddressOrDie("4.1.0.0");
   std::vector<IPRange> covering_subnets;
-  EXPECT_FALSE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                          &covering_subnets));
+  EXPECT_FALSE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   EXPECT_TRUE(covering_subnets.empty());
 }
 
@@ -3070,8 +3049,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_SingleAddressInterval) {
   IPAddress first_addr = StringToIPAddressOrDie("4.1.0.1");
   IPAddress last_addr = first_addr;
   std::vector<IPRange> covering_subnets;
-  EXPECT_TRUE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                         &covering_subnets));
+  EXPECT_TRUE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   ASSERT_EQ(1u, covering_subnets.size());
   EXPECT_EQ(IPRange(first_addr), covering_subnets[0]);
 }
@@ -3080,8 +3059,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_MaxIPv4Interval) {
   IPAddress first_addr = StringToIPAddressOrDie("0.0.0.0");
   IPAddress last_addr = StringToIPAddressOrDie("255.255.255.255");
   std::vector<IPRange> covering_subnets;
-  EXPECT_TRUE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                         &covering_subnets));
+  EXPECT_TRUE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   ASSERT_EQ(1u, covering_subnets.size());
   EXPECT_EQ(StringToIPRangeOrDie("0.0.0.0/0"), covering_subnets[0]);
 }
@@ -3091,8 +3070,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_MaxIPv6Interval) {
   IPAddress last_addr =
       StringToIPAddressOrDie("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
   std::vector<IPRange> covering_subnets;
-  EXPECT_TRUE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                         &covering_subnets));
+  EXPECT_TRUE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   ASSERT_EQ(1u, covering_subnets.size());
   EXPECT_EQ(StringToIPRangeOrDie("::0/0"), covering_subnets[0]);
 }
@@ -3102,8 +3081,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_TestIPv4_Case1) {
   IPAddress last_addr = StringToIPAddressOrDie("255.255.255.255");
 
   std::vector<IPRange> covering_subnets;
-  EXPECT_TRUE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                         &covering_subnets));
+  EXPECT_TRUE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   ASSERT_EQ(1u, covering_subnets.size());
   EXPECT_EQ(StringToIPRangeOrDie("255.255.254.0/23"), covering_subnets[0]);
 }
@@ -3122,8 +3101,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_TestIPv4_Case2) {
   expected_covering_subnets.push_back(StringToIPRangeOrDie("6.1.0.0/24"));
 
   std::vector<IPRange> covering_subnets;
-  EXPECT_TRUE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                         &covering_subnets));
+  EXPECT_TRUE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   EXPECT_EQ(expected_covering_subnets, covering_subnets);
 }
 #endif
@@ -3142,8 +3121,8 @@ TEST(IPRangeTest, IPAddressIntervalToSubnets_TestIPv6) {
   expected_covering_subnets.push_back(StringToIPRangeOrDie("2001:2000::/128"));
 
   std::vector<IPRange> covering_subnets;
-  EXPECT_TRUE(IPAddressIntervalToSubnets(first_addr, last_addr,
-                                         &covering_subnets));
+  EXPECT_TRUE(
+      IPAddressIntervalToSubnets(first_addr, last_addr, &covering_subnets));
   EXPECT_EQ(expected_covering_subnets, covering_subnets);
 }
 #endif
@@ -3190,13 +3169,12 @@ TEST(IPRangeTest, NthAddressInRange) {
   EXPECT_EQ("0.0.255.255", NthAddressInRange(range, 0xffff).ToString());
   EXPECT_EQ("255.255.255.255", NthAddressInRange(range, kuint32max).ToString());
 
-  ASSERT_TRUE(StringToIPRange("fedc:ba98:7654:3210:123:4567:89ab:cdef/128",
-                              &range));
+  ASSERT_TRUE(
+      StringToIPRange("fedc:ba98:7654:3210:123:4567:89ab:cdef/128", &range));
   EXPECT_EQ("fedc:ba98:7654:3210:123:4567:89ab:cdef",
             NthAddressInRange(range, 0).ToString());
 
-  ASSERT_TRUE(StringToIPRange("fedc:ba98:7654:3210:123::/80",
-                              &range));
+  ASSERT_TRUE(StringToIPRange("fedc:ba98:7654:3210:123::/80", &range));
   EXPECT_EQ("fedc:ba98:7654:3210:123::f",
             NthAddressInRange(range, 15).ToString());
   EXPECT_EQ("fedc:ba98:7654:3210:123:0:ffff:ffff",
@@ -3220,32 +3198,34 @@ TEST(IPAddress, IndexInRange) {
   EXPECT_EQ(1, IndexInRange(IPRange(StringToIPAddressOrDie("1.1.1.1"), 24),
                             StringToIPAddressOrDie("1.1.1.1")));
 
-  EXPECT_EQ(128, IndexInRange(
-      StringToIPRangeOrDie("2001:718:1001:700:200:5efe:c0a8:0300/120"),
-      StringToIPAddressOrDie("2001:718:1001:700:200:5efe:c0a8:0380")));
-  EXPECT_EQ(286326784, IndexInRange(
-      StringToIPRangeOrDie("2001:718:1001:700:0000:0000:0000:0000/64"),
-      StringToIPAddressOrDie("2001:718:1001:700:0000:0000:1111:0000")));
-  EXPECT_EQ(16, IndexInRange(
-      IPRange(StringToIPAddressOrDie("0:0:0:0:0:0:8:1"), 120),
-      StringToIPAddressOrDie("0:0:0:0:0:0:8:10")));
+  EXPECT_EQ(
+      128, IndexInRange(
+               StringToIPRangeOrDie("2001:718:1001:700:200:5efe:c0a8:0300/120"),
+               StringToIPAddressOrDie("2001:718:1001:700:200:5efe:c0a8:0380")));
+  EXPECT_EQ(
+      286326784,
+      IndexInRange(
+          StringToIPRangeOrDie("2001:718:1001:700:0000:0000:0000:0000/64"),
+          StringToIPAddressOrDie("2001:718:1001:700:0000:0000:1111:0000")));
+  EXPECT_EQ(
+      16, IndexInRange(IPRange(StringToIPAddressOrDie("0:0:0:0:0:0:8:1"), 120),
+                       StringToIPAddressOrDie("0:0:0:0:0:0:8:10")));
 
   EXPECT_DEATH(IndexInRange(StringToIPRangeOrDie("1.1.1.0/24"),
                             StringToIPAddressOrDie("1.1.2.0")),
-                            "is not within");
-  EXPECT_DEATH(IndexInRange(
-      StringToIPRangeOrDie("2001:718:1001:700:200:5efe:c0a8:0300/120"),
-      StringToIPAddressOrDie("3001:718:1001:700:200:5efe:c0a8:0380")),
+               "is not within");
+  EXPECT_DEATH(
+      IndexInRange(
+          StringToIPRangeOrDie("2001:718:1001:700:200:5efe:c0a8:0300/120"),
+          StringToIPAddressOrDie("3001:718:1001:700:200:5efe:c0a8:0380")),
       "is not within");
 
-  EXPECT_DEATH(IndexInRange(
-      StringToIPRangeOrDie("0:0:0:0:0:0:c0a8:0/120"),
-      StringToIPAddressOrDie("192.168.0.10")),
-      "is not within");
-  EXPECT_DEATH(IndexInRange(
-      StringToIPRangeOrDie("192.168.0.0/24"),
-      StringToIPAddressOrDie("0:0:0:0:0:0:c0a8:000a")),
-      "is not within");
+  EXPECT_DEATH(IndexInRange(StringToIPRangeOrDie("0:0:0:0:0:0:c0a8:0/120"),
+                            StringToIPAddressOrDie("192.168.0.10")),
+               "is not within");
+  EXPECT_DEATH(IndexInRange(StringToIPRangeOrDie("192.168.0.0/24"),
+                            StringToIPAddressOrDie("0:0:0:0:0:0:c0a8:000a")),
+               "is not within");
 }
 
 TEST(IPRangeTest, LoggingUninitialized) {
@@ -3267,12 +3247,10 @@ TEST(IPRangeDeathTest, MiscUninitialized) {
 // Invalid conversion in *OrDie() functions.
 TEST(IPRangeDeathTest, InvalidStringConversion) {
   // Invalid conversions.
-  EXPECT_DEATH(StringToIPRangeOrDie("foo/10"),
-               "Invalid IP range foo/10");
+  EXPECT_DEATH(StringToIPRangeOrDie("foo/10"), "Invalid IP range foo/10");
   EXPECT_DEATH(StringToIPRangeOrDie(std::string("128.59.16.20/16")),
                "Invalid IP range");
-  EXPECT_DEATH(StringToIPRangeOrDie("::g/42"),
-               "Invalid IP range ::g/42");
+  EXPECT_DEATH(StringToIPRangeOrDie("::g/42"), "Invalid IP range ::g/42");
   EXPECT_DEATH(StringToIPRangeOrDie("2001:db8:1234::/32"),
                "Invalid IP range 2001:db8:1234::/32");
 
@@ -3316,40 +3294,17 @@ TEST(MaskLengthToIPAddress, InvalidConversions) {
 
 TEST(MaskLengthToIPAddress, IPv4Conversions) {
   const char* kValues[] = {
-    "255.255.255.255",
-    "255.255.255.254",
-    "255.255.255.252",
-    "255.255.255.248",
-    "255.255.255.240",
-    "255.255.255.224",
-    "255.255.255.192",
-    "255.255.255.128",
-    "255.255.255.0",
-    "255.255.254.0",
-    "255.255.252.0",
-    "255.255.248.0",
-    "255.255.240.0",
-    "255.255.224.0",
-    "255.255.192.0",
-    "255.255.128.0",
-    "255.255.0.0",
-    "255.254.0.0",
-    "255.252.0.0",
-    "255.248.0.0",
-    "255.240.0.0",
-    "255.224.0.0",
-    "255.192.0.0",
-    "255.128.0.0",
-    "255.0.0.0",
-    "254.0.0.0",
-    "252.0.0.0",
-    "248.0.0.0",
-    "240.0.0.0",
-    "224.0.0.0",
-    "192.0.0.0",
-    "128.0.0.0",
-    "0.0.0.0"
-  };
+      "255.255.255.255", "255.255.255.254", "255.255.255.252",
+      "255.255.255.248", "255.255.255.240", "255.255.255.224",
+      "255.255.255.192", "255.255.255.128", "255.255.255.0",
+      "255.255.254.0",   "255.255.252.0",   "255.255.248.0",
+      "255.255.240.0",   "255.255.224.0",   "255.255.192.0",
+      "255.255.128.0",   "255.255.0.0",     "255.254.0.0",
+      "255.252.0.0",     "255.248.0.0",     "255.240.0.0",
+      "255.224.0.0",     "255.192.0.0",     "255.128.0.0",
+      "255.0.0.0",       "254.0.0.0",       "252.0.0.0",
+      "248.0.0.0",       "240.0.0.0",       "224.0.0.0",
+      "192.0.0.0",       "128.0.0.0",       "0.0.0.0"};
 
   for (size_t i = 0; i < ABSL_ARRAYSIZE(kValues); ++i) {
     IPAddress mask;
@@ -3363,20 +3318,20 @@ TEST(MaskLengthToIPAddress, IPv6Conversions) {
     int length;
     const std::string expected;
   } kTests[] = {
-    {0, "::"},
-    {1, "8000::"},
-    {15, "fffe::"},
-    {31, "ffff:fffe::"},
-    {47, "ffff:ffff:fffe::"},
-    {59, "ffff:ffff:ffff:ffe0::"},
-    {63, "ffff:ffff:ffff:fffe::"},
-    {64, "ffff:ffff:ffff:ffff::"},
-    {65, "ffff:ffff:ffff:ffff:8000::"},
-    {79, "ffff:ffff:ffff:ffff:fffe::"},
-    {95, "ffff:ffff:ffff:ffff:ffff:fffe::"},
-    {111, "ffff:ffff:ffff:ffff:ffff:ffff:fffe:0"},
-    {127, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"},
-    {128, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+      {0, "::"},
+      {1, "8000::"},
+      {15, "fffe::"},
+      {31, "ffff:fffe::"},
+      {47, "ffff:ffff:fffe::"},
+      {59, "ffff:ffff:ffff:ffe0::"},
+      {63, "ffff:ffff:ffff:fffe::"},
+      {64, "ffff:ffff:ffff:ffff::"},
+      {65, "ffff:ffff:ffff:ffff:8000::"},
+      {79, "ffff:ffff:ffff:ffff:fffe::"},
+      {95, "ffff:ffff:ffff:ffff:ffff:fffe::"},
+      {111, "ffff:ffff:ffff:ffff:ffff:ffff:fffe:0"},
+      {127, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"},
+      {128, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
   };
 
   for (const MaskExpected& test : kTests) {
@@ -3391,19 +3346,19 @@ TEST(NetMaskToMaskLength, Invalid) {
   EXPECT_FALSE(NetMaskToMaskLength(uninitialized, nullptr));
 
   const char* kInvalid[] = {
-    "127.0.0.0",
-    "255.255.0.255",
-    "255.254.255.255",
-    "255.0.0.1",
-    "ffff:ffff:7fff::",
-    "7fff:ffff:ffff::",
-    "ffff:ff7f:ffff::",
-    "ffff:ffff:ffff:7fff::",
-    "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffd",
-    "ffff:ffff:ffff:ffff:ffff:ffff:fffd::",
-    "ffff:ffff:ffff:ffff:ffff:fffd::",
-    "ffff:ffff:ffff:ffff:fffd::",
-    "ffff:ffff:ffff:fffd::",
+      "127.0.0.0",
+      "255.255.0.255",
+      "255.254.255.255",
+      "255.0.0.1",
+      "ffff:ffff:7fff::",
+      "7fff:ffff:ffff::",
+      "ffff:ff7f:ffff::",
+      "ffff:ffff:ffff:7fff::",
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffd",
+      "ffff:ffff:ffff:ffff:ffff:ffff:fffd::",
+      "ffff:ffff:ffff:ffff:ffff:fffd::",
+      "ffff:ffff:ffff:ffff:fffd::",
+      "ffff:ffff:ffff:fffd::",
   };
 
   for (const std::string& mask : kInvalid) {

--- a/stratum/glue/net_util/ipaddress_test.cc
+++ b/stratum/glue/net_util/ipaddress_test.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/base/macros.h"
 #include "absl/container/node_hash_set.h"
 #include "absl/hash/hash_testing.h"
 #include "absl/numeric/int128.h"
@@ -30,10 +31,6 @@
 using absl::kuint128max;
 
 namespace stratum {
-
-#define ARRAYSIZE(a)            \
-  ((sizeof(a) / sizeof(*(a))) / \
-   static_cast<size_t>(!(sizeof(a) % sizeof(*(a))))) // NOLINT
 
 #define HAVE_SCOPEDMOCKLOG 0
 #define HAVE_FIXEDARRAY 0
@@ -120,7 +117,7 @@ TEST(IPAddressTest, UnsafeIPv4Strings) {
   };
 
   IPAddress ip;
-  for (size_t i = 0; i < ARRAYSIZE(kUnsafeIPv4Strings); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(kUnsafeIPv4Strings); ++i) {
     EXPECT_FALSE(StringToIPAddress(kUnsafeIPv4Strings[i], &ip));
   }
 }
@@ -771,7 +768,7 @@ TEST(IPAddressTest, GetIsatapIPv4Address) {
   EXPECT_TRUE(GetTeredoInfo(addr6, NULL, NULL, NULL, NULL));
   EXPECT_FALSE(GetIsatapIPv4Address(addr6, NULL));
 
-  for (size_t i = 0; i < ARRAYSIZE(kIsatapAddresses); i++) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(kIsatapAddresses); i++) {
     ASSERT_TRUE(StringToIPAddress(kIsatapAddresses[i], &addr6));
     EXPECT_TRUE(GetIsatapIPv4Address(addr6, NULL));
     EXPECT_TRUE(GetIsatapIPv4Address(addr6, &compare4));
@@ -1173,7 +1170,7 @@ TEST(ColonlessHexToIPv6AddressTest, BogusInput) {
   };
 
   IPAddress dummy;
-  for (size_t i = 0; i < ARRAYSIZE(bogus); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(bogus); ++i) {
     EXPECT_FALSE(ColonlessHexToIPv6Address(bogus[i], NULL));
     EXPECT_FALSE(ColonlessHexToIPv6Address(bogus[i], &dummy));
   }
@@ -2008,7 +2005,7 @@ TEST(IPRangeTest, DottedQuadNetmasks) {
   };
 
   // Check bogus std::strings.
-  for (size_t i = 0; i < ARRAYSIZE(kBogusDottedQuadStrings); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(kBogusDottedQuadStrings); ++i) {
     const std::string& bogus = kBogusDottedQuadStrings[i];
     EXPECT_FALSE(StringToIPRangeAndTruncate(bogus, NULL))
         << "Apparently '" << bogus << "' is actually valid?";
@@ -2046,7 +2043,7 @@ TEST(IPRangeTest, DottedQuadNetmasks) {
       {"1.2.3.4/0.0.0.0", "0.0.0.0", 0},
   };
 
-  for (size_t i = 0; i < ARRAYSIZE(dotted_quad_tests); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(dotted_quad_tests); ++i) {
     IPRange range;
     IPAddress host;
 
@@ -2553,7 +2550,7 @@ TEST(IPRangeTest, PacksIPv4AndIPv6Range) {
                        "127.0.0.1",
                        "2001:dead:beaf::1",
                        "2001:dead::"};
-  for (size_t i = 0; i < ARRAYSIZE(ips); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(ips); ++i) {
     IPAddress ip = StringToIPAddressOrDie(ips[i]);
     int max_subnet_length = (ip.address_family() == AF_INET ? 32 : 128);
     std::string packed;
@@ -2579,7 +2576,7 @@ TEST(IPRangeTest, VerifyPackedStringFormat) {
   std::string ipranges[] = {"0.0.0.0/0", "::/0"};
   std::string expected_packed[] = {std::string("\xc8", 1),
                                    std::string("\x00", 1)};
-  for (size_t i = 0; i < ARRAYSIZE(ipranges); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(ipranges); ++i) {
     IPRange iprange = StringToIPRangeOrDie(ipranges[i]);
     std::string packed;
     IPRange unpacked;
@@ -2605,7 +2602,7 @@ TEST(IPRangeTest, FailsOnBadHeaderLengths) {
   const IPRange original = TruncatedAddressToIPRange(kIpv6, 52);
   const std::string packed = original.ToPackedString();
   int bad_lengths[] = {129, 199, 233, 255, -1, 256, 1000};
-  for (size_t i = 0; i < ARRAYSIZE(bad_lengths); ++i) {
+  for (size_t i = 0; i < ABSL_ARRAYSIZE(bad_lengths); ++i) {
     IPRange result;
     std::string bad_packed = static_cast<char>(bad_lengths[i]) + packed;
     EXPECT_FALSE(PackedStringToIPRange(bad_packed, &result));

--- a/stratum/glue/net_util/ports.cc
+++ b/stratum/glue/net_util/ports.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/glue/net_util/ports.h"
 
 #include <errno.h>

--- a/stratum/glue/net_util/ports.h
+++ b/stratum/glue/net_util/ports.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_GLUE_NET_UTIL_PORTS_H_
 #define STRATUM_GLUE_NET_UTIL_PORTS_H_
 


### PR DESCRIPTION
Apply formatting tools and replace `ARRAYSIZE` macro with `ABSL_ARRAYSIZE`.