### PR TITLE
Refactor SwitchInterface to use generic StreamMessageRequest/Response types

### DIFF
--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -236,6 +236,24 @@ namespace {
   return pi_node->TransmitPacket(packet);
 }
 
+::util::Status BFSwitch::RegisterDigestReceiveWriter(
+    uint64 node_id,
+    std::shared_ptr<WriterInterface<::p4::v1::DigestList>> writer) {
+  ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
+  return pi_node->RegisterDigestReceiveWriter(writer);
+}
+
+::util::Status BFSwitch::UnregisterDigestReceiveWriter(uint64 node_id) {
+  ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
+  return pi_node->UnregisterDigestReceiveWriter();
+}
+
+::util::Status BFSwitch::AckDigestList(uint64 node_id,
+                                       const ::p4::v1::DigestListAck& ack) {
+  ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
+  return pi_node->AckDigestList(ack);
+}
+
 ::util::Status BFSwitch::RegisterEventNotifyWriter(
     std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) {
   return bf_chassis_manager_->RegisterEventNotifyWriter(writer);

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -218,40 +218,20 @@ namespace {
   return pi_node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status BFSwitch::RegisterPacketReceiveWriter(
+::util::Status BFSwitch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->RegisterPacketReceiveWriter(writer);
+  return pi_node->RegisterStreamMessageResponseWriter(writer);
 }
-
-::util::Status BFSwitch::UnregisterPacketReceiveWriter(uint64 node_id) {
+::util::Status BFSwitch::UnregisterStreamMessageResponseWriter(uint64 node_id) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->UnregisterPacketReceiveWriter();
+  return pi_node->UnregisterStreamMessageResponseWriter();
 }
-
-::util::Status BFSwitch::TransmitPacket(uint64 node_id,
-                                        const ::p4::v1::PacketOut& packet) {
+::util::Status BFSwitch::SendStreamMessageRequest(
+    uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->TransmitPacket(packet);
-}
-
-::util::Status BFSwitch::RegisterDigestReceiveWriter(
-    uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::DigestList>> writer) {
-  ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->RegisterDigestReceiveWriter(writer);
-}
-
-::util::Status BFSwitch::UnregisterDigestReceiveWriter(uint64 node_id) {
-  ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->UnregisterDigestReceiveWriter();
-}
-
-::util::Status BFSwitch::AckDigestList(uint64 node_id,
-                                       const ::p4::v1::DigestListAck& ack) {
-  ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->AckDigestList(ack);
+  return pi_node->SendStreamMessageRequest(request);
 }
 
 ::util::Status BFSwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -228,10 +228,10 @@ namespace {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   return pi_node->UnregisterStreamMessageResponseWriter();
 }
-::util::Status BFSwitch::SendStreamMessageRequest(
+::util::Status BFSwitch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->SendStreamMessageRequest(request);
+  return pi_node->HandleStreamMessageRequest(request);
 }
 
 ::util::Status BFSwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -52,7 +52,7 @@ class BFSwitch : public SwitchInterface {
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       override;
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override;
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -53,6 +53,12 @@ class BFSwitch : public SwitchInterface {
   ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) override;
   ::util::Status TransmitPacket(uint64 node_id,
                                 const ::p4::v1::PacketOut& packet) override;
+  ::util::Status RegisterDigestReceiveWriter(
+      uint64 node_id,
+      std::shared_ptr<WriterInterface<::p4::v1::DigestList>> writer) override;
+  ::util::Status UnregisterDigestReceiveWriter(uint64 node_id) override;
+  ::util::Status AckDigestList(uint64 node_id,
+                               const ::p4::v1::DigestListAck& ack) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;
   ::util::Status UnregisterEventNotifyWriter() override;

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -47,18 +47,13 @@ class BFSwitch : public SwitchInterface {
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) override;
-  ::util::Status RegisterPacketReceiveWriter(
+  ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) override;
-  ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) override;
-  ::util::Status TransmitPacket(uint64 node_id,
-                                const ::p4::v1::PacketOut& packet) override;
-  ::util::Status RegisterDigestReceiveWriter(
-      uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::DigestList>> writer) override;
-  ::util::Status UnregisterDigestReceiveWriter(uint64 node_id) override;
-  ::util::Status AckDigestList(uint64 node_id,
-                               const ::p4::v1::DigestListAck& ack) override;
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
+      override;
+  ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override;
+  ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;
   ::util::Status UnregisterEventNotifyWriter() override;

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -325,7 +325,7 @@ BfrtNode::~BfrtNode() = default;
   return bfrt_packetio_manager_->UnregisterPacketReceiveWriter();
 }
 
-::util::Status BfrtNode::SendStreamMessageRequest(
+::util::Status BfrtNode::HandleStreamMessageRequest(
     const ::p4::v1::StreamMessageRequest& req) {
   absl::WriterMutexLock l(&lock_);
   if (!initialized_) {

--- a/stratum/hal/lib/barefoot/bfrt_node.h
+++ b/stratum/hal/lib/barefoot/bfrt_node.h
@@ -57,7 +57,7 @@ class BfrtNode final {
       const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
           writer) LOCKS_EXCLUDED(lock_);
   ::util::Status UnregisterStreamMessageResponseWriter() LOCKS_EXCLUDED(lock_);
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       const ::p4::v1::StreamMessageRequest& req) LOCKS_EXCLUDED(lock_);
   // Factory function for creating the instance of the class.
   static std::unique_ptr<BfrtNode> CreateInstance(

--- a/stratum/hal/lib/barefoot/bfrt_node.h
+++ b/stratum/hal/lib/barefoot/bfrt_node.h
@@ -53,12 +53,12 @@ class BfrtNode final {
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) LOCKS_EXCLUDED(lock_);
-  ::util::Status RegisterPacketReceiveWriter(
-      const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer)
-      LOCKS_EXCLUDED(lock_);
-  ::util::Status UnregisterPacketReceiveWriter() LOCKS_EXCLUDED(lock_);
-  ::util::Status TransmitPacket(const ::p4::v1::PacketOut& packet)
-      LOCKS_EXCLUDED(lock_);
+  ::util::Status RegisterStreamMessageResponseWriter(
+      const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
+          writer) LOCKS_EXCLUDED(lock_);
+  ::util::Status UnregisterStreamMessageResponseWriter() LOCKS_EXCLUDED(lock_);
+  ::util::Status SendStreamMessageRequest(
+      const ::p4::v1::StreamMessageRequest& req) LOCKS_EXCLUDED(lock_);
   // Factory function for creating the instance of the class.
   static std::unique_ptr<BfrtNode> CreateInstance(
       BfrtTableManager* bfrt_table_manager,

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -161,22 +161,23 @@ BfrtSwitch::~BfrtSwitch() {}
   return bfrt_node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status BfrtSwitch::RegisterPacketReceiveWriter(
+::util::Status BfrtSwitch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(node_id));
-  return bfrt_node->RegisterPacketReceiveWriter(writer);
+  return bfrt_node->RegisterStreamMessageResponseWriter(writer);
 }
 
-::util::Status BfrtSwitch::UnregisterPacketReceiveWriter(uint64 node_id) {
+::util::Status BfrtSwitch::UnregisterStreamMessageResponseWriter(
+    uint64 node_id) {
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(node_id));
-  return bfrt_node->UnregisterPacketReceiveWriter();
+  return bfrt_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status BfrtSwitch::TransmitPacket(uint64 node_id,
-                                          const ::p4::v1::PacketOut& packet) {
+::util::Status BfrtSwitch::SendStreamMessageRequest(
+    uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(node_id));
-  return bfrt_node->TransmitPacket(packet);
+  return bfrt_node->SendStreamMessageRequest(request);
 }
 
 ::util::Status BfrtSwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -174,10 +174,10 @@ BfrtSwitch::~BfrtSwitch() {}
   return bfrt_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status BfrtSwitch::SendStreamMessageRequest(
+::util::Status BfrtSwitch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(node_id));
-  return bfrt_node->SendStreamMessageRequest(request);
+  return bfrt_node->HandleStreamMessageRequest(request);
 }
 
 ::util::Status BfrtSwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/barefoot/bfrt_switch.h
+++ b/stratum/hal/lib/barefoot/bfrt_switch.h
@@ -51,14 +51,14 @@ class BfrtSwitch : public SwitchInterface {
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status RegisterPacketReceiveWriter(
+  ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) override
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
+      override LOCKS_EXCLUDED(chassis_lock);
+  ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) override
-      LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status TransmitPacket(uint64 node_id,
-                                const ::p4::v1::PacketOut& packet) override
+  ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override

--- a/stratum/hal/lib/barefoot/bfrt_switch.h
+++ b/stratum/hal/lib/barefoot/bfrt_switch.h
@@ -57,7 +57,7 @@ class BfrtSwitch : public SwitchInterface {
       override LOCKS_EXCLUDED(chassis_lock);
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterEventNotifyWriter(

--- a/stratum/hal/lib/bcm/BUILD
+++ b/stratum/hal/lib/bcm/BUILD
@@ -645,6 +645,7 @@ stratum_cc_library(
         "//stratum/glue:logging",
         "//stratum/glue/status:status_macros",
         "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/common:writer_interface",
         "//stratum/hal/lib/p4:p4_table_mapper",
         "//stratum/lib:macros",
         "@com_github_google_glog//:glog",

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -354,7 +354,6 @@ BcmNode::~BcmNode() {}
     case ::p4::v1::StreamMessageRequest::kPacket: {
       return bcm_packetio_manager_->TransmitPacket(
           GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, req.packet());
-      break;
     }
     default:
       RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -344,7 +344,7 @@ BcmNode::~BcmNode() {}
       GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER);
 }
 
-::util::Status BcmNode::SendStreamMessageRequest(
+::util::Status BcmNode::HandleStreamMessageRequest(
     const ::p4::v1::StreamMessageRequest& req) {
   absl::ReaderMutexLock l(&lock_);
   if (!initialized_) {

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -10,7 +10,7 @@
 #include "absl/memory/memory.h"
 #include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
-#include "stratum/hal/lib/common/channel_writer_wrapper.h"
+#include "stratum/hal/lib/common/writer_interface.h"
 #include "stratum/lib/macros.h"
 
 // TODO(unknown): This flag is currently false to skip static entry writes
@@ -326,18 +326,13 @@ BcmNode::~BcmNode() {}
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  auto w =
-      std::make_shared<ConstraintChannelWriter<::p4::v1::StreamMessageResponse,
+  auto packet_in_writer =
+      std::make_shared<ConstraintWriterWrapper<::p4::v1::StreamMessageResponse,
                                                ::p4::v1::PacketIn>>(
           writer, &::p4::v1::StreamMessageResponse::mutable_packet);
-  ::p4::v1::PacketIn pkt;
-  LOG(WARNING) << "RegisterStreamMessageResponseWriter: "
-               << Demangle(typeid(w).name());
 
-  bcm_packetio_manager_->RegisterPacketReceiveWriterOld(
-      GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, w);
   return bcm_packetio_manager_->RegisterPacketReceiveWriter(
-      GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, writer);
+      GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, packet_in_writer);
 }
 
 ::util::Status BcmNode::UnregisterStreamMessageResponseWriter() {

--- a/stratum/hal/lib/bcm/bcm_node.h
+++ b/stratum/hal/lib/bcm/bcm_node.h
@@ -85,19 +85,20 @@ class BcmNode {
   // Registers a writer to be invoked on receipt of a packet on any port on this
   // node. The sent P4 PacketIn instance includes all the info on where
   // the packet was received on this node as well as its payload.
-  virtual ::util::Status RegisterPacketReceiveWriter(
-      const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer)
-      SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(lock_);
+  virtual ::util::Status RegisterStreamMessageResponseWriter(
+      const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
+          writer) SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(lock_);
 
-  // Unregisters writer registered in RegisterPacketReceiveWriter().
-  virtual ::util::Status UnregisterPacketReceiveWriter()
+  // Unregisters writer registered in RegisterStreamMessageResponseWriter().
+  virtual ::util::Status UnregisterStreamMessageResponseWriter()
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(lock_);
 
   // Transmits a packet received from controller directly to a port on this node
   // or to the ingress pipeline of the node to let the chip route the packet.
   // The given P4 PacketOut instance includes all the info on where to
   // transmit the packet as well as its payload.
-  virtual ::util::Status TransmitPacket(const ::p4::v1::PacketOut& packet)
+  virtual ::util::Status SendStreamMessageRequest(
+      const ::p4::v1::StreamMessageRequest& request)
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(lock_);
 
   // Updates any managers which rely on current port state. This is generally

--- a/stratum/hal/lib/bcm/bcm_node.h
+++ b/stratum/hal/lib/bcm/bcm_node.h
@@ -97,7 +97,7 @@ class BcmNode {
   // or to the ingress pipeline of the node to let the chip route the packet.
   // The given P4 PacketOut instance includes all the info on where to
   // transmit the packet as well as its payload.
-  virtual ::util::Status SendStreamMessageRequest(
+  virtual ::util::Status HandleStreamMessageRequest(
       const ::p4::v1::StreamMessageRequest& request)
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(lock_);
 

--- a/stratum/hal/lib/bcm/bcm_node_mock.h
+++ b/stratum/hal/lib/bcm/bcm_node_mock.h
@@ -41,7 +41,7 @@ class BcmNodeMock : public BcmNode {
       ::util::Status(
           std::function<void(const ::p4::v1::StreamMessageResponse& resp)>
               callback));
-  MOCK_METHOD1(SendStreamMessageRequest,
+  MOCK_METHOD1(HandleStreamMessageRequest,
                ::util::Status(const ::p4::v1::StreamMessageRequest& req));
   MOCK_METHOD1(UpdatePortState, ::util::Status(uint32 port_id));
 };

--- a/stratum/hal/lib/bcm/bcm_node_mock.h
+++ b/stratum/hal/lib/bcm/bcm_node_mock.h
@@ -37,11 +37,12 @@ class BcmNodeMock : public BcmNode {
                               WriterInterface<::p4::v1::ReadResponse>* writer,
                               std::vector<::util::Status>* details));
   MOCK_METHOD1(
-      RegisterPacketReceiveHandler,
+      RegisterStreamMessageResponseWriter,
       ::util::Status(
-          std::function<void(const ::p4::v1::PacketIn& packet)> callback));
-  MOCK_METHOD1(TransmitPacket,
-               ::util::Status(const ::p4::v1::PacketOut& packet));
+          std::function<void(const ::p4::v1::StreamMessageResponse& resp)>
+              callback));
+  MOCK_METHOD1(SendStreamMessageRequest,
+               ::util::Status(const ::p4::v1::StreamMessageRequest& req));
   MOCK_METHOD1(UpdatePortState, ::util::Status(uint32 port_id));
 };
 

--- a/stratum/hal/lib/bcm/bcm_node_test.cc
+++ b/stratum/hal/lib/bcm/bcm_node_test.cc
@@ -96,15 +96,16 @@ class BcmNodeTest : public ::testing::Test {
     return bcm_node_->WriteForwardingEntries(req, results);
   }
 
-  ::util::Status RegisterPacketReceiveWriter(
-      const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer) {
+  ::util::Status RegisterStreamMessageResponseWriter(
+      const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
+          writer) {
     absl::ReaderMutexLock l(&chassis_lock);
-    return bcm_node_->RegisterPacketReceiveWriter(writer);
+    return bcm_node_->RegisterStreamMessageResponseWriter(writer);
   }
 
-  ::util::Status UnregisterPacketReceiveWriter() {
+  ::util::Status UnregisterStreamMessageResponseWriter() {
     absl::ReaderMutexLock l(&chassis_lock);
-    return bcm_node_->UnregisterPacketReceiveWriter();
+    return bcm_node_->UnregisterStreamMessageResponseWriter();
   }
 
   ::util::Status UpdatePortState(uint32 port_id) {
@@ -1619,26 +1620,27 @@ TEST_F(BcmNodeTest, WriteForwardingEntriesSuccess_DeleteMulticastGroupEntry) {
   EXPECT_EQ(1U, results.size());
 }
 
-// RegisterPacketReceiveWriter() should forward the call to BcmPacketioManager
-// and return success or error based on the returned result.
-TEST_F(BcmNodeTest, RegisterPacketReceiveWriter) {
+// RegisterStreamMessageResponseWriter() should forward the call to
+// BcmPacketioManager and return success or error based on the returned result.
+TEST_F(BcmNodeTest, RegisterStreamMessageResponseWriter) {
   ASSERT_NO_FATAL_FAILURE(PushChassisConfigWithCheck());
 
-  auto writer = std::make_shared<WriterMock<::p4::v1::PacketIn>>();
-  EXPECT_CALL(*bcm_packetio_manager_mock_,
-              RegisterPacketReceiveWriter(
-                  GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, Eq(writer)))
+  auto writer = std::make_shared<WriterMock<::p4::v1::StreamMessageResponse>>();
+  EXPECT_CALL(
+      *bcm_packetio_manager_mock_,
+      RegisterPacketReceiveWriter(
+          GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, _ /*Eq(writer)*/))
       .WillOnce(Return(::util::OkStatus()))
       .WillOnce(Return(DefaultError()));
 
-  EXPECT_OK(RegisterPacketReceiveWriter(writer));
-  EXPECT_THAT(RegisterPacketReceiveWriter(writer),
+  EXPECT_OK(RegisterStreamMessageResponseWriter(writer));
+  EXPECT_THAT(RegisterStreamMessageResponseWriter(writer),
               DerivedFromStatus(DefaultError()));
 }
 
-// UnregisterPacketReceiveWriter() should forward the call to BcmPacketioManager
-// and return success or error based on the returned result.
-TEST_F(BcmNodeTest, UnregisterPacketReceiveWriter) {
+// UnregisterStreamMessageResponseWriter() should forward the call to
+// BcmPacketioManager and return success or error based on the returned result.
+TEST_F(BcmNodeTest, UnregisterStreamMessageResponseWriter) {
   ASSERT_NO_FATAL_FAILURE(PushChassisConfigWithCheck());
 
   EXPECT_CALL(*bcm_packetio_manager_mock_,
@@ -1647,8 +1649,8 @@ TEST_F(BcmNodeTest, UnregisterPacketReceiveWriter) {
       .WillOnce(Return(::util::OkStatus()))
       .WillOnce(Return(DefaultError()));
 
-  EXPECT_OK(UnregisterPacketReceiveWriter());
-  EXPECT_THAT(UnregisterPacketReceiveWriter(),
+  EXPECT_OK(UnregisterStreamMessageResponseWriter());
+  EXPECT_THAT(UnregisterStreamMessageResponseWriter(),
               DerivedFromStatus(DefaultError()));
 }
 

--- a/stratum/hal/lib/bcm/bcm_node_test.cc
+++ b/stratum/hal/lib/bcm/bcm_node_test.cc
@@ -1626,10 +1626,9 @@ TEST_F(BcmNodeTest, RegisterStreamMessageResponseWriter) {
   ASSERT_NO_FATAL_FAILURE(PushChassisConfigWithCheck());
 
   auto writer = std::make_shared<WriterMock<::p4::v1::StreamMessageResponse>>();
-  EXPECT_CALL(
-      *bcm_packetio_manager_mock_,
-      RegisterPacketReceiveWriter(
-          GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, _ /*Eq(writer)*/))
+  EXPECT_CALL(*bcm_packetio_manager_mock_,
+              RegisterPacketReceiveWriter(
+                  GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, _))
       .WillOnce(Return(::util::OkStatus()))
       .WillOnce(Return(DefaultError()));
 

--- a/stratum/hal/lib/bcm/bcm_packetio_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.cc
@@ -343,7 +343,8 @@ BcmPacketioManager::~BcmPacketioManager() {}
 
 ::util::Status BcmPacketioManager::RegisterPacketReceiveWriter(
     GoogleConfig::BcmKnetIntfPurpose purpose,
-    const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer) {
+    const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
+        writer) {
   if (mode_ == OPERATION_MODE_SIM) {
     LOG(WARNING) << "Skipped registering packet RX writer in "
                  << "BcmPacketioManager in sim mode for node with ID "
@@ -360,6 +361,35 @@ BcmPacketioManager::~BcmPacketioManager() {}
     // If it is a valid purpose, update the internal map.
     absl::WriterMutexLock l(&rx_writer_lock_);
     purpose_to_rx_writer_[purpose] = writer;
+  }
+  LOG(INFO) << "Registered packet RX writer for KNET interface "
+            << intf->netif_name << " with purpose "
+            << GoogleConfig::BcmKnetIntfPurpose_Name(purpose)
+            << " on node with ID " << node_id_ << " mapped to unit " << unit_
+            << ".";
+
+  return ::util::OkStatus();
+}
+
+::util::Status BcmPacketioManager::RegisterPacketReceiveWriterOld(
+    GoogleConfig::BcmKnetIntfPurpose purpose,
+    const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer) {
+  if (mode_ == OPERATION_MODE_SIM) {
+    LOG(WARNING) << "Skipped registering packet RX writer in "
+                 << "BcmPacketioManager in sim mode for node with ID "
+                 << node_id_ << " mapped to unit " << unit_ << ".";
+    return ::util::OkStatus();
+  }
+
+  // Used only to check the validity of the given purpose. Note that purpose is
+  // already known (after config is pushed), we do not expect any more change
+  // in the corresponding BcmKnetIntf. Any change by later config pushes will
+  // be rejected.
+  ASSIGN_OR_RETURN(const BcmKnetIntf* intf, GetBcmKnetIntf(purpose));
+  {
+    // If it is a valid purpose, update the internal map.
+    absl::WriterMutexLock l(&rx_writer_lock_);
+    purpose_to_rx_writer_old_[purpose] = writer;
   }
   LOG(INFO) << "Registered packet RX writer for KNET interface "
             << intf->netif_name << " with purpose "
@@ -1124,7 +1154,15 @@ std::string BcmPacketioManager::GetKnetIntfNameTemplate(
         auto* writer = gtl::FindOrNull(purpose_to_rx_writer_, purpose);
         if (writer != nullptr) {
           for (const auto& p : packets) {
-            (*writer)->Write(p);
+            ::p4::v1::StreamMessageResponse resp;
+            *resp.mutable_packet() = p;
+            (*writer)->Write(resp);
+          }
+        }
+        auto* writer_old = gtl::FindOrNull(purpose_to_rx_writer_old_, purpose);
+        if (writer_old != nullptr) {
+          for (const auto& p : packets) {
+            (*writer_old)->Write(p);
           }
         }
       }

--- a/stratum/hal/lib/bcm/bcm_packetio_manager.h
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.h
@@ -276,6 +276,11 @@ class BcmPacketioManager {
   // on the node which this class is mapped to.
   virtual ::util::Status RegisterPacketReceiveWriter(
       GoogleConfig::BcmKnetIntfPurpose purpose,
+      const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
+          writer);
+
+  virtual ::util::Status RegisterPacketReceiveWriterOld(
+      GoogleConfig::BcmKnetIntfPurpose purpose,
       const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer);
 
   virtual ::util::Status UnregisterPacketReceiveWriter(
@@ -484,8 +489,11 @@ class BcmPacketioManager {
   // Map from purpose for a KNET interface to the RX packet handler. This map
   // is updated every time a controller is connected.
   std::map<GoogleConfig::BcmKnetIntfPurpose,
-           std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>>
+           std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>>
       purpose_to_rx_writer_ GUARDED_BY(rx_writer_lock_);
+  std::map<GoogleConfig::BcmKnetIntfPurpose,
+           std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>>
+      purpose_to_rx_writer_old_ GUARDED_BY(rx_writer_lock_);
 
   // A vector of KnetIntfRxThreadData pointers.
   std::vector<KnetIntfRxThreadData*> knet_intf_rx_thread_data_;

--- a/stratum/hal/lib/bcm/bcm_packetio_manager.h
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager.h
@@ -276,11 +276,6 @@ class BcmPacketioManager {
   // on the node which this class is mapped to.
   virtual ::util::Status RegisterPacketReceiveWriter(
       GoogleConfig::BcmKnetIntfPurpose purpose,
-      const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
-          writer);
-
-  virtual ::util::Status RegisterPacketReceiveWriterOld(
-      GoogleConfig::BcmKnetIntfPurpose purpose,
       const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer);
 
   virtual ::util::Status UnregisterPacketReceiveWriter(
@@ -489,11 +484,8 @@ class BcmPacketioManager {
   // Map from purpose for a KNET interface to the RX packet handler. This map
   // is updated every time a controller is connected.
   std::map<GoogleConfig::BcmKnetIntfPurpose,
-           std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>>
-      purpose_to_rx_writer_ GUARDED_BY(rx_writer_lock_);
-  std::map<GoogleConfig::BcmKnetIntfPurpose,
            std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>>
-      purpose_to_rx_writer_old_ GUARDED_BY(rx_writer_lock_);
+      purpose_to_rx_writer_ GUARDED_BY(rx_writer_lock_);
 
   // A vector of KnetIntfRxThreadData pointers.
   std::vector<KnetIntfRxThreadData*> knet_intf_rx_thread_data_;

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -485,7 +485,7 @@ BcmSwitch::~BcmSwitch() {}
       case SetRequest::Request::RequestCase::kOpticalNetworkInterface:
         switch (req.optical_network_interface().value_case()) {
           case SetRequest::Request::OpticalNetworkInterface::ValueCase::
-              kOpticalTransceiverInfo: {  // NOLINT
+              kOpticalTransceiverInfo: {
             status.Update(phal_interface_->SetOpticalTransceiverInfo(
                 req.optical_network_interface().module(),
                 req.optical_network_interface().network_interface(),

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -188,37 +188,38 @@ BcmSwitch::~BcmSwitch() {}
   return bcm_node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status BcmSwitch::RegisterPacketReceiveWriter(
+::util::Status BcmSwitch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   absl::ReaderMutexLock l(&chassis_lock);
   if (shutdown) {
     return MAKE_ERROR(ERR_CANCELLED) << "Switch is shutdown.";
   }
   // Get BcmNode which the node_id is associated with.
   ASSIGN_OR_RETURN(auto* bcm_node, GetBcmNodeFromNodeId(node_id));
-  return bcm_node->RegisterPacketReceiveWriter(writer);
+  return bcm_node->RegisterStreamMessageResponseWriter(writer);
 }
 
-::util::Status BcmSwitch::UnregisterPacketReceiveWriter(uint64 node_id) {
+::util::Status BcmSwitch::UnregisterStreamMessageResponseWriter(
+    uint64 node_id) {
   absl::ReaderMutexLock l(&chassis_lock);
   if (shutdown) {
     return MAKE_ERROR(ERR_CANCELLED) << "Switch is shutdown.";
   }
   // Get BcmNode which the node_id is associated with.
   ASSIGN_OR_RETURN(auto* bcm_node, GetBcmNodeFromNodeId(node_id));
-  return bcm_node->UnregisterPacketReceiveWriter();
+  return bcm_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status BcmSwitch::TransmitPacket(uint64 node_id,
-                                         const ::p4::v1::PacketOut& packet) {
+::util::Status BcmSwitch::SendStreamMessageRequest(
+    uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&chassis_lock);
   if (shutdown) {
     return MAKE_ERROR(ERR_CANCELLED) << "Switch is shutdown.";
   }
   // Get BcmNode which the node_id is associated with.
   ASSIGN_OR_RETURN(auto* bcm_node, GetBcmNodeFromNodeId(node_id));
-  return bcm_node->TransmitPacket(packet);
+  return bcm_node->SendStreamMessageRequest(request);
 }
 
 ::util::Status BcmSwitch::RegisterEventNotifyWriter(
@@ -483,7 +484,8 @@ BcmSwitch::~BcmSwitch() {}
         break;
       case SetRequest::Request::RequestCase::kOpticalNetworkInterface:
         switch (req.optical_network_interface().value_case()) {
-          case SetRequest::Request::OpticalNetworkInterface::ValueCase::kOpticalTransceiverInfo: {  // NOLINT
+          case SetRequest::Request::OpticalNetworkInterface::ValueCase::
+              kOpticalTransceiverInfo: {  // NOLINT
             status.Update(phal_interface_->SetOpticalTransceiverInfo(
                 req.optical_network_interface().module(),
                 req.optical_network_interface().network_interface(),

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -211,7 +211,7 @@ BcmSwitch::~BcmSwitch() {}
   return bcm_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status BcmSwitch::SendStreamMessageRequest(
+::util::Status BcmSwitch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&chassis_lock);
   if (shutdown) {
@@ -219,7 +219,7 @@ BcmSwitch::~BcmSwitch() {}
   }
   // Get BcmNode which the node_id is associated with.
   ASSIGN_OR_RETURN(auto* bcm_node, GetBcmNodeFromNodeId(node_id));
-  return bcm_node->SendStreamMessageRequest(request);
+  return bcm_node->HandleStreamMessageRequest(request);
 }
 
 ::util::Status BcmSwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/bcm/bcm_switch.h
+++ b/stratum/hal/lib/bcm/bcm_switch.h
@@ -56,14 +56,15 @@ class BcmSwitch : public SwitchInterface {
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status RegisterPacketReceiveWriter(
+  ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) override
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>
+          writer) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) override
+  ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status TransmitPacket(uint64 node_id,
-                                const ::p4::v1::PacketOut& packet) override
+  ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override

--- a/stratum/hal/lib/bcm/bcm_switch.h
+++ b/stratum/hal/lib/bcm/bcm_switch.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_SWITCH_H_
 #define STRATUM_HAL_LIB_BCM_BCM_SWITCH_H_
 
@@ -11,13 +10,13 @@
 #include <string>
 #include <vector>
 
-#include "stratum/hal/lib/bcm/bcm_chassis_manager.h"
+#include "absl/synchronization/mutex.h"
 #include "stratum//hal/lib/bcm/bcm_global_vars.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/hal/lib/bcm/bcm_chassis_manager.h"
 #include "stratum/hal/lib/bcm/bcm_node.h"
 #include "stratum/hal/lib/common/phal_interface.h"
 #include "stratum/hal/lib/common/switch_interface.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {
@@ -58,9 +57,8 @@ class BcmSwitch : public SwitchInterface {
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>
-          writer) override
-      LOCKS_EXCLUDED(chassis_lock);
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
+      override LOCKS_EXCLUDED(chassis_lock);
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status SendStreamMessageRequest(

--- a/stratum/hal/lib/bcm/bcm_switch.h
+++ b/stratum/hal/lib/bcm/bcm_switch.h
@@ -61,7 +61,7 @@ class BcmSwitch : public SwitchInterface {
       override LOCKS_EXCLUDED(chassis_lock);
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override
       LOCKS_EXCLUDED(chassis_lock);
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterEventNotifyWriter(

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -150,10 +150,10 @@ Bmv2Switch::~Bmv2Switch() {}
   return pi_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status Bmv2Switch::SendStreamMessageRequest(
+::util::Status Bmv2Switch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->SendStreamMessageRequest(request);
+  return pi_node->HandleStreamMessageRequest(request);
 }
 
 ::util::Status Bmv2Switch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -137,22 +137,23 @@ Bmv2Switch::~Bmv2Switch() {}
   return pi_node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status Bmv2Switch::RegisterPacketReceiveWriter(
+::util::Status Bmv2Switch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->RegisterPacketReceiveWriter(writer);
+  return pi_node->RegisterStreamMessageResponseWriter(writer);
 }
 
-::util::Status Bmv2Switch::UnregisterPacketReceiveWriter(uint64 node_id) {
+::util::Status Bmv2Switch::UnregisterStreamMessageResponseWriter(
+    uint64 node_id) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->UnregisterPacketReceiveWriter();
+  return pi_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status Bmv2Switch::TransmitPacket(uint64 node_id,
-                                          const ::p4::v1::PacketOut& packet) {
+::util::Status Bmv2Switch::SendStreamMessageRequest(
+    uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->TransmitPacket(packet);
+  return pi_node->SendStreamMessageRequest(request);
 }
 
 ::util::Status Bmv2Switch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/bmv2/bmv2_switch.h
+++ b/stratum/hal/lib/bmv2/bmv2_switch.h
@@ -51,7 +51,7 @@ class Bmv2Switch : public SwitchInterface {
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       override;
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override;
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;

--- a/stratum/hal/lib/bmv2/bmv2_switch.h
+++ b/stratum/hal/lib/bmv2/bmv2_switch.h
@@ -46,12 +46,13 @@ class Bmv2Switch : public SwitchInterface {
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) override;
-  ::util::Status RegisterPacketReceiveWriter(
+  ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) override;
-  ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) override;
-  ::util::Status TransmitPacket(uint64 node_id,
-                                const ::p4::v1::PacketOut& packet) override;
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
+      override;
+  ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override;
+  ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;
   ::util::Status UnregisterEventNotifyWriter() override;

--- a/stratum/hal/lib/common/channel_writer_wrapper.h
+++ b/stratum/hal/lib/common/channel_writer_wrapper.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_CHANNEL_WRITER_WRAPPER_H_
 #define STRATUM_HAL_LIB_COMMON_CHANNEL_WRITER_WRAPPER_H_
 
@@ -34,6 +33,25 @@ class ChannelWriterWrapper : public WriterInterface<T> {
 
  private:
   std::unique_ptr<ChannelWriter<T>> writer_;
+};
+
+template <typename T, typename R>
+class ConstraintChannelWriter : public WriterInterface<R> {
+ public:
+  explicit ConstraintChannelWriter(std::shared_ptr<WriterInterface<T>> writer,
+                                    R* (T::*get_mutable_inner_message)())
+      : writer_(std::move(writer)),
+        get_mutable_inner_message_(get_mutable_inner_message) {}
+  bool Write(const R& msg) override {
+    if (!writer_) return false;
+    T t;
+    *(t.*get_mutable_inner_message_)() = msg;
+    return writer_->Write(t);
+  }
+
+ private:
+  std::shared_ptr<WriterInterface<T>> writer_;
+  R* (T::*get_mutable_inner_message_)();
 };
 
 }  // namespace hal

--- a/stratum/hal/lib/common/channel_writer_wrapper.h
+++ b/stratum/hal/lib/common/channel_writer_wrapper.h
@@ -35,25 +35,6 @@ class ChannelWriterWrapper : public WriterInterface<T> {
   std::unique_ptr<ChannelWriter<T>> writer_;
 };
 
-template <typename T, typename R>
-class ConstraintChannelWriter : public WriterInterface<R> {
- public:
-  explicit ConstraintChannelWriter(std::shared_ptr<WriterInterface<T>> writer,
-                                    R* (T::*get_mutable_inner_message)())
-      : writer_(std::move(writer)),
-        get_mutable_inner_message_(get_mutable_inner_message) {}
-  bool Write(const R& msg) override {
-    if (!writer_) return false;
-    T t;
-    *(t.*get_mutable_inner_message_)() = msg;
-    return writer_->Write(t);
-  }
-
- private:
-  std::shared_ptr<WriterInterface<T>> writer_;
-  R* (T::*get_mutable_inner_message_)();
-};
-
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -609,7 +609,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
         }
         if (!status.ok()) {
           LOG(INFO) << "Failed to ack digest: " << status;
-          // TODO(max): investigate if creating response for every failure is
+          // TODO(max): investigate if creating responses for every failure is
           // too resource intensive.
           auto resp = ToStreamMessageResponse(status);
           *resp.mutable_error()

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -87,19 +87,19 @@ P4Service::~P4Service() {}
     connection_ids_.clear();
   }
   {
-    absl::WriterMutexLock l(&packet_in_thread_lock_);
+    absl::WriterMutexLock l(&stream_response_thread_lock_);
     // Unregister writers and close PacketIn Channels.
-    for (const auto& pair : packet_in_channels_) {
+    for (const auto& pair : stream_response_channels_) {
       auto status =
-          switch_interface_->UnregisterPacketReceiveWriter(pair.first);
+          switch_interface_->UnregisterStreamMessageResponseWriter(pair.first);
       if (!status.ok()) {
         LOG(ERROR) << status;
       }
       pair.second->Close();
     }
-    packet_in_channels_.clear();
+    stream_response_channels_.clear();
     // Join threads.
-    for (const auto& tid : packet_in_reader_tids_) {
+    for (const auto& tid : stream_response_reader_tids_) {
       int ret = pthread_join(tid, nullptr);
       if (ret) {
         LOG(ERROR) << "Failed to join thread " << tid << " with error " << ret
@@ -578,20 +578,15 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
       }
       case ::p4::v1::StreamMessageRequest::kPacket: {
         // If this stream is not the master stream generate a stream error.
+        ::util::Status status;
         if (!IsMasterController(node_id, connection_id)) {
-          ::util::Status status = MAKE_ERROR(ERR_PERMISSION_DENIED)
-                                  << "Controller with connection ID "
-                                  << connection_id << "is not a master";
-          LOG_EVERY_N(INFO, 500) << "Failed to transmit packet: " << status;
-          auto resp = ToStreamMessageResponse(status);
-          *resp.mutable_error()->mutable_packet_out()->mutable_packet_out() =
-              req.packet();
-          stream->Write(resp);  // Best effort.
-          break;
+          status = MAKE_ERROR(ERR_PERMISSION_DENIED)
+                   << "Controller with connection ID " << connection_id
+                   << "is not a master";
+        } else {
+          // If master, try to transmit the packet.
+          status = switch_interface_->SendStreamMessageRequest(node_id, req);
         }
-        // If master, try to transmit the packet.
-        ::util::Status status =
-            switch_interface_->TransmitPacket(node_id, req.packet());
         if (!status.ok()) {
           LOG_EVERY_N(INFO, 500) << "Failed to transmit packet: " << status;
           auto resp = ToStreamMessageResponse(status);
@@ -601,7 +596,27 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
         }
         break;
       }
-      case ::p4::v1::StreamMessageRequest::kDigestAck:
+      case ::p4::v1::StreamMessageRequest::kDigestAck: {
+        // If this stream is not the master stream generate a stream error.
+        ::util::Status status;
+        if (!IsMasterController(node_id, connection_id)) {
+          status = MAKE_ERROR(ERR_PERMISSION_DENIED)
+                   << "Controller with connection ID " << connection_id
+                   << "is not a master";
+        } else {
+          // If master, try to ack the digest.
+          status = switch_interface_->SendStreamMessageRequest(node_id, req);
+        }
+        if (!status.ok()) {
+          LOG_EVERY_N(INFO, 500) << "Failed to ack digest: " << status;
+          auto resp = ToStreamMessageResponse(status);
+          *resp.mutable_error()
+               ->mutable_digest_list_ack()
+               ->mutable_digest_list_ack() = req.digest_ack();
+          stream->Write(resp);  // Best effort.
+        }
+        break;
+      }
       case ::p4::v1::StreamMessageRequest::UPDATE_NOT_SET:
         return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                               "Need to specify either arbitration or packet.");
@@ -645,34 +660,36 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   absl::WriterMutexLock l(&controller_lock_);
   auto it = node_id_to_controllers_.find(node_id);
   if (it == node_id_to_controllers_.end()) {
-    absl::WriterMutexLock l(&packet_in_thread_lock_);
+    absl::WriterMutexLock l(&stream_response_thread_lock_);
     // This is the first time we are hearing about this node. Lets try to add
-    // an RX packet writer for it. If the node_id is invalid, registration will
-    // fail.
-    std::shared_ptr<Channel<::p4::v1::PacketIn>> channel =
-        Channel<::p4::v1::PacketIn>::Create(128);
+    // an RX response writer for it. If the node_id is invalid, registration
+    // will fail.
+    std::shared_ptr<Channel<::p4::v1::StreamMessageResponse>> channel =
+        Channel<::p4::v1::StreamMessageResponse>::Create(128);
     // Create the writer and register with the SwitchInterface.
-    auto writer = std::make_shared<ChannelWriterWrapper<::p4::v1::PacketIn>>(
-        ChannelWriter<::p4::v1::PacketIn>::Create(channel));
-    RETURN_IF_ERROR(
-        switch_interface_->RegisterPacketReceiveWriter(node_id, writer));
+    auto writer =
+        std::make_shared<ChannelWriterWrapper<::p4::v1::StreamMessageResponse>>(
+            ChannelWriter<::p4::v1::StreamMessageResponse>::Create(channel));
+    RETURN_IF_ERROR(switch_interface_->RegisterStreamMessageResponseWriter(
+        node_id, writer));
     // Create the reader and pass it to a new thread.
-    auto reader = ChannelReader<::p4::v1::PacketIn>::Create(channel);
+    auto reader =
+        ChannelReader<::p4::v1::StreamMessageResponse>::Create(channel);
     pthread_t tid = 0;
-    int ret = pthread_create(
-        &tid, nullptr, PacketReceiveThreadFunc,
-        new ReaderArgs<::p4::v1::PacketIn>{this, std::move(reader), node_id});
+    int ret = pthread_create(&tid, nullptr, StreamResponseReceiveThreadFunc,
+                             new ReaderArgs<::p4::v1::StreamMessageResponse>{
+                                 this, std::move(reader), node_id});
     if (ret) {
       // Clean up state and return error.
       RETURN_IF_ERROR(
-          switch_interface_->UnregisterPacketReceiveWriter(node_id));
+          switch_interface_->UnregisterStreamMessageResponseWriter(node_id));
       return MAKE_ERROR(ERR_INTERNAL)
              << "Failed to create packet-in receiver thread for node "
              << node_id << " with error " << ret << ".";
     }
     // Store Channel and tid for Teardown().
-    packet_in_reader_tids_.push_back(tid);
-    packet_in_channels_[node_id] = channel;
+    stream_response_reader_tids_.push_back(tid);
+    stream_response_channels_[node_id] = channel;
     node_id_to_controllers_[node_id] = {};
     it = node_id_to_controllers_.find(node_id);
   }
@@ -833,21 +850,23 @@ bool P4Service::IsMasterController(uint64 node_id, uint64 connection_id) const {
   return it->second.begin()->connection_id() == connection_id;
 }
 
-void* P4Service::PacketReceiveThreadFunc(void* arg) {
-  auto* args = reinterpret_cast<ReaderArgs<::p4::v1::PacketIn>*>(arg);
+void* P4Service::StreamResponseReceiveThreadFunc(void* arg) {
+  auto* args =
+      reinterpret_cast<ReaderArgs<::p4::v1::StreamMessageResponse>*>(arg);
   auto* p4_service = args->p4_service;
   auto node_id = args->node_id;
   auto reader = std::move(args->reader);
   delete args;
-  return p4_service->ReceivePackets(node_id, std::move(reader));
+  return p4_service->ReceiveStreamRespones(node_id, std::move(reader));
 }
 
-void* P4Service::ReceivePackets(
-    uint64 node_id, std::unique_ptr<ChannelReader<::p4::v1::PacketIn>> reader) {
+void* P4Service::ReceiveStreamRespones(
+    uint64 node_id,
+    std::unique_ptr<ChannelReader<::p4::v1::StreamMessageResponse>> reader) {
   do {
-    ::p4::v1::PacketIn packet_in;
-    // Block on next packet RX from Channel.
-    int code = reader->Read(&packet_in, absl::InfiniteDuration()).error_code();
+    ::p4::v1::StreamMessageResponse resp;
+    // Block on next stream response RX from Channel.
+    int code = reader->Read(&resp, absl::InfiniteDuration()).error_code();
     // Exit if the Channel is closed.
     if (code == ERR_CANCELLED) break;
     // Read should never timeout.
@@ -855,20 +874,24 @@ void* P4Service::ReceivePackets(
       LOG(ERROR) << "Read with infinite timeout failed with ENTRY_NOT_FOUND.";
       continue;
     }
-    // Handle PacketIn.
-    PacketReceiveHandler(node_id, packet_in);
+    // Handle StreamMessageResponse.
+    StreamResponseReceiveHandler(node_id, resp);
   } while (true);
   return nullptr;
 }
 
-void P4Service::PacketReceiveHandler(uint64 node_id,
-                                     const ::p4::v1::PacketIn& packet) {
-  // We send the packets only to the master controller stream for this node.
+void P4Service::StreamResponseReceiveHandler(
+    uint64 node_id, const ::p4::v1::StreamMessageResponse& resp) {
+  // We don't expect arbitration updates from the switch.
+  if (resp.has_arbitration()) {
+    LOG(ERROR) << "Received MasterArbitrationUpdate from switch. This should "
+                  "never happen!";
+    return;
+  }
+  // We send the responses only to the master controller stream for this node.
   absl::ReaderMutexLock l(&controller_lock_);
   auto it = node_id_to_controllers_.find(node_id);
   if (it == node_id_to_controllers_.end() || it->second.empty()) return;
-  ::p4::v1::StreamMessageResponse resp;
-  *resp.mutable_packet() = packet;
   it->second.begin()->stream()->Write(resp);
 }
 

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -585,7 +585,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
                    << "is not a master";
         } else {
           // If master, try to transmit the packet.
-          status = switch_interface_->SendStreamMessageRequest(node_id, req);
+          status = switch_interface_->HandleStreamMessageRequest(node_id, req);
         }
         if (!status.ok()) {
           LOG_EVERY_N(INFO, 500) << "Failed to transmit packet: " << status;
@@ -605,7 +605,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
                    << "is not a master";
         } else {
           // If master, try to ack the digest.
-          status = switch_interface_->SendStreamMessageRequest(node_id, req);
+          status = switch_interface_->HandleStreamMessageRequest(node_id, req);
         }
         if (!status.ok()) {
           LOG(INFO) << "Failed to ack digest: " << status;

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -608,7 +608,9 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
           status = switch_interface_->SendStreamMessageRequest(node_id, req);
         }
         if (!status.ok()) {
-          LOG_EVERY_N(INFO, 500) << "Failed to ack digest: " << status;
+          LOG(INFO) << "Failed to ack digest: " << status;
+          // TODO(max): investigate if creating response for every failure is
+          // too resource intensive.
           auto resp = ToStreamMessageResponse(status);
           *resp.mutable_error()
                ->mutable_digest_list_ack()
@@ -884,9 +886,8 @@ void P4Service::StreamResponseReceiveHandler(
     uint64 node_id, const ::p4::v1::StreamMessageResponse& resp) {
   // We don't expect arbitration updates from the switch.
   if (resp.has_arbitration()) {
-    LOG(ERROR) << "Received MasterArbitrationUpdate from switch. This should "
+    LOG(FATAL) << "Received MasterArbitrationUpdate from switch. This should "
                   "never happen!";
-    return;
   }
   // We send the responses only to the master controller stream for this node.
   absl::ReaderMutexLock l(&controller_lock_);

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -891,14 +891,14 @@ TEST_P(P4ServiceTest, StreamChannelSuccess) {
   EXPECT_CALL(*switch_mock_, RegisterStreamMessageResponseWriter(kNodeId1, _))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*switch_mock_,
-              SendStreamMessageRequest(kNodeId1, EqualsProto(req1)))
+              HandleStreamMessageRequest(kNodeId1, EqualsProto(req1)))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*switch_mock_,
-              SendStreamMessageRequest(kNodeId1, EqualsProto(req2)))
+              HandleStreamMessageRequest(kNodeId1, EqualsProto(req2)))
       .WillOnce(Return(::util::Status(StratumErrorSpace(), ERR_INVALID_PARAM,
                                       kOperErrorMsg)));
   EXPECT_CALL(*switch_mock_,
-              SendStreamMessageRequest(kNodeId1, EqualsProto(req3)))
+              HandleStreamMessageRequest(kNodeId1, EqualsProto(req3)))
       .WillOnce(Return(::util::OkStatus()));
 
   //----------------------------------------------------------------------------

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -83,7 +83,15 @@ class P4ServiceTest : public ::testing::TestWithParam<OperationMode> {
   void TearDown() override { server_->Shutdown(); }
 
   void OnPacketReceive(const ::p4::v1::PacketIn& packet) {
-    p4_service_->PacketReceiveHandler(kNodeId1, packet);
+    ::p4::v1::StreamMessageResponse resp;
+    *resp.mutable_packet() = packet;
+    p4_service_->StreamResponseReceiveHandler(kNodeId1, resp);
+  }
+
+  void OnDigestListReceive(const ::p4::v1::DigestList& digest) {
+    ::p4::v1::StreamMessageResponse resp;
+    *resp.mutable_digest() = digest;
+    p4_service_->StreamResponseReceiveHandler(kNodeId1, resp);
   }
 
   void FillTestForwardingPipelineConfigsAndSave(
@@ -159,6 +167,15 @@ class P4ServiceTest : public ::testing::TestWithParam<OperationMode> {
   )";
   static constexpr char kTestPacketMetadata4[] = R"(
   )";
+  static constexpr char kTestDigestList1[] = R"(
+      digest_id: 123456
+      list_id: 654321
+      timestamp: 1234567890
+  )";
+  static constexpr char kTestDigestListAck1[] = R"(
+      digest_id: 123456
+      list_id: 654321
+  )";
   static constexpr char kOperErrorMsg[] = "Some error";
   static constexpr char kAggrErrorMsg[] = "A few errors happened";
   static constexpr uint64 kNodeId1 = 123123123;
@@ -185,6 +202,8 @@ constexpr char P4ServiceTest::kTestPacketMetadata1[];
 constexpr char P4ServiceTest::kTestPacketMetadata2[];
 constexpr char P4ServiceTest::kTestPacketMetadata3[];
 constexpr char P4ServiceTest::kTestPacketMetadata4[];
+constexpr char P4ServiceTest::kTestDigestList1[];
+constexpr char P4ServiceTest::kTestDigestListAck1[];
 constexpr char P4ServiceTest::kOperErrorMsg[];
 constexpr char P4ServiceTest::kAggrErrorMsg[];
 constexpr uint64 P4ServiceTest::kNodeId1;
@@ -852,21 +871,45 @@ TEST_P(P4ServiceTest, StreamChannelSuccess) {
   ASSERT_OK(ParseProtoFromString(kTestPacketMetadata3, packet3.add_metadata()));
   ASSERT_OK(ParseProtoFromString(kTestPacketMetadata4, packet4.add_metadata()));
 
+  // Sample digest lists and acks. We don't care about data.
+  ::p4::v1::DigestList digest_list1;
+  ::p4::v1::DigestListAck digest_ack1;
+  ASSERT_OK(ParseProtoFromString(kTestDigestList1, &digest_list1));
+  ASSERT_OK(ParseProtoFromString(kTestDigestListAck1, &digest_ack1));
+
+  // Sample StreamMessageRequests.
+  ::p4::v1::StreamMessageRequest req1;
+  ::p4::v1::StreamMessageRequest req2;
+  ::p4::v1::StreamMessageRequest req3;
+  *req1.mutable_packet() = packet2;
+  *req2.mutable_packet() = packet4;
+  *req3.mutable_digest_ack() = digest_ack1;
+
   EXPECT_CALL(*auth_policy_checker_mock_,
               Authorize("P4Service", "StreamChannel", _))
       .WillRepeatedly(Return(::util::OkStatus()));
-  EXPECT_CALL(*switch_mock_, RegisterPacketReceiveWriter(kNodeId1, _))
+  EXPECT_CALL(*switch_mock_, RegisterStreamMessageResponseWriter(kNodeId1, _))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*switch_mock_, TransmitPacket(kNodeId1, EqualsProto(packet2)))
+  EXPECT_CALL(*switch_mock_,
+              SendStreamMessageRequest(kNodeId1, EqualsProto(req1)))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*switch_mock_, TransmitPacket(kNodeId1, EqualsProto(packet4)))
+  EXPECT_CALL(*switch_mock_,
+              SendStreamMessageRequest(kNodeId1, EqualsProto(req2)))
       .WillOnce(Return(::util::Status(StratumErrorSpace(), ERR_INVALID_PARAM,
                                       kOperErrorMsg)));
+  EXPECT_CALL(*switch_mock_,
+              SendStreamMessageRequest(kNodeId1, EqualsProto(req3)))
+      .WillOnce(Return(::util::OkStatus()));
 
   //----------------------------------------------------------------------------
-  // Before any connection, any packet received from the controller will be
+  // Before any connection, any PacketIn received from the CPU will be
   // ignored.
   OnPacketReceive(packet3);
+
+  //----------------------------------------------------------------------------
+  // Before any connection, any digest list received from the switch will be
+  // ignored.
+  OnDigestListReceive(digest_list1);
 
   //----------------------------------------------------------------------------
   // Now start with making the stream channels for all the controllers. We use
@@ -1027,6 +1070,11 @@ TEST_P(P4ServiceTest, StreamChannelSuccess) {
   ASSERT_TRUE(ProtoEqual(resp.error().packet_out().packet_out(), packet4));
 
   //----------------------------------------------------------------------------
+  // Controller #2 sends some digest ack.
+  *req.mutable_digest_ack() = digest_ack1;
+  ASSERT_TRUE(stream2->Write(req));
+
+  //----------------------------------------------------------------------------
   // Controller #1 tries sends some packet out too. However its packet will be
   // dropped as it is not master any more and a stream error will be generated.
   *req.mutable_packet() = packet1;
@@ -1034,6 +1082,16 @@ TEST_P(P4ServiceTest, StreamChannelSuccess) {
   ASSERT_TRUE(stream1->Read(&resp));
   ASSERT_EQ(::google::rpc::PERMISSION_DENIED, resp.error().canonical_code());
   ASSERT_TRUE(ProtoEqual(resp.error().packet_out().packet_out(), packet1));
+
+  //----------------------------------------------------------------------------
+  // Controller #1 tries sends some digest ack out too. However its ack will be
+  // dropped as it is not master any more and a stream error will be generated.
+  *req.mutable_digest_ack() = digest_ack1;
+  ASSERT_TRUE(stream1->Write(req));
+  ASSERT_TRUE(stream1->Read(&resp));
+  ASSERT_EQ(::google::rpc::PERMISSION_DENIED, resp.error().canonical_code());
+  ASSERT_TRUE(ProtoEqual(resp.error().digest_list_ack().digest_list_ack(),
+                         digest_ack1));
 
   //----------------------------------------------------------------------------
   // Controller #3 connects. Master will be still Controller #2, as it has the
@@ -1081,6 +1139,14 @@ TEST_P(P4ServiceTest, StreamChannelSuccess) {
 
   ASSERT_TRUE(stream3->Read(&resp));
   ASSERT_TRUE(ProtoEqual(resp.packet(), packet3));
+
+  //----------------------------------------------------------------------------
+  // We receive some digest from switch. This will be forwarded to the master
+  // which is Controller #3.
+  OnDigestListReceive(digest_list1);
+
+  ASSERT_TRUE(stream3->Read(&resp));
+  ASSERT_TRUE(ProtoEqual(resp.digest(), digest_list1));
 
   //----------------------------------------------------------------------------
   // Now Controller #1 disconnects. In this case there will be no mastership
@@ -1190,7 +1256,7 @@ TEST_P(P4ServiceTest, StreamChannelFailureWhenRegisterHandlerFails) {
   EXPECT_CALL(*auth_policy_checker_mock_,
               Authorize("P4Service", "StreamChannel", _))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*switch_mock_, RegisterPacketReceiveWriter(kNodeId1, _))
+  EXPECT_CALL(*switch_mock_, RegisterStreamMessageResponseWriter(kNodeId1, _))
       .WillOnce(Return(
           ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kOperErrorMsg)));
 
@@ -1219,7 +1285,7 @@ TEST_P(P4ServiceTest, StreamChannelFailureForTooManyControllersPerNode) {
   EXPECT_CALL(*auth_policy_checker_mock_,
               Authorize("P4Service", "StreamChannel", _))
       .WillRepeatedly(Return(::util::OkStatus()));
-  EXPECT_CALL(*switch_mock_, RegisterPacketReceiveWriter(kNodeId1, _))
+  EXPECT_CALL(*switch_mock_, RegisterStreamMessageResponseWriter(kNodeId1, _))
       .WillOnce(Return(::util::OkStatus()));
 
   req.mutable_arbitration()->set_device_id(kNodeId1);

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -165,7 +165,7 @@ class SwitchInterface {
   virtual ::util::Status UnregisterStreamMessageResponseWriter(
       uint64 node_id) = 0;
 
-  // Sends a request received from the controller to the given node. A
+  // Handles a request received from the controller on the given node. A
   // StreamMessageRequest can carry PacketOuts, digest acks, or other
   // platform-specific requests.
   // PacketOuts: Transmits a packet received from controller directly to a

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -173,7 +173,7 @@ class SwitchInterface {
   //      pipeline of the node to let the chip route the packet. The given
   //      ::p4::PacketOut instance includes all the info on where to transmit
   //      the packet as well as its payload.
-  // DigestListAck: Acknowledges the recival of a previously sent DigestList.
+  // DigestListAck: Acknowledges the receipt of a previously sent DigestList.
   virtual ::util::Status SendStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) = 0;
 

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -2,21 +2,20 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_SWITCH_INTERFACE_H_
 #define STRATUM_HAL_LIB_COMMON_SWITCH_INTERFACE_H_
 
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
 
+#include "p4/v1/p4runtime.grpc.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/gnmi_events.h"
 #include "stratum/hal/lib/common/writer_interface.h"
 #include "stratum/lib/channel/channel.h"
-#include "p4/v1/p4runtime.grpc.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -169,6 +168,20 @@ class SwitchInterface {
   // payload.
   virtual ::util::Status TransmitPacket(uint64 node_id,
                                         const ::p4::v1::PacketOut& packet) = 0;
+
+  // Registers a writer to be invoked when we receive a digest list on the
+  // specified node.
+  virtual ::util::Status RegisterDigestReceiveWriter(
+      uint64 node_id,
+      std::shared_ptr<WriterInterface<::p4::v1::DigestList>> writer) = 0;
+
+  // Unregisters the writer registered to this node by
+  // RegisterDigestReceiveWriter().
+  virtual ::util::Status UnregisterDigestReceiveWriter(uint64 node_id) = 0;
+
+  // Acknowledges the recival of a previously sent DigestList.
+  virtual ::util::Status AckDigestList(uint64 node_id,
+                                       const ::p4::v1::DigestListAck& ack) = 0;
 
   // Registers a writer for sending gNMI events.
   virtual ::util::Status RegisterEventNotifyWriter(

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -149,39 +149,33 @@ class SwitchInterface {
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) = 0;
 
-  // Registers a writer to be invoked when we receive a packet on any port on
-  // the specified node which are destined for the controller. The sent
-  // ::p4::PacketIn instance includes all the info on where the packet was
-  // received on this node as well as its payload.
-  virtual ::util::Status RegisterPacketReceiveWriter(
+  // Registers a writer to be invoked when we receive a StreamMessageResponse on
+  // the specified node which are destined for the controller. A
+  // StreamMessageResponse can carry many different types of sub-messages, such
+  // as PacketIns, digests or idle timeout notifications.
+  // PacketIns: The sent ::p4::PacketIn instance includes all the info on
+  //      where the packet was received on this node as well as its payload.
+  virtual ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) = 0;
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>
+          writer) = 0;
 
   // Unregisters the writer registered to this node by
-  // RegisterPacketReceiveWriter().
-  virtual ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) = 0;
+  // RegisterStreamMessageResponseWriter().
+  virtual ::util::Status UnregisterStreamMessageResponseWriter(
+      uint64 node_id) = 0;
 
-  // Transmits a packet received from controller directly to a port on a given
-  // node (specified by 'node_id') or to the ingress pipeline of the node
-  // to let the chip route the packet. The given ::p4::PacketOut instance
-  // includes all the info on where to transmit the packet as well as its
-  // payload.
-  virtual ::util::Status TransmitPacket(uint64 node_id,
-                                        const ::p4::v1::PacketOut& packet) = 0;
-
-  // Registers a writer to be invoked when we receive a digest list on the
-  // specified node.
-  virtual ::util::Status RegisterDigestReceiveWriter(
-      uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::DigestList>> writer) = 0;
-
-  // Unregisters the writer registered to this node by
-  // RegisterDigestReceiveWriter().
-  virtual ::util::Status UnregisterDigestReceiveWriter(uint64 node_id) = 0;
-
-  // Acknowledges the recival of a previously sent DigestList.
-  virtual ::util::Status AckDigestList(uint64 node_id,
-                                       const ::p4::v1::DigestListAck& ack) = 0;
+  // Sends a request received from the controller to the given node. A
+  // StreamMessageRequest can carry PacketOuts, digest acks, or other
+  // platform-specific requests.
+  // PacketOuts: Transmits a packet received from controller directly to a
+  //      port on a given node (specified by 'node_id') or to the ingress
+  //      pipeline of the node to let the chip route the packet. The given
+  //      ::p4::PacketOut instance includes all the info on where to transmit
+  //      the packet as well as its payload.
+  // DigestListAck: Acknowledges the recival of a previously sent DigestList.
+  virtual ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request) = 0;
 
   // Registers a writer for sending gNMI events.
   virtual ::util::Status RegisterEventNotifyWriter(

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -174,7 +174,7 @@ class SwitchInterface {
   //      ::p4::PacketOut instance includes all the info on where to transmit
   //      the packet as well as its payload.
   // DigestListAck: Acknowledges the receipt of a previously sent DigestList.
-  virtual ::util::Status SendStreamMessageRequest(
+  virtual ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) = 0;
 
   // Registers a writer for sending gNMI events.

--- a/stratum/hal/lib/common/switch_mock.h
+++ b/stratum/hal/lib/common/switch_mock.h
@@ -52,7 +52,7 @@ class SwitchMock : public SwitchInterface {
               writer));
   MOCK_METHOD1(UnregisterStreamMessageResponseWriter,
                ::util::Status(uint64 node_id));
-  MOCK_METHOD2(SendStreamMessageRequest,
+  MOCK_METHOD2(HandleStreamMessageRequest,
                ::util::Status(uint64 node_id,
                               const ::p4::v1::StreamMessageRequest& request));
   MOCK_METHOD1(

--- a/stratum/hal/lib/common/switch_mock.h
+++ b/stratum/hal/lib/common/switch_mock.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_SWITCH_MOCK_H_
 #define STRATUM_HAL_LIB_COMMON_SWITCH_MOCK_H_
 
@@ -10,8 +9,8 @@
 #include <string>
 #include <vector>
 
-#include "stratum/hal/lib/common/switch_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/common/switch_interface.h"
 
 namespace stratum {
 namespace hal {
@@ -30,9 +29,7 @@ class SwitchMock : public SwitchInterface {
       SaveForwardingPipelineConfig,
       ::util::Status(uint64 node_id,
                      const ::p4::v1::ForwardingPipelineConfig& config));
-  MOCK_METHOD1(
-      CommitForwardingPipelineConfig,
-      ::util::Status(uint64 node_id));
+  MOCK_METHOD1(CommitForwardingPipelineConfig, ::util::Status(uint64 node_id));
   MOCK_METHOD2(
       VerifyForwardingPipelineConfig,
       ::util::Status(uint64 node_id,
@@ -48,14 +45,16 @@ class SwitchMock : public SwitchInterface {
                               WriterInterface<::p4::v1::ReadResponse>* writer,
                               std::vector<::util::Status>* details));
   MOCK_METHOD2(
-      RegisterPacketReceiveWriter,
+      RegisterStreamMessageResponseWriter,
       ::util::Status(
           uint64 node_id,
-          std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer));
-  MOCK_METHOD1(UnregisterPacketReceiveWriter, ::util::Status(uint64 node_id));
-  MOCK_METHOD2(TransmitPacket,
+          std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>
+              writer));
+  MOCK_METHOD1(UnregisterStreamMessageResponseWriter,
+               ::util::Status(uint64 node_id));
+  MOCK_METHOD2(SendStreamMessageRequest,
                ::util::Status(uint64 node_id,
-                              const ::p4::v1::PacketOut& packet));
+                              const ::p4::v1::StreamMessageRequest& request));
   MOCK_METHOD1(
       RegisterEventNotifyWriter,
       ::util::Status(std::shared_ptr<WriterInterface<GnmiEventPtr>> writer));

--- a/stratum/hal/lib/common/writer_interface.h
+++ b/stratum/hal/lib/common/writer_interface.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
 #define STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
 
@@ -24,6 +23,31 @@ class WriterInterface {
  protected:
   // Default constructor. To be called by the Mock class instance only.
   WriterInterface() {}
+};
+
+// Wrapper for WriterInterface class which constrains the allowed protobuf
+// message type to one specific embedded message. It can be used when we have a
+// channel for a generic message with embedded oneof submessages and want to
+// restrict write access to only one specific oneof message. This allows using
+// the same channel across different writers, while maintaining type safety
+// without the need for extra channels and threads.
+template <typename T, typename R>
+class ConstraintWriterWrapper : public WriterInterface<R> {
+ public:
+  explicit ConstraintWriterWrapper(std::shared_ptr<WriterInterface<T>> writer,
+                                   R* (T::*get_mutable_inner_message)())
+      : writer_(std::move(writer)),
+        get_mutable_inner_message_(get_mutable_inner_message) {}
+  bool Write(const R& msg) override {
+    if (!writer_) return false;
+    T t;
+    *(t.*get_mutable_inner_message_)() = msg;
+    return writer_->Write(t);
+  }
+
+ private:
+  std::shared_ptr<WriterInterface<T>> writer_;
+  R* (T::*get_mutable_inner_message_)();
 };
 
 }  // namespace hal

--- a/stratum/hal/lib/common/writer_interface.h
+++ b/stratum/hal/lib/common/writer_interface.h
@@ -5,6 +5,9 @@
 #ifndef STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
 #define STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
 
+#include <memory>
+#include <utility>
+
 namespace stratum {
 namespace hal {
 

--- a/stratum/hal/lib/dummy/dummy_node.cc
+++ b/stratum/hal/lib/dummy/dummy_node.cc
@@ -94,7 +94,7 @@ namespace dummy_switch {
   return ::util::OkStatus();
 }
 
-::util::Status DummyNode::SendStreamMessageRequest(
+::util::Status DummyNode::HandleStreamMessageRequest(
     const ::p4::v1::StreamMessageRequest& request) {
   // TODO(Yi Tseng): Implement this method.
   absl::WriterMutexLock l(&node_lock_);

--- a/stratum/hal/lib/dummy/dummy_node.cc
+++ b/stratum/hal/lib/dummy/dummy_node.cc
@@ -82,19 +82,20 @@ namespace dummy_switch {
   return ::util::OkStatus();
 }
 
-::util::Status DummyNode::RegisterPacketReceiveWriter(
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+::util::Status DummyNode::RegisterStreamMessageResponseWriter(
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   // TODO(Yi Tseng): Implement this method.
   absl::WriterMutexLock l(&node_lock_);
   return ::util::OkStatus();
 }
-::util::Status DummyNode::UnregisterPacketReceiveWriter() {
+::util::Status DummyNode::UnregisterStreamMessageResponseWriter() {
   // TODO(Yi Tseng): Implement this method.
   absl::WriterMutexLock l(&node_lock_);
   return ::util::OkStatus();
 }
 
-::util::Status DummyNode::TransmitPacket(const ::p4::v1::PacketOut& packet) {
+::util::Status DummyNode::SendStreamMessageRequest(
+    const ::p4::v1::StreamMessageRequest& request) {
   // TODO(Yi Tseng): Implement this method.
   absl::WriterMutexLock l(&node_lock_);
   return ::util::OkStatus();

--- a/stratum/hal/lib/dummy/dummy_node.h
+++ b/stratum/hal/lib/dummy/dummy_node.h
@@ -94,17 +94,18 @@ class DummyNode {
   // The node should sends P4Runtime PacketIn message to the writer
   // if any message or packet comes from the dataplane.
   // The node may add/remove metadata to/from the packet in message.
-  ::util::Status RegisterPacketReceiveWriter(
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer)
+  ::util::Status RegisterStreamMessageResponseWriter(
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(node_lock_);
-  ::util::Status UnregisterPacketReceiveWriter()
+  ::util::Status UnregisterStreamMessageResponseWriter()
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(node_lock_);
 
   // Transmit a packet to the dataplane.
   // The packet out message should contains necessary metadata for the dataplane
   // to handle the packet payload.
   // The node may add/remove metadata to/from the message.
-  ::util::Status TransmitPacket(const ::p4::v1::PacketOut& packet)
+  ::util::Status SendStreamMessageRequest(
+      const ::p4::v1::StreamMessageRequest& request)
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(node_lock_);
 
   // Retrieve port data from this node

--- a/stratum/hal/lib/dummy/dummy_node.h
+++ b/stratum/hal/lib/dummy/dummy_node.h
@@ -100,10 +100,11 @@ class DummyNode {
   ::util::Status UnregisterStreamMessageResponseWriter()
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(node_lock_);
 
-  // Transmit a packet to the dataplane.
-  // The packet out message should contains necessary metadata for the dataplane
-  // to handle the packet payload.
-  // The node may add/remove metadata to/from the message.
+  // Handle a StreamMessageRequest from the controller.
+  // PacketOuts:
+  //    The packet out message should contains necessary metadata for the
+  //    dataplane to handle the packet payload. The node may add/remove metadata
+  //    to/from the message.
   ::util::Status HandleStreamMessageRequest(
       const ::p4::v1::StreamMessageRequest& request)
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(node_lock_);

--- a/stratum/hal/lib/dummy/dummy_node.h
+++ b/stratum/hal/lib/dummy/dummy_node.h
@@ -104,7 +104,7 @@ class DummyNode {
   // The packet out message should contains necessary metadata for the dataplane
   // to handle the packet payload.
   // The node may add/remove metadata to/from the message.
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       const ::p4::v1::StreamMessageRequest& request)
       SHARED_LOCKS_REQUIRED(chassis_lock) LOCKS_EXCLUDED(node_lock_);
 

--- a/stratum/hal/lib/dummy/dummy_switch.cc
+++ b/stratum/hal/lib/dummy/dummy_switch.cc
@@ -177,31 +177,32 @@ namespace dummy_switch {
   return node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status DummySwitch::RegisterPacketReceiveWriter(
+::util::Status DummySwitch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   absl::ReaderMutexLock l(&chassis_lock);
   LOG(INFO) << __FUNCTION__;
   DummyNode* node = nullptr;
   ASSIGN_OR_RETURN(node, GetDummyNode(node_id));
-  return node->RegisterPacketReceiveWriter(writer);
+  return node->RegisterStreamMessageResponseWriter(writer);
 }
 
-::util::Status DummySwitch::UnregisterPacketReceiveWriter(uint64 node_id) {
+::util::Status DummySwitch::UnregisterStreamMessageResponseWriter(
+    uint64 node_id) {
   absl::ReaderMutexLock l(&chassis_lock);
   LOG(INFO) << __FUNCTION__;
   DummyNode* node = nullptr;
   ASSIGN_OR_RETURN(node, GetDummyNode(node_id));
-  return node->UnregisterPacketReceiveWriter();
+  return node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status DummySwitch::TransmitPacket(uint64 node_id,
-                                           const ::p4::v1::PacketOut& packet) {
+::util::Status DummySwitch::SendStreamMessageRequest(
+    uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&chassis_lock);
   LOG(INFO) << __FUNCTION__;
   DummyNode* node = nullptr;
   ASSIGN_OR_RETURN(node, GetDummyNode(node_id));
-  return node->TransmitPacket(packet);
+  return node->SendStreamMessageRequest(request);
 }
 
 ::util::Status DummySwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/dummy/dummy_switch.cc
+++ b/stratum/hal/lib/dummy/dummy_switch.cc
@@ -196,13 +196,13 @@ namespace dummy_switch {
   return node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status DummySwitch::SendStreamMessageRequest(
+::util::Status DummySwitch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&chassis_lock);
   LOG(INFO) << __FUNCTION__;
   DummyNode* node = nullptr;
   ASSIGN_OR_RETURN(node, GetDummyNode(node_id));
-  return node->SendStreamMessageRequest(request);
+  return node->HandleStreamMessageRequest(request);
 }
 
 ::util::Status DummySwitch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/dummy/dummy_switch.h
+++ b/stratum/hal/lib/dummy/dummy_switch.h
@@ -54,14 +54,14 @@ class DummySwitch : public SwitchInterface {
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details)
       LOCKS_EXCLUDED(chassis_lock) override;
-  ::util::Status RegisterPacketReceiveWriter(
+  ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer)
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       LOCKS_EXCLUDED(chassis_lock) override;
-  ::util::Status UnregisterPacketReceiveWriter(uint64 node_id)
+  ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id)
       LOCKS_EXCLUDED(chassis_lock) override;
-  ::util::Status TransmitPacket(uint64 node_id,
-                                const ::p4::v1::PacketOut& packet)
+  ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request)
       LOCKS_EXCLUDED(chassis_lock) override;
 
   ::util::Status RegisterEventNotifyWriter(

--- a/stratum/hal/lib/dummy/dummy_switch.h
+++ b/stratum/hal/lib/dummy/dummy_switch.h
@@ -60,7 +60,7 @@ class DummySwitch : public SwitchInterface {
       LOCKS_EXCLUDED(chassis_lock) override;
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id)
       LOCKS_EXCLUDED(chassis_lock) override;
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request)
       LOCKS_EXCLUDED(chassis_lock) override;
 

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -158,10 +158,10 @@ NP4Switch::~NP4Switch() {}
   return pi_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status NP4Switch::SendStreamMessageRequest(
+::util::Status NP4Switch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->SendStreamMessageRequest(request);
+  return pi_node->HandleStreamMessageRequest(request);
 }
 
 ::util::Status NP4Switch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -145,22 +145,23 @@ NP4Switch::~NP4Switch() {}
   return pi_node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status NP4Switch::RegisterPacketReceiveWriter(
+::util::Status NP4Switch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
-    std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) {
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->RegisterPacketReceiveWriter(writer);
+  return pi_node->RegisterStreamMessageResponseWriter(writer);
 }
 
-::util::Status NP4Switch::UnregisterPacketReceiveWriter(uint64 node_id) {
+::util::Status NP4Switch::UnregisterStreamMessageResponseWriter(
+    uint64 node_id) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->UnregisterPacketReceiveWriter();
+  return pi_node->UnregisterStreamMessageResponseWriter();
 }
 
-::util::Status NP4Switch::TransmitPacket(uint64 node_id,
-                                         const ::p4::v1::PacketOut& packet) {
+::util::Status NP4Switch::SendStreamMessageRequest(
+    uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
-  return pi_node->TransmitPacket(packet);
+  return pi_node->SendStreamMessageRequest(request);
 }
 
 ::util::Status NP4Switch::RegisterEventNotifyWriter(

--- a/stratum/hal/lib/np4intel/np4_switch.h
+++ b/stratum/hal/lib/np4intel/np4_switch.h
@@ -53,7 +53,7 @@ class NP4Switch : public SwitchInterface {
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       override;
   ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override;
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;

--- a/stratum/hal/lib/np4intel/np4_switch.h
+++ b/stratum/hal/lib/np4intel/np4_switch.h
@@ -48,12 +48,13 @@ class NP4Switch : public SwitchInterface {
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details) override;
-  ::util::Status RegisterPacketReceiveWriter(
+  ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
-      std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> writer) override;
-  ::util::Status UnregisterPacketReceiveWriter(uint64 node_id) override;
-  ::util::Status TransmitPacket(uint64 node_id,
-                                const ::p4::v1::PacketOut& packet) override;
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
+      override;
+  ::util::Status UnregisterStreamMessageResponseWriter(uint64 node_id) override;
+  ::util::Status SendStreamMessageRequest(
+      uint64 node_id, const ::p4::v1::StreamMessageRequest& request) override;
   ::util::Status RegisterEventNotifyWriter(
       std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) override;
   ::util::Status UnregisterEventNotifyWriter() override;

--- a/stratum/hal/lib/pi/BUILD
+++ b/stratum/hal/lib/pi/BUILD
@@ -1,16 +1,14 @@
 # Copyright 2018-present Barefoot Networks, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
-    "stratum_cc_test",
-    "HOST_ARCHES",
 )
 load(":bf_pi.bzl", "barefoot_pi_deps")
+
+licenses(["notice"])  # Apache v2
 
 package(
     default_visibility = STRATUM_INTERNAL,
@@ -34,13 +32,14 @@ stratum_cc_library(
     name = "pi_node",
     srcs = ["pi_node.cc"],
     hdrs = ["pi_node.h"],
-    deps = pi_node_common_deps +
-           ["@com_github_p4lang_PI//proto/frontend:pifeproto"],
+    deps = pi_node_common_deps + [
+        "@com_github_p4lang_PI//proto/frontend:pifeproto",
+    ],
 )
-
 
 # PI Node for Barefoot targets
 barefoot_pi_deps()
+
 stratum_cc_library(
     name = "pi_node_bf",
     srcs = ["pi_node.cc"],
@@ -53,6 +52,7 @@ stratum_cc_library(
     name = "pi_node_np4",
     srcs = ["pi_node.cc"],
     hdrs = ["pi_node.h"],
-    deps = pi_node_common_deps +
-           ["@com_github_p4lang_PI_np4//proto/frontend:pifeproto"],
+    deps = pi_node_common_deps + [
+        "@com_github_p4lang_PI_np4//proto/frontend:pifeproto",
+    ],
 )

--- a/stratum/hal/lib/pi/bf_pi.bzl
+++ b/stratum/hal/lib/pi/bf_pi.bzl
@@ -4,7 +4,6 @@
 load("//bazel:deps.bzl", "BF_SDE_PI_VER")
 
 def barefoot_pi_deps():
-
     pi_dep_map = {
         "//conditions:default": "@com_github_p4lang_PI_bf_9_3_0//proto/frontend:pifeproto",
     }

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -192,7 +192,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
   return ::util::OkStatus();
 }
 
-::util::Status PINode::SendStreamMessageRequest(
+::util::Status PINode::HandleStreamMessageRequest(
     const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -62,18 +62,7 @@ namespace {
 void StreamMessageCb(uint64_t node_id, ::p4::v1::StreamMessageResponse* msg,
                      void* cookie) {
   auto* pi_node = static_cast<PINode*>(cookie);
-  switch (msg->update_case()) {
-    case ::p4::v1::StreamMessageResponse::kPacket:
-      pi_node->SendPacketIn(msg->packet());
-      break;
-    case ::p4::v1::StreamMessageResponse::kDigest:
-      pi_node->SendDigestList(msg->digest());
-      break;
-    default:
-      VLOG(1) << "Dropping unknown P4Runtime stream message in node " << node_id
-              << ": " << msg->ShortDebugString() << ".";
-      break;
-  }
+  pi_node->SendStreamMessageResponse(*msg);
 }
 
 PINode::PINode(::pi::fe::proto::DeviceMgr* device_mgr, int unit)
@@ -188,8 +177,8 @@ std::unique_ptr<PINode> PINode::CreateInstance(
   return ::util::OkStatus();
 }
 
-::util::Status PINode::RegisterPacketReceiveWriter(
-    const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer) {
+::util::Status PINode::RegisterStreamMessageResponseWriter(
+    std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   absl::MutexLock l(&rx_writer_lock_);
   rx_writer_ = writer;
   // The StreamMessageCb callback is registered with the DeviceMgr instance when
@@ -197,63 +186,26 @@ std::unique_ptr<PINode> PINode::CreateInstance(
   return ::util::OkStatus();
 }
 
-::util::Status PINode::UnregisterPacketReceiveWriter() {
+::util::Status PINode::UnregisterStreamMessageResponseWriter() {
   absl::MutexLock l(&rx_writer_lock_);
   rx_writer_ = nullptr;
   return ::util::OkStatus();
 }
 
-::util::Status PINode::TransmitPacket(const ::p4::v1::PacketOut& packet) {
+::util::Status PINode::SendStreamMessageRequest(
+    const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
     RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
-  ::p4::v1::StreamMessageRequest msg;
-  // a const_cast for the sake of avoiding a copy; should be ok because
-  // stream_message_request_handle does not modify the message.
-  msg.set_allocated_packet(const_cast<::p4::v1::PacketOut*>(&packet));
-  auto status = toUtilStatus(device_mgr_->stream_message_request_handle(msg));
-  msg.release_packet();
-  return status;
+  return toUtilStatus(device_mgr_->stream_message_request_handle(request));
 }
 
-::util::Status PINode::RegisterDigestReceiveWriter(
-    const std::shared_ptr<WriterInterface<::p4::v1::DigestList>>& writer) {
-  absl::MutexLock l(&rx_writer_lock_);
-  rx_digest_list_writer_ = writer;
-  // The StreamMessageCb callback is registered with the DeviceMgr instance when
-  // the P4 forwarding pipeline is assigned.
-  return ::util::OkStatus();
-}
-
-::util::Status PINode::UnregisterDigestReceiveWriter() {
-  absl::MutexLock l(&rx_writer_lock_);
-  rx_digest_list_writer_ = nullptr;
-  return ::util::OkStatus();
-}
-
-::util::Status PINode::AckDigestList(const ::p4::v1::DigestListAck& ack) {
-  absl::ReaderMutexLock l(&lock_);
-  if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
-  }
-  ::p4::v1::StreamMessageRequest msg;
-  *msg.mutable_digest_ack() = ack;
-  return toUtilStatus(device_mgr_->stream_message_request_handle(msg));
-}
-
-void PINode::SendPacketIn(const ::p4::v1::PacketIn& packet) {
-  // acquire the lock during the Write: SendPacketIn may be called from
-  // different threads and Write is not thread-safe.
+void PINode::SendStreamMessageResponse(
+    const ::p4::v1::StreamMessageResponse& response) {
   absl::MutexLock l(&rx_writer_lock_);
   if (rx_writer_ == nullptr) return;
-  rx_writer_->Write(packet);
-}
-
-void PINode::SendDigestList(const ::p4::v1::DigestList& digest_list) {
-  absl::MutexLock l(&rx_writer_lock_);
-  if (rx_digest_list_writer_ == nullptr) return;
-  rx_digest_list_writer_->Write(digest_list);
+  rx_writer_->Write(response);
 }
 
 }  // namespace pi

--- a/stratum/hal/lib/pi/pi_node.h
+++ b/stratum/hal/lib/pi/pi_node.h
@@ -51,7 +51,7 @@ class PINode final {
       LOCKS_EXCLUDED(rx_writer_lock_);
   ::util::Status UnregisterStreamMessageResponseWriter()
       LOCKS_EXCLUDED(rx_writer_lock_);
-  ::util::Status SendStreamMessageRequest(
+  ::util::Status HandleStreamMessageRequest(
       const ::p4::v1::StreamMessageRequest& request);
 
   // Factory function for creating the instance of the class.

--- a/stratum/hal/lib/pi/pi_node.h
+++ b/stratum/hal/lib/pi/pi_node.h
@@ -52,6 +52,12 @@ class PINode final {
   ::util::Status UnregisterPacketReceiveWriter()
       LOCKS_EXCLUDED(rx_writer_lock_);
   ::util::Status TransmitPacket(const ::p4::v1::PacketOut& packet);
+  ::util::Status RegisterDigestReceiveWriter(
+      const std::shared_ptr<WriterInterface<::p4::v1::DigestList>>& writer)
+      LOCKS_EXCLUDED(rx_writer_lock_);
+  ::util::Status UnregisterDigestReceiveWriter()
+      LOCKS_EXCLUDED(rx_writer_lock_);
+  ::util::Status AckDigestList(const ::p4::v1::DigestListAck& ack);
 
   // Factory function for creating the instance of the class.
   static std::unique_ptr<PINode> CreateInstance(
@@ -72,8 +78,12 @@ class PINode final {
   friend void StreamMessageCb(uint64_t node_id,
                               p4::v1::StreamMessageResponse* msg, void* cookie);
 
-  // Write packet on the registered RX writer.
+  // Write a packet on the registered RX writer.
   void SendPacketIn(const ::p4::v1::PacketIn& packet)
+      LOCKS_EXCLUDED(rx_writer_lock_);
+
+  // Write a digest list on the registered RX writer.
+  void SendDigestList(const ::p4::v1::DigestList& digest_list)
       LOCKS_EXCLUDED(rx_writer_lock_);
 
   // Reader-writer lock used to protect access to node-specific state.
@@ -87,6 +97,10 @@ class PINode final {
 
   // RX packet handler.
   std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> rx_writer_
+      GUARDED_BY(rx_writer_lock_);
+
+  // RX digest handler.
+  std::shared_ptr<WriterInterface<::p4::v1::DigestList>> rx_digest_list_writer_
       GUARDED_BY(rx_writer_lock_);
 
   const int unit_;

--- a/stratum/hal/lib/pi/pi_node.h
+++ b/stratum/hal/lib/pi/pi_node.h
@@ -46,18 +46,13 @@ class PINode final {
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
       std::vector<::util::Status>* details);
-  ::util::Status RegisterPacketReceiveWriter(
-      const std::shared_ptr<WriterInterface<::p4::v1::PacketIn>>& writer)
+  ::util::Status RegisterStreamMessageResponseWriter(
+      std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       LOCKS_EXCLUDED(rx_writer_lock_);
-  ::util::Status UnregisterPacketReceiveWriter()
+  ::util::Status UnregisterStreamMessageResponseWriter()
       LOCKS_EXCLUDED(rx_writer_lock_);
-  ::util::Status TransmitPacket(const ::p4::v1::PacketOut& packet);
-  ::util::Status RegisterDigestReceiveWriter(
-      const std::shared_ptr<WriterInterface<::p4::v1::DigestList>>& writer)
-      LOCKS_EXCLUDED(rx_writer_lock_);
-  ::util::Status UnregisterDigestReceiveWriter()
-      LOCKS_EXCLUDED(rx_writer_lock_);
-  ::util::Status AckDigestList(const ::p4::v1::DigestListAck& ack);
+  ::util::Status SendStreamMessageRequest(
+      const ::p4::v1::StreamMessageRequest& request);
 
   // Factory function for creating the instance of the class.
   static std::unique_ptr<PINode> CreateInstance(
@@ -78,12 +73,9 @@ class PINode final {
   friend void StreamMessageCb(uint64_t node_id,
                               p4::v1::StreamMessageResponse* msg, void* cookie);
 
-  // Write a packet on the registered RX writer.
-  void SendPacketIn(const ::p4::v1::PacketIn& packet)
-      LOCKS_EXCLUDED(rx_writer_lock_);
-
-  // Write a digest list on the registered RX writer.
-  void SendDigestList(const ::p4::v1::DigestList& digest_list)
+  // Write a response on the registered RX writer.
+  void SendStreamMessageResponse(
+      const ::p4::v1::StreamMessageResponse& response)
       LOCKS_EXCLUDED(rx_writer_lock_);
 
   // Reader-writer lock used to protect access to node-specific state.
@@ -96,11 +88,7 @@ class PINode final {
   mutable absl::Mutex rx_writer_lock_;
 
   // RX packet handler.
-  std::shared_ptr<WriterInterface<::p4::v1::PacketIn>> rx_writer_
-      GUARDED_BY(rx_writer_lock_);
-
-  // RX digest handler.
-  std::shared_ptr<WriterInterface<::p4::v1::DigestList>> rx_digest_list_writer_
+  std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> rx_writer_
       GUARDED_BY(rx_writer_lock_);
 
   const int unit_;


### PR DESCRIPTION
This PR modifies the SwitchInterface to use the generic `StreamMessageRequest` and `StreamMessageResponse` data types instead of the embedded messages like `PacketIn` or `PacketOut`. Using the encapsulating message reduces the number of nearly identical functions in the interface. Switch implementations can still decide which sub-messages to support, but extending support in one implementation does not require changes to the interface anymore.

This change also includes code changes to allow passing digests lists and acks from and to the controller for Stratum-bf, as PI does most of the work and we only connect the parts.

We do not address the topic of caching and resending digests / acks in this PR. For now this problem is pushed into the switch implementations (by passing down the acks transparently).

### Design discussion

Passing down the more generic `StreamMessageResponse` channel (writer) instead of the specialized `PacketIn` weakens the type-safety of the interface: a packetio manger could write digest lists to the channel. Here are all options:

- Pass down generic `StreamMessageResponse`: weakens type-safety, most generic, no extra resources
- Split sub-messages into separate functions and channels: enlarges SwitchInterface with nearly duplicate functions, needs additional threads and channels per sub-message type
- `ConstraintChannelWriter`: no extra resources, keeps type-safety, needs somewhat specialized one-off code

TODOs:

- [x] Test this on HW
- [x] Update all implementations with new SwitchInterface function signatures

Closes #528
Closes #482