### PR TITLE
Update setup_dev_env.sh for automated testing

### DIFF
--- a/setup_dev_env.sh
+++ b/setup_dev_env.sh
@@ -30,6 +30,7 @@ Usage: $0
     [--git-name <name>]             use the provided name for git commits
     [--git-email <email>]           use the provided email for git commits
     [--git-editor <editor command>] use the provided editor for git
+    [--program <path>]              run the provided program instead of bash
     [--np4-intel]                   create NP4 Intel build environment
     [-- [Docker options]]           additional Docker options for running the container
 EOF
@@ -68,6 +69,11 @@ do
         ;;
     --git-editor)
         GIT_EDITOR="$2"
+        shift
+        shift
+        ;;
+    --program)
+        DOCKER_PROGRAM="$2"
         shift
         shift
         ;;
@@ -131,5 +137,15 @@ fi
 if [ "$NP4_INTEL" == YES ]; then
     DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -v /dev/intel-fpga-fme.0:/dev/intel-fpga-fme.0"
 fi
+
+DOCKER_GID=$(id -g $USER)
+if [ -z "$DOCKER_GID" ]; then
+    DOCKER_GID=$(id -u $USER)
+fi
+if [ -z "$DOCKER_PROGRAM" ]; then
+    DOCKER_PROGRAM="bash"
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -it"
+fi
+
 DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS $@"
-docker run $DOCKER_RUN_OPTIONS -w /stratum --user $USER -ti $IMAGE_NAME bash
+docker run $DOCKER_RUN_OPTIONS -w /stratum --user $USER:$DOCKER_GID $IMAGE_NAME $DOCKER_PROGRAM

--- a/setup_dev_env.sh
+++ b/setup_dev_env.sh
@@ -31,6 +31,7 @@ Usage: $0
     [--git-email <email>]           use the provided email for git commits
     [--git-editor <editor command>] use the provided editor for git
     [--program <path>]              run the provided program instead of bash
+                                    for example: /stratum/tools/run_unit_tests.sh
     [--np4-intel]                   create NP4 Intel build environment
     [-- [Docker options]]           additional Docker options for running the container
 EOF

--- a/tools/run_unit_tests.sh
+++ b/tools/run_unit_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright 2021-present Extreme Networks, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run stratum unit tests inside the stratum dev container.
+# Run from /stratum.
+
+TEST_CMD="xargs -a .circleci/test-targets.txt bazel test"
+# --flaky_test_attempts to retry transient admin_service_test failures
+TEST_CMD="$TEST_CMD --flaky_test_attempts 5"
+eval $TEST_CMD


### PR DESCRIPTION
- Added the --program option to setup_dev_env.sh to allow invocation with a program other than bash. When this option is given, the docker container is run without -ti (though the user could add those options back in manually if needed).
- Added the run_unit_tests.sh script to the tools directory. This is intended for use with the --program option of setup_dev_env.sh
- Changed setup_dev_env.sh to use the user's group ID in the docker container. Otherwise, it defaults to using the user's UID as the GID. This can cause issues on shared systems where the user does not have sudo privileges, as the bogus GID maps to a random group, and the user cannot delete files in the .cache directory that were created with that GID. This has been tested in various environments at Extreme. Please test in your environment to verify it causes no issues.