### PR TITLE
Rename ConstraintWriterWrapper to ProtoOneofWriterWrapper

### DIFF
--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -244,6 +244,7 @@ stratum_cc_library(
         "//stratum/glue:logging",
         "//stratum/glue/status:status_macros",
         "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/common:proto_oneof_writer_wrapper",
         "//stratum/hal/lib/common:writer_interface",
         "//stratum/lib:constants",
         "//stratum/lib:macros",

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -14,6 +14,7 @@
 #include "stratum/hal/lib/barefoot/bf_pipeline_utils.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 #include "stratum/hal/lib/barefoot/bfrt_constants.h"
+#include "stratum/hal/lib/common/proto_oneof_writer_wrapper.h"
 #include "stratum/hal/lib/common/writer_interface.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
@@ -309,7 +310,7 @@ BfrtNode::~BfrtNode() = default;
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
   auto packet_in_writer =
-      std::make_shared<ConstraintWriterWrapper<::p4::v1::StreamMessageResponse,
+      std::make_shared<ProtoOneofWriterWrapper<::p4::v1::StreamMessageResponse,
                                                ::p4::v1::PacketIn>>(
           writer, &::p4::v1::StreamMessageResponse::mutable_packet);
 

--- a/stratum/hal/lib/bcm/BUILD
+++ b/stratum/hal/lib/bcm/BUILD
@@ -645,6 +645,7 @@ stratum_cc_library(
         "//stratum/glue:logging",
         "//stratum/glue/status:status_macros",
         "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/common:proto_oneof_writer_wrapper",
         "//stratum/hal/lib/common:writer_interface",
         "//stratum/hal/lib/p4:p4_table_mapper",
         "//stratum/lib:macros",

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -10,6 +10,7 @@
 #include "absl/memory/memory.h"
 #include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
+#include "stratum/hal/lib/common/proto_oneof_writer_wrapper.h"
 #include "stratum/hal/lib/common/writer_interface.h"
 #include "stratum/lib/macros.h"
 
@@ -327,7 +328,7 @@ BcmNode::~BcmNode() {}
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
   auto packet_in_writer =
-      std::make_shared<ConstraintWriterWrapper<::p4::v1::StreamMessageResponse,
+      std::make_shared<ProtoOneofWriterWrapper<::p4::v1::StreamMessageResponse,
                                                ::p4::v1::PacketIn>>(
           writer, &::p4::v1::StreamMessageResponse::mutable_packet);
 

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -660,6 +660,11 @@ cc_library(
 )
 
 stratum_cc_library(
+    name = "proto_oneof_writer_wrapper",
+    hdrs = ["proto_oneof_writer_wrapper.h"],
+)
+
+stratum_cc_library(
     name = "server_writer_wrapper",
     hdrs = ["server_writer_wrapper.h"],
     deps = [

--- a/stratum/hal/lib/common/proto_oneof_writer_wrapper.h
+++ b/stratum/hal/lib/common/proto_oneof_writer_wrapper.h
@@ -2,8 +2,8 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
-#define STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
+#ifndef STRATUM_HAL_LIB_COMMON_PROTO_ONEOF_WRITER_WRAPPER_H_
+#define STRATUM_HAL_LIB_COMMON_PROTO_ONEOF_WRITER_WRAPPER_H_
 
 #include <memory>
 #include <utility>
@@ -20,9 +20,9 @@ namespace hal {
 // the same channel across different writers, while maintaining type safety
 // without the need for extra channels and threads.
 template <typename T, typename R>
-class ConstraintWriterWrapper : public WriterInterface<R> {
+class ProtoOneofWriterWrapper : public WriterInterface<R> {
  public:
-  explicit ConstraintWriterWrapper(std::shared_ptr<WriterInterface<T>> writer,
+  explicit ProtoOneofWriterWrapper(std::shared_ptr<WriterInterface<T>> writer,
                                    R* (T::*get_mutable_inner_message)())
       : writer_(std::move(writer)),
         get_mutable_inner_message_(get_mutable_inner_message) {}
@@ -41,4 +41,4 @@ class ConstraintWriterWrapper : public WriterInterface<R> {
 }  // namespace hal
 }  // namespace stratum
 
-#endif  // STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
+#endif  // STRATUM_HAL_LIB_COMMON_PROTO_ONEOF_WRITER_WRAPPER_H_

--- a/stratum/hal/lib/common/protobuf_oneof_writer_wrapper.h
+++ b/stratum/hal/lib/common/protobuf_oneof_writer_wrapper.h
@@ -1,0 +1,44 @@
+// Copyright 2018 Google LLC
+// Copyright 2018-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
+#define STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_
+
+#include <memory>
+#include <utility>
+
+#include "stratum/hal/lib/common/writer_interface.h"
+
+namespace stratum {
+namespace hal {
+
+// Wrapper for WriterInterface class which constrains the allowed protobuf
+// message type to one specific embedded message. It can be used when we have a
+// channel for a generic message with embedded oneof submessages and want to
+// restrict write access to only one specific oneof message. This allows using
+// the same channel across different writers, while maintaining type safety
+// without the need for extra channels and threads.
+template <typename T, typename R>
+class ConstraintWriterWrapper : public WriterInterface<R> {
+ public:
+  explicit ConstraintWriterWrapper(std::shared_ptr<WriterInterface<T>> writer,
+                                   R* (T::*get_mutable_inner_message)())
+      : writer_(std::move(writer)),
+        get_mutable_inner_message_(get_mutable_inner_message) {}
+  bool Write(const R& msg) override {
+    if (!writer_) return false;
+    T t;
+    *(t.*get_mutable_inner_message_)() = msg;
+    return writer_->Write(t);
+  }
+
+ private:
+  std::shared_ptr<WriterInterface<T>> writer_;
+  R* (T::*get_mutable_inner_message_)();
+};
+
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_COMMON_WRITER_INTERFACE_H_

--- a/stratum/hal/lib/common/writer_interface.h
+++ b/stratum/hal/lib/common/writer_interface.h
@@ -28,31 +28,6 @@ class WriterInterface {
   WriterInterface() {}
 };
 
-// Wrapper for WriterInterface class which constrains the allowed protobuf
-// message type to one specific embedded message. It can be used when we have a
-// channel for a generic message with embedded oneof submessages and want to
-// restrict write access to only one specific oneof message. This allows using
-// the same channel across different writers, while maintaining type safety
-// without the need for extra channels and threads.
-template <typename T, typename R>
-class ConstraintWriterWrapper : public WriterInterface<R> {
- public:
-  explicit ConstraintWriterWrapper(std::shared_ptr<WriterInterface<T>> writer,
-                                   R* (T::*get_mutable_inner_message)())
-      : writer_(std::move(writer)),
-        get_mutable_inner_message_(get_mutable_inner_message) {}
-  bool Write(const R& msg) override {
-    if (!writer_) return false;
-    T t;
-    *(t.*get_mutable_inner_message_)() = msg;
-    return writer_->Write(t);
-  }
-
- private:
-  std::shared_ptr<WriterInterface<T>> writer_;
-  R* (T::*get_mutable_inner_message_)();
-};
-
 }  // namespace hal
 }  // namespace stratum
 


### PR DESCRIPTION
In retrospect, this class should have gone into its own file, like [ChannelWriterWrapper](https://github.com/stratum/stratum/blob/master/stratum/hal/lib/common/channel_writer_wrapper.h).