### PR TITLE
Update reference links to stratum main branch

### DIFF
--- a/.circleci/check-cpp-format.sh
+++ b/.circleci/check-cpp-format.sh
@@ -5,8 +5,8 @@
 #
 set -ex
 
-# Files in this branch that are different from master.
-CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/master -- '*.h' '*.cc')
+# Files in this branch that are different from main.
+CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/main -- '*.h' '*.cc')
 
 # List of files that are already formatted.
 read -r -d '\0' KNOWN_FILES << EOF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@ version: 2.1
 
 # Cache Bazel output root (see bazelrc) to speed up job execution time.
 # The idea is to use the last cache available for the same branch, or the one
-# from master if this is the first build for this branch.
+# from main if this is the first build for this branch.
 # TODO: consider using Bazel remote cache (e.g. local HTTP proxy cache backed by S3)
 restore_bazel_cache: &restore_bazel_cache
   restore_cache:
     keys:
       - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
       - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}
-      - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-master
+      - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-main
 save_bazel_cache: &save_bazel_cache
   save_cache:
     # Always saving the cache, even in case of failures, helps with completing
@@ -389,7 +389,7 @@ workflows:
       - publish-docker-build:
           filters:
             branches:
-              only: master
+              only: main
       - publish-docker-mininet:
           requires:
             - publish-docker-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,4 +53,4 @@ Some additional points:
 ## Community Guidelines
 
 This project follows [Google's Open Source Community
-Guidelines](https://opensource.google.com/conduct/) and ONF's [Code of Conduct](https://github.com/stratum/stratum/blob/master/CODE_OF_CONDUCT.md).
+Guidelines](https://opensource.google.com/conduct/) and ONF's [Code of Conduct](https://github.com/stratum/stratum/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,4 +53,4 @@ Some additional points:
 ## Community Guidelines
 
 This project follows [Google's Open Source Community
-Guidelines](https://opensource.google.com/conduct/) and ONF's [Code of Conduct](https://github.com/stratum/stratum/blob/main/CODE_OF_CONDUCT.md).
+Guidelines](https://opensource.google.com/conduct/) and ONF's [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Copyright 2018-present Open Networking Foundation
 
 Stratum is an open source silicon-independent switch operating system for software defined networks. It is building an open, minimal production-ready distribution for white box switches. Stratum exposes a set of next-generation SDN interfaces including P4Runtime and OpenConfig, enabling interchangeability of forwarding devices and programmability of forwarding behaviors. Current support includes Barefoot Tofino and Broadcom Tomahawk devices, as well as the bmv2 software switch.
 
-Build status (master): [![CircleCI](https://circleci.com/gh/stratum/stratum/tree/master.svg?style=svg)](https://circleci.com/gh/stratum/stratum/tree/master)
-[![codecov](https://codecov.io/gh/stratum/stratum/branch/master/graph/badge.svg)](https://codecov.io/gh/stratum/stratum)
+Build status (main): [![CircleCI](https://circleci.com/gh/stratum/stratum/tree/main.svg?style=svg)](https://circleci.com/gh/stratum/stratum/tree/main)
+[![codecov](https://codecov.io/gh/stratum/stratum/branch/main/graph/badge.svg)](https://codecov.io/gh/stratum/stratum)
 
 # Documentation
 

--- a/stratum/docs/setup_guide_barefoot_tofino_onos.md
+++ b/stratum/docs/setup_guide_barefoot_tofino_onos.md
@@ -80,7 +80,7 @@ cd stratum
 ./stratum/hal/bin/barefoot/docker/start-stratum-container.sh
 ```
 
-:warning: **Important**: Huge table allocation **must** be activated on the host system, see [here](https://github.com/stratum/stratum/blob/master/stratum/hal/bin/barefoot/README.md#huge-pages--dma-allocation-error).
+:warning: **Important**: Huge table allocation **must** be activated on the host system, see [here](https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/README.md#huge-pages--dma-allocation-error).
 
 :pencil2: (Optional) You can tunnel the ports exposed by Stratum (P4Runtime, gNMI, gNOI) via SSH tunnels:
 
@@ -217,11 +217,11 @@ In case of problems with these instructions, feel free to create an issue or PR.
 
 ## Useful links
 
-- ["Running Stratum on a Barefoot Tofino based switch"](https://github.com/stratum/stratum/blob/master/stratum/hal/bin/barefoot/README.md)
+- ["Running Stratum on a Barefoot Tofino based switch"](https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/README.md)
     - mostly about building/running Stratum, not preparing the OS or integrating with ONOS
 - [fabric-tofino](https://github.com/opencord/fabric-tofino)
-- ["Running Stratum on a Barefoot Tofino based switch"](https://github.com/stratum/stratum/tree/master/stratum/hal/bin/barefoot)
-- ["Trellis+Stratum example" (Untested)](https://github.com/stratum/stratum/tree/master/tools/mininet/examples/trellis)
+- ["Running Stratum on a Barefoot Tofino based switch"](https://github.com/stratum/stratum/tree/main/stratum/hal/bin/barefoot)
+- ["Trellis+Stratum example" (Untested)](https://github.com/stratum/stratum/tree/main/tools/mininet/examples/trellis)
 - [ONL building](https://opennetlinux.org/doc-building.html)
 - [stratum-bf Docker](https://registry.hub.docker.com/r/stratumproject/stratum-bf)
 - [ONOS CLI](https://wiki.onosproject.org/display/ONOS/Appendix+A+%3A+CLI+commands)

--- a/stratum/docs/setup_guide_barefoot_tofino_onos.md
+++ b/stratum/docs/setup_guide_barefoot_tofino_onos.md
@@ -80,7 +80,7 @@ cd stratum
 ./stratum/hal/bin/barefoot/docker/start-stratum-container.sh
 ```
 
-:warning: **Important**: Huge table allocation **must** be activated on the host system, see [here](https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/README.md#huge-pages--dma-allocation-error).
+:warning: **Important**: Huge table allocation **must** be activated on the host system, see [here](/stratum/hal/bin/barefoot/README.md#huge-pages--dma-allocation-error).
 
 :pencil2: (Optional) You can tunnel the ports exposed by Stratum (P4Runtime, gNMI, gNOI) via SSH tunnels:
 
@@ -217,11 +217,11 @@ In case of problems with these instructions, feel free to create an issue or PR.
 
 ## Useful links
 
-- ["Running Stratum on a Barefoot Tofino based switch"](https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/README.md)
+- ["Running Stratum on a Barefoot Tofino based switch"](/stratum/hal/bin/barefoot/README.md)
     - mostly about building/running Stratum, not preparing the OS or integrating with ONOS
 - [fabric-tofino](https://github.com/opencord/fabric-tofino)
-- ["Running Stratum on a Barefoot Tofino based switch"](https://github.com/stratum/stratum/tree/main/stratum/hal/bin/barefoot)
-- ["Trellis+Stratum example" (Untested)](https://github.com/stratum/stratum/tree/main/tools/mininet/examples/trellis)
+- ["Running Stratum on a Barefoot Tofino based switch"](/stratum/hal/bin/barefoot)
+- ["Trellis+Stratum example" (Untested)](/tools/mininet/examples/trellis)
 - [ONL building](https://opennetlinux.org/doc-building.html)
 - [stratum-bf Docker](https://registry.hub.docker.com/r/stratumproject/stratum-bf)
 - [ONOS CLI](https://wiki.onosproject.org/display/ONOS/Appendix+A+%3A+CLI+commands)

--- a/stratum/docs/setup_guide_barefoot_tofino_onos.md
+++ b/stratum/docs/setup_guide_barefoot_tofino_onos.md
@@ -80,7 +80,7 @@ cd stratum
 ./stratum/hal/bin/barefoot/docker/start-stratum-container.sh
 ```
 
-:warning: **Important**: Huge table allocation **must** be activated on the host system, see [here](/stratum/hal/bin/barefoot/README.md#huge-pages--dma-allocation-error).
+:warning: **Important**: Huge table allocation **must** be activated on the host system, see [here](/stratum/hal/bin/barefoot/README.run.md#huge-pages--dma-allocation-error).
 
 :pencil2: (Optional) You can tunnel the ports exposed by Stratum (P4Runtime, gNMI, gNOI) via SSH tunnels:
 

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -486,7 +486,7 @@ Either the ONL image is not correctly set up or ONLP support is simply broken on
 this particular switch model. As a workaround, [BSP mode](#Running-with-BSP-or-on-Tofino-model),
 which bypasses ONLP, is available.
 
-[start-stratum-container-sh]: https://github.com/stratum/stratum/blob/master/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+[start-stratum-container-sh]: https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
 
 ### RESOURCE_EXHAUSTED when pushing pipeline
 
@@ -550,7 +550,7 @@ E20201207 20:44:53.612030 18416 error_buffer.cc:30] (p4_service.cc:422): Failed 
 
 This error occurs when the binary pipeline is not in the correct format.
 Make sure the pipeline config binary has been packed correctly for PI node, like
-so: https://github.com/stratum/stratum/blob/master/stratum/hal/bin/barefoot/update_config.py#L39-L52.
+so: https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/update_config.py#L39-L52.
 You cannot push the compiler output (e.g. `tofino.bin`) directly.
 
 Also, consider moving to the newer [protobuf](README.pipeline.md) based pipeline

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -486,8 +486,6 @@ Either the ONL image is not correctly set up or ONLP support is simply broken on
 this particular switch model. As a workaround, [BSP mode](#Running-with-BSP-or-on-Tofino-model),
 which bypasses ONLP, is available.
 
-[start-stratum-container-sh]: https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
-
 ### RESOURCE_EXHAUSTED when pushing pipeline
 
 Stratum rejects a SetForwardingPipelineConfig request with a RESOURCE_EXHAUSTED
@@ -550,7 +548,7 @@ E20201207 20:44:53.612030 18416 error_buffer.cc:30] (p4_service.cc:422): Failed 
 
 This error occurs when the binary pipeline is not in the correct format.
 Make sure the pipeline config binary has been packed correctly for PI node, like
-so: https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/update_config.py#L39-L52.
+so: [update_config.py](/stratum/hal/bin/barefoot/update_config.py#L39-L52).
 You cannot push the compiler output (e.g. `tofino.bin`) directly.
 
 Also, consider moving to the newer [protobuf](README.pipeline.md) based pipeline

--- a/stratum/lib/security/README.md
+++ b/stratum/lib/security/README.md
@@ -37,4 +37,4 @@ To start Stratum with SSL/TLS, add the following flags:
 
 [1]:https://grpc.io/docs/guides/auth/#with-server-authentication-ssltls-5
 [2]:https://www.openssl.org/
-[3]:https://github.com/stratum/stratum/blob/master/tools/tls/generate-certs.sh
+[3]:https://github.com/stratum/stratum/blob/main/tools/tls/generate-certs.sh

--- a/stratum/lib/security/README.md
+++ b/stratum/lib/security/README.md
@@ -37,4 +37,4 @@ To start Stratum with SSL/TLS, add the following flags:
 
 [1]:https://grpc.io/docs/guides/auth/#with-server-authentication-ssltls-5
 [2]:https://www.openssl.org/
-[3]:https://github.com/stratum/stratum/blob/main/tools/tls/generate-certs.sh
+[3]:../../../tools/tls/generate-certs.sh

--- a/tools/mininet/README.md
+++ b/tools/mininet/README.md
@@ -21,7 +21,7 @@ Alternatively, you can obtain the image from Docker Hub:
 
     docker pull opennetworking/mn-stratum
 
-This image is updated daily and built from the master branch of Stratum.
+This image is updated daily and built from the main branch of Stratum.
 
 ## Run container
 


### PR DESCRIPTION
Probably not needed until next tuesday when the github scripts used to update default branch to `main`