### PR TITLE
Add deflect-on-drop API to Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -58,6 +58,7 @@ BFChassisManager::BFChassisManager(OperationMode mode,
       node_id_to_port_id_to_singleton_port_key_(),
       node_id_to_port_id_to_sdk_port_id_(),
       node_id_to_sdk_port_id_to_port_id_(),
+      node_id_to_deflect_on_drop_config_(),
       xcvr_port_key_to_xcvr_state_(),
       phal_interface_(ABSL_DIE_IF_NULL(phal_interface)),
       bf_sde_interface_(ABSL_DIE_IF_NULL(bf_sde_interface)) {}
@@ -275,6 +276,8 @@ BFChassisManager::~BFChassisManager() = default;
       node_id_to_port_id_to_singleton_port_key;
   std::map<uint64, std::map<uint32, uint32>> node_id_to_port_id_to_sdk_port_id;
   std::map<uint64, std::map<uint32, uint32>> node_id_to_sdk_port_id_to_port_id;
+  std::map<uint64, TofinoConfig::DeflectOnPacketDropConfig>
+      node_id_to_deflect_on_drop_config;
   std::map<PortKey, HwState> xcvr_port_key_to_xcvr_state;
 
   {
@@ -369,6 +372,7 @@ BFChassisManager::~BFChassisManager() = default;
 
   if (config.has_vendor_config() &&
       config.vendor_config().has_tofino_config()) {
+    // Handle port shaping.
     const auto& node_id_to_port_shaping_config =
         config.vendor_config().tofino_config().node_id_to_port_shaping_config();
     for (const auto& key : node_id_to_port_shaping_config) {
@@ -392,6 +396,33 @@ BFChassisManager::~BFChassisManager() = default;
         node_id_to_port_id_to_port_config[node_id][port_id].shaping_config =
             shaping_config;
       }
+    }
+
+    // Handle deflect-on-drop config.
+    const auto& node_id_to_deflect_on_drop_configs =
+        config.vendor_config()
+            .tofino_config()
+            .node_id_to_deflect_on_drop_configs();
+    for (const auto& key : node_id_to_deflect_on_drop_configs) {
+      const uint64 node_id = key.first;
+      const auto& deflect_config = key.second;
+      for (const auto& drop_target : deflect_config.drop_targets()) {
+        const uint32 port_id = drop_target.port();
+        CHECK_RETURN_IF_FALSE(node_id_to_port_id_to_sdk_port_id.count(node_id));
+        CHECK_RETURN_IF_FALSE(node_id_to_unit.count(node_id));
+        int unit = node_id_to_unit[node_id];
+        CHECK_RETURN_IF_FALSE(
+            node_id_to_port_id_to_sdk_port_id[node_id].count(port_id));
+        const uint32 sdk_port_id =
+            node_id_to_port_id_to_sdk_port_id[node_id][port_id];
+        RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(
+            unit, sdk_port_id, drop_target.queue()));
+        LOG(INFO) << "Configured deflect on drop to target port " << port_id
+                  << " (SDK port " << sdk_port_id << ")"
+                  << " in node " << node_id << ".";
+      }
+      CHECK_RETURN_IF_FALSE(gtl::InsertIfNotPresent(
+          &node_id_to_deflect_on_drop_config, node_id, deflect_config));
     }
   }
 
@@ -422,6 +453,7 @@ BFChassisManager::~BFChassisManager() = default;
       node_id_to_port_id_to_singleton_port_key;
   node_id_to_port_id_to_sdk_port_id_ = node_id_to_port_id_to_sdk_port_id;
   node_id_to_sdk_port_id_to_port_id_ = node_id_to_sdk_port_id_to_port_id;
+  node_id_to_deflect_on_drop_config_ = node_id_to_deflect_on_drop_config;
   xcvr_port_key_to_xcvr_state_ = xcvr_port_key_to_xcvr_state;
   initialized_ = true;
 
@@ -877,6 +909,16 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     p.second = config_new;
   }
 
+  for (const auto& drop_target :
+       node_id_to_deflect_on_drop_config_[node_id].drop_targets()) {
+    ASSIGN_OR_RETURN(auto sdk_port_id,
+                     GetSdkPortId(node_id, drop_target.port()));
+    RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(
+        unit, sdk_port_id, drop_target.queue()));
+    LOG(INFO) << "Configured deflect on drop target port " << sdk_port_id
+              << " in node " << node_id << ".";
+  }
+
   return status;
 }
 
