### PR TITLE
Do not return priority for default table entries

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -446,7 +446,7 @@ struct RegisterClearThreadData {
   }
 
   // Priority.
-  // Default action do not have a priority, even when the table ususally
+  // Default actions do not have a priority, even when the table usually
   // requires one. The SDE would return 0 (highest).
   if (has_priority_field && !request.is_default_action()) {
     uint32 bf_priority;

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -445,10 +445,14 @@ struct RegisterClearThreadData {
     }
   }
 
-  // Priority.
   // Default actions do not have a priority, even when the table usually
-  // requires one. The SDE would return 0 (highest).
-  if (has_priority_field && !request.is_default_action()) {
+  // requires one. The SDE would return 0 (highest) which we must not translate.
+  if (request.is_default_action()) {
+    has_priority_field = false;
+  }
+
+  // Priority.
+  if (has_priority_field) {
     uint32 bf_priority;
     RETURN_IF_ERROR(table_key->GetPriority(&bf_priority));
     ASSIGN_OR_RETURN(uint64 p4rt_priority,

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -445,8 +445,10 @@ struct RegisterClearThreadData {
     }
   }
 
-  // Priority
-  if (has_priority_field) {
+  // Priority.
+  // Default action do not have a priority, even when the table ususally
+  // requires one. The SDE would return 0 (highest).
+  if (has_priority_field && !request.is_default_action()) {
     uint32 bf_priority;
     RETURN_IF_ERROR(table_key->GetPriority(&bf_priority));
     ASSIGN_OR_RETURN(uint64 p4rt_priority,


### PR DESCRIPTION
The the SDE returns 0 (unset, highest), which we would incorrectly translate to UINT32_MAX.