@@ -1185,6 +1227,7 @@ void BFChassisManager::CleanupInternalState() {
   node_id_to_port_id_to_singleton_port_key_.clear();
   node_id_to_port_id_to_sdk_port_id_.clear();
   node_id_to_sdk_port_id_to_port_id_.clear();
+  node_id_to_deflect_on_drop_config_.clear();
   xcvr_port_key_to_xcvr_state_.clear();
 }
 

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.h
@@ -237,6 +237,10 @@ class BFChassisManager {
   std::map<uint64, std::map<uint32, uint32>> node_id_to_sdk_port_id_to_port_id_
       GUARDED_BY(chassis_lock);
 
+  // Map from node ID to deflect-on-drop configuration.
+  std::map<uint64, TofinoConfig::DeflectOnPacketDropConfig>
+      node_id_to_deflect_on_drop_config_ GUARDED_BY(chassis_lock);
+
   // Map from PortKey representing (slot, port) of a transceiver port to the
   // state of the transceiver module plugged into that (slot, port).
   std::map<PortKey, HwState> xcvr_port_key_to_xcvr_state_

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -219,6 +219,10 @@ class BfSdeInterface {
   // Set the CPU port in the traffic manager.
   virtual ::util::Status SetTmCpuPort(int device, int port) = 0;
 
+  // Sets the (port, queue) deflect destination for dropped packets.
+  virtual ::util::Status SetDeflectOnDropDestination(int device, int port,
+                                                     int queue) = 0;
+
   // Check whether we are running on the software model.
   virtual ::util::StatusOr<bool> IsSoftwareModel(int device) = 0;
 

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -95,6 +95,8 @@ class BfSdeMock : public BfSdeInterface {
                ::util::StatusOr<uint32>(int device, const PortKey& port_key));
   MOCK_METHOD1(GetPcieCpuPort, ::util::StatusOr<int>(int device));
   MOCK_METHOD2(SetTmCpuPort, ::util::Status(int device, int port));
+  MOCK_METHOD3(SetDeflectOnDropDestination,
+               ::util::Status(int device, int port, int queue));
   MOCK_METHOD1(IsSoftwareModel, ::util::StatusOr<bool>(int device));
   MOCK_CONST_METHOD1(GetBfChipType, std::string(int device));
   MOCK_CONST_METHOD0(GetSdeVersion, std::string());

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -1313,6 +1313,15 @@ std::string BfSdeWrapper::GetSdeVersion() const {
   return ::util::OkStatus();
 }
 
+::util::Status BfSdeWrapper::SetDeflectOnDropDestination(int device, int port,
+                                                         int queue) {
+  // The DoD destination must be a pipe-local port.
+  p4_pd_tm_pipe_t pipe = DEV_PORT_TO_PIPE(port);
+  RETURN_IF_BFRT_ERROR(
+      p4_pd_tm_set_negative_mirror_dest(device, pipe, port, queue));
+  return ::util::OkStatus();
+}
+
 // BFRT
 
 ::util::Status BfSdeWrapper::AddDevice(int device,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -172,6 +172,8 @@ class BfSdeWrapper : public BfSdeInterface {
       int device, const PortKey& port_key) override;
   ::util::StatusOr<int> GetPcieCpuPort(int device) override;
   ::util::Status SetTmCpuPort(int device, int port) override;
+  ::util::Status SetDeflectOnDropDestination(int device, int port,
+                                             int queue) override;
   ::util::StatusOr<bool> IsSoftwareModel(int device) override;
   std::string GetBfChipType(int device) const override;
   std::string GetSdeVersion() const override;

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -683,8 +683,11 @@ message TofinoConfig {
   // packets will be deflected to.
   message DeflectOnPacketDropConfig {
     message DropTarget {
-      uint32 port = 1;
-      uint32 queue = 2;
+      oneof port_type {
+        uint32 port = 1;
+        uint32 sdk_port = 2;
+      }
+      uint32 queue = 3;
     }
     repeated DropTarget drop_targets = 1;
   }

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -679,9 +679,20 @@ message TofinoConfig {
     map<uint32, BfPerPortShapingConfig> per_port_shaping_configs = 1;
   }
 
+  // DeflectOnPacketDropConfig specifies the port and queue where dropped
+  // packets will be deflected to.
+  message DeflectOnPacketDropConfig {
+    message DropTarget {
+      uint32 port = 1;
+      uint32 queue = 2;
+    }
+    repeated DropTarget drop_targets = 1;
+  }
+
   // Maps from the index of the nodes (1-based) to all the configs related to
   // that specific node.
   map<uint64, BfPortShapingConfig> node_id_to_port_shaping_config = 1;
+  map<uint64, DeflectOnPacketDropConfig> node_id_to_deflect_on_drop_configs = 2;
 }
 
 message VendorConfig {


### PR DESCRIPTION
This PR adds allows setting the deflect-on-drop config on Stratum-bfrt via the ChassisConfig.


Example config:
```
vendor_config {
  tofino_config {
    node_id_to_deflect_on_drop_configs {
      key: 1  # node id
      value {
        drop_targets {
          port: 16  # reference to singleton port
          # or 
          # sdk_port: 324
          queue: 0
        }
      }
    }
  }
}
```

TODO:

- [x] test on HW