### PR TITLE
Namespace all using directives

### DIFF
--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -23,8 +23,6 @@ int switch_pci_sysfs_str_get(char* name, size_t name_size);
 #include "stratum/lib/security/auth_policy_checker.h"
 #include "stratum/lib/security/credentials_manager.h"
 
-using ::pi::fe::proto::DeviceMgr;
-
 DEFINE_string(bf_sde_install, "/usr",
               "Absolute path to the directory where the BF SDE is installed");
 DEFINE_bool(bf_switchd_background, false,
@@ -36,6 +34,8 @@ DEFINE_bool(bf_sim, false, "Run with the Tofino simulator");
 namespace stratum {
 namespace hal {
 namespace barefoot {
+
+using ::pi::fe::proto::DeviceMgr;
 
 namespace {
 

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -20,11 +20,11 @@
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 
-using ::stratum::hal::pi::PINode;
-
 namespace stratum {
 namespace hal {
 namespace barefoot {
+
+using ::stratum::hal::pi::PINode;
 
 BFSwitch::BFSwitch(PhalInterface* phal_interface,
                    BFChassisManager* bf_chassis_manager,

--- a/stratum/hal/lib/barefoot/bfrt_counter_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_counter_manager_test.cc
@@ -13,16 +13,16 @@
 #include "stratum/hal/lib/barefoot/bf_sde_mock.h"
 #include "stratum/lib/utils.h"
 
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
-
-namespace stratum {
-namespace hal {
-namespace barefoot {
 
 class BfrtCounterManagerTest : public ::testing::Test {
  protected:

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager_test.cc
@@ -14,18 +14,18 @@
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 
-using ::stratum::test_utils::EqualsProto;
-using ::stratum::test_utils::StatusIs;
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+using test_utils::EqualsProto;
+using test_utils::StatusIs;
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
-
-namespace stratum {
-namespace hal {
-namespace barefoot {
 
 class BfrtPacketioManagerTest : public ::testing::Test {
  protected:

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
@@ -12,16 +12,16 @@
 #include "stratum/hal/lib/barefoot/bf_sde_mock.h"
 #include "stratum/lib/utils.h"
 
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
-
-namespace stratum {
-namespace hal {
-namespace barefoot {
 
 class BfrtPreManagerTest : public ::testing::Test {
  protected:

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -13,14 +13,6 @@
 #include "stratum/hal/lib/barefoot/bf_sde_mock.h"
 #include "stratum/lib/utils.h"
 
-using ::testing::_;
-using ::testing::ByMove;
-using ::testing::DoAll;
-using ::testing::HasSubstr;
-using ::testing::Invoke;
-using ::testing::InvokeWithoutArgs;
-using ::testing::Return;
-
 // FIXME
 DEFINE_string(bfrt_sde_config_dir, "/var/run/stratum/bfrt_config",
               "The dir used by the SDE to load the device configuration.");
@@ -28,6 +20,14 @@ DEFINE_string(bfrt_sde_config_dir, "/var/run/stratum/bfrt_config",
 namespace stratum {
 namespace hal {
 namespace barefoot {
+
+using ::testing::_;
+using ::testing::ByMove;
+using ::testing::DoAll;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
 
 class BfrtTableManagerTest : public ::testing::Test {
  protected:

--- a/stratum/hal/lib/barefoot/utils_test.cc
+++ b/stratum/hal/lib/barefoot/utils_test.cc
@@ -15,11 +15,11 @@
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/error.pb.h"
 
-using ::testing::HasSubstr;
-
 namespace stratum {
 namespace hal {
 namespace barefoot {
+
+using ::testing::HasSubstr;
 
 TEST(DefaultRangeLowValueTest, HasFullBitwidth) {
   EXPECT_EQ(RangeDefaultLow(0).size(), 0);

--- a/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
@@ -39,6 +39,10 @@ DECLARE_string(bcm_sdk_shell_log_file);
 DECLARE_string(bcm_sdk_checkpoint_dir);
 DECLARE_string(test_tmpdir);
 
+namespace stratum {
+namespace hal {
+namespace bcm {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
@@ -47,10 +51,6 @@ using ::testing::Matcher;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::SetArgPointee;
-
-namespace stratum {
-namespace hal {
-namespace bcm {
 
 static constexpr uint64 kNodeId = 7654321ULL;
 static constexpr uint32 kPortId = 12345;

--- a/stratum/hal/lib/bcm/bcm_l2_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_l2_manager_test.cc
@@ -2,27 +2,26 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/bcm/bcm_l2_manager.h"
 
+#include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/bcm/bcm_chassis_ro_mock.h"
 #include "stratum/hal/lib/bcm/bcm_sdk_mock.h"
 #include "stratum/hal/lib/common/constants.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/substitute.h"
-
-using ::testing::_;
-using ::testing::HasSubstr;
-using ::testing::Return;
 
 namespace stratum {
 namespace hal {
 namespace bcm {
+
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::Return;
 
 MATCHER_P(DerivedFromStatus, status, "") {
   if (arg.error_code() != status.error_code()) {

--- a/stratum/hal/lib/bcm/bcm_node_test.cc
+++ b/stratum/hal/lib/bcm/bcm_node_test.cc
@@ -22,6 +22,10 @@
 #include "stratum/hal/lib/p4/p4_table_mapper_mock.h"
 #include "stratum/lib/utils.h"
 
+namespace stratum {
+namespace hal {
+namespace bcm {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::Eq;
@@ -30,10 +34,6 @@ using ::testing::InSequence;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::WithArgs;
-
-namespace stratum {
-namespace hal {
-namespace bcm {
 
 MATCHER_P(EqualsProto, proto, "") { return ProtoEqual(arg, proto); }
 

--- a/stratum/hal/lib/bcm/bcm_packetio_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_packetio_manager_test.cc
@@ -26,6 +26,10 @@
 // #include "util/libcproxy/libcwrapper.h"
 // #include "util/libcproxy/passthrough_proxy.h"
 
+namespace stratum {
+namespace hal {
+namespace bcm {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
@@ -34,10 +38,6 @@ using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::WithArgs;
-
-namespace stratum {
-namespace hal {
-namespace bcm {
 
 MATCHER_P(EqualsProto, proto, "") { return ProtoEqual(arg, proto); }
 

--- a/stratum/hal/lib/bcm/bcm_serdes_db_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_serdes_db_manager_test.cc
@@ -16,11 +16,11 @@
 DECLARE_string(test_tmpdir);
 DECLARE_string(bcm_serdes_db_proto_file);
 
-using ::testing::HasSubstr;
-
 namespace stratum {
 namespace hal {
 namespace bcm {
+
+using ::testing::HasSubstr;
 
 class BcmSerdesDbManagerTest : public ::testing::Test {
  protected:

--- a/stratum/hal/lib/bcm/bcm_switch_test.cc
+++ b/stratum/hal/lib/bcm/bcm_switch_test.cc
@@ -21,6 +21,10 @@
 #include "stratum/lib/channel/channel_mock.h"
 #include "stratum/lib/utils.h"
 
+namespace stratum {
+namespace hal {
+namespace bcm {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
@@ -31,10 +35,6 @@ using ::testing::Return;
 using ::testing::Sequence;
 using ::testing::WithArg;
 using ::testing::WithArgs;
-
-namespace stratum {
-namespace hal {
-namespace bcm {
 
 namespace {
 

--- a/stratum/hal/lib/bcm/macros_test.cc
+++ b/stratum/hal/lib/bcm/macros_test.cc
@@ -2,25 +2,22 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/bcm/macros.h"
 
-#include "stratum/glue/status/status_test_util.h"
-#include "stratum/lib/macros.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-using ::testing::HasSubstr;
+#include "stratum/glue/status/status_test_util.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {
 namespace bcm {
 
+using ::testing::HasSubstr;
+
 class BcmMacrosTest : public ::testing::Test {
  protected:
-  int FakeBcmFunc(int error_code) {
-    return error_code;
-  }
+  int FakeBcmFunc(int error_code) { return error_code; }
 
   ::util::Status FuncWithReturnIfBcmError(int error_code) {
     RETURN_IF_BCM_ERROR(FakeBcmFunc(error_code));

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -180,14 +180,14 @@ DEFINE_int32(max_num_linkscan_writers, 10,
              "Max number of linkscan event Writers supported.");
 DECLARE_string(bcm_sdk_checkpoint_dir);
 
-using ::google::protobuf::util::MessageDifferencer;
-
 // TODO(unknown): There are many CHECK_RETURN_IF_FALSE in this file which will
 // need to be changed to return ERR_INTERNAL as opposed to ERR_INVALID_PARAM.
 
 namespace stratum {
 namespace hal {
 namespace bcm {
+
+using ::google::protobuf::util::MessageDifferencer;
 
 constexpr absl::Duration BcmSdkWrapper::kWriteTimeout;
 constexpr int BcmSdkWrapper::kUdfChunkSize;

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -18,11 +18,11 @@
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 
-using ::stratum::hal::pi::PINode;
-
 namespace stratum {
 namespace hal {
 namespace bmv2 {
+
+using ::stratum::hal::pi::PINode;
 
 Bmv2Switch::Bmv2Switch(PhalInterface* phal_interface,
                        Bmv2ChassisManager* bmv2_chassis_manager,

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -32,6 +32,9 @@ DECLARE_string(chassis_config_file);
 DECLARE_string(gnmi_capabilities_file);
 DECLARE_string(test_tmpdir);
 
+namespace stratum {
+namespace hal {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
@@ -41,9 +44,6 @@ using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 using ::testing::WithArgs;
-
-namespace stratum {
-namespace hal {
 
 class Event;
 

--- a/stratum/hal/lib/common/diag_service_test.cc
+++ b/stratum/hal/lib/common/diag_service_test.cc
@@ -2,6 +2,8 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#include "stratum/hal/lib/common/diag_service.h"
+
 #include <memory>
 #include <string>
 
@@ -14,7 +16,6 @@
 #include "gtest/gtest.h"
 #include "stratum/glue/net_util/ports.h"
 #include "stratum/glue/status/status_test_util.h"
-#include "stratum/hal/lib/common/diag_service.h"
 #include "stratum/hal/lib/common/error_buffer.h"
 #include "stratum/hal/lib/common/switch_mock.h"
 #include "stratum/lib/security/auth_policy_checker_mock.h"
@@ -22,10 +23,10 @@
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
 
-using ::testing::IsEmpty;
-
 namespace stratum {
 namespace hal {
+
+using ::testing::IsEmpty;
 
 MATCHER_P(EqualsProto, proto, "") { return ProtoEqual(arg, proto); }
 
@@ -121,9 +122,9 @@ TEST_P(DiagServiceTest, GetBERTResultSuccess) {
 }
 
 INSTANTIATE_TEST_SUITE_P(DiagServiceTestWithMode, DiagServiceTest,
-                        ::testing::Values(OPERATION_MODE_STANDALONE,
-                                          OPERATION_MODE_COUPLED,
-                                          OPERATION_MODE_SIM));
+                         ::testing::Values(OPERATION_MODE_STANDALONE,
+                                           OPERATION_MODE_COUPLED,
+                                           OPERATION_MODE_SIM));
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/error_buffer_test.cc
+++ b/stratum/hal/lib/common/error_buffer_test.cc
@@ -2,27 +2,27 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/common/error_buffer.h"
 
 #include <pthread.h>
-#include <memory>
-#include <algorithm>
 
+#include <algorithm>
+#include <memory>
+
+#include "absl/memory/memory.h"
 #include "gflags/gflags.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/public/lib/error.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-
-using ::testing::HasSubstr;
 
 DECLARE_int32(max_num_errors_to_track);
 
 namespace stratum {
 namespace hal {
+
+using ::testing::HasSubstr;
 
 class ErrorBufferTest : public ::testing::Test {
  public:
@@ -77,8 +77,7 @@ TEST_F(ErrorBufferTest, SingleThreadedCase) {
       ::util::Status(StratumErrorSpace(), ERR_UNKNOWN, kErrorMsg2),
       "Some additional info: ", GTL_LOC);
   error_buffer_->AddError(
-      ::util::Status(StratumErrorSpace(), ERR_TABLE_FULL, kErrorMsg3),
-      GTL_LOC);
+      ::util::Status(StratumErrorSpace(), ERR_TABLE_FULL, kErrorMsg3), GTL_LOC);
   ASSERT_TRUE(error_buffer_->ErrorExists());
 
   // Get the errors back and verify.
@@ -114,8 +113,7 @@ TEST_F(ErrorBufferTest, MultiThreadedCase) {
   StartTestThread();
   for (int i = 0; i < FLAGS_max_num_errors_to_track / 2; ++i) {
     error_buffer_->AddError(
-        ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg1),
-        GTL_LOC);
+        ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg1), GTL_LOC);
   }
   WaitForTestThreadToDie();
   ASSERT_TRUE(error_buffer_->ErrorExists());

--- a/stratum/hal/lib/common/file_service_test.cc
+++ b/stratum/hal/lib/common/file_service_test.cc
@@ -23,10 +23,10 @@
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
 
-using ::testing::IsEmpty;
-
 namespace stratum {
 namespace hal {
+
+using ::testing::IsEmpty;
 
 MATCHER_P(EqualsProto, proto, "") { return ProtoEqual(arg, proto); }
 
@@ -143,9 +143,9 @@ TEST_P(FileServiceTest, RemoveSuccess) {
 }
 
 INSTANTIATE_TEST_SUITE_P(FileServiceTestWithMode, FileServiceTest,
-                        ::testing::Values(OPERATION_MODE_STANDALONE,
-                                          OPERATION_MODE_COUPLED,
-                                          OPERATION_MODE_SIM));
+                         ::testing::Values(OPERATION_MODE_STANDALONE,
+                                           OPERATION_MODE_COUPLED,
+                                           OPERATION_MODE_SIM));
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/gnmi_publisher_test.cc
+++ b/stratum/hal/lib/common/gnmi_publisher_test.cc
@@ -14,6 +14,9 @@
 #include "gtest/gtest.h"
 #include "absl/synchronization/mutex.h"
 
+namespace stratum {
+namespace hal {
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::HasSubstr;
@@ -23,9 +26,6 @@ using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::WithArgs;
 using ::testing::DoAll;
-
-namespace stratum {
-namespace hal {
 
 // There are two types of tests in this file, namely: ones that can be executed
 // multiple times with different paths and ones that should be executed once. To

--- a/stratum/hal/lib/common/utils_test.cc
+++ b/stratum/hal/lib/common/utils_test.cc
@@ -2,24 +2,22 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/common/utils.h"
 
-#include <string>
 #include <limits>
+#include <string>
 
-#include "stratum/lib/constants.h"
-#include "stratum/glue/status/canonical_errors.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/substitute.h"
 #include "google/protobuf/util/message_differencer.h"
-
-
-using ::google::protobuf::util::MessageDifferencer;
+#include "gtest/gtest.h"
+#include "stratum/glue/status/canonical_errors.h"
+#include "stratum/lib/constants.h"
 
 namespace stratum {
 namespace hal {
+
+using ::google::protobuf::util::MessageDifferencer;
 
 TEST(CommonUtilsTest, PrintNodeForEmptyNodeProto) {
   Node node;
@@ -425,13 +423,15 @@ TEST(DecimalUtilTest, TestFromDoubleToDecimal64) {
 
   // Some edge cases
   ::util::IsOutOfRange(
-    ConvertDoubleToDecimal64(std::numeric_limits<double>::max(), 0).status());
-  ::util::IsOutOfRange(ConvertDoubleToDecimal64(
-    std::numeric_limits<double>::min(), 0).status());
-  ::util::IsOutOfRange(ConvertDoubleToDecimal64(
-    std::numeric_limits<double>::infinity(), 0).status());
-  ::util::IsOutOfRange(ConvertDoubleToDecimal64(
-    std::numeric_limits<double>::lowest(), 0).status());
+      ConvertDoubleToDecimal64(std::numeric_limits<double>::max(), 0).status());
+  ::util::IsOutOfRange(
+      ConvertDoubleToDecimal64(std::numeric_limits<double>::min(), 0).status());
+  ::util::IsOutOfRange(
+      ConvertDoubleToDecimal64(std::numeric_limits<double>::infinity(), 0)
+          .status());
+  ::util::IsOutOfRange(
+      ConvertDoubleToDecimal64(std::numeric_limits<double>::lowest(), 0)
+          .status());
 }
 
 void DecimalToDoubleTest(int64 digits, uint32 precision, double to) {

--- a/stratum/hal/lib/np4intel/np4_chassis_manager_test.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager_test.cc
@@ -16,15 +16,15 @@
 #include "stratum/hal/lib/common/phal_mock.h"
 #include "stratum/lib/constants.h"
 
+namespace stratum {
+namespace hal {
+namespace np4intel {
+
 using ::testing::_;
 using ::testing::AtMost;
 using ::testing::Matcher;
 using ::testing::Mock;
 using ::testing::Return;
-
-namespace stratum {
-namespace hal {
-namespace np4intel {
 
 namespace {
 

--- a/stratum/hal/lib/p4/p4_action_mapper_test.cc
+++ b/stratum/hal/lib/p4/p4_action_mapper_test.cc
@@ -22,13 +22,13 @@
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/glue/status/status_test_util.h"
 
+namespace stratum {
+namespace hal {
+
 using ::testing::AnyNumber;
 using ::testing::HasSubstr;
 using ::testing::Return;
 using ::testing::ReturnRef;
-
-namespace stratum {
-namespace hal {
 
 // This hidden namespace stores constants related to the test input file.
 namespace {

--- a/stratum/hal/lib/p4/p4_config_verifier_test.cc
+++ b/stratum/hal/lib/p4/p4_config_verifier_test.cc
@@ -27,11 +27,11 @@
 DECLARE_string(match_field_error_level);
 DECLARE_string(action_field_error_level);
 
-using ::testing::HasSubstr;
-using ::gflags::FlagSaver;
-
 namespace stratum {
 namespace hal {
+
+using ::testing::HasSubstr;
+using ::gflags::FlagSaver;
 
 // This class is the P4ConfigVerifier test fixture.
 class P4ConfigVerifierTest : public testing::Test {

--- a/stratum/hal/lib/p4/p4_info_manager_test.cc
+++ b/stratum/hal/lib/p4/p4_info_manager_test.cc
@@ -19,11 +19,11 @@
 
 DECLARE_bool(skip_p4_min_objects_check);
 
-using gflags::FlagSaver;
-using ::testing::HasSubstr;
-
 namespace stratum {
 namespace hal {
+
+using gflags::FlagSaver;
+using ::testing::HasSubstr;
 
 // This class is the P4InfoManager test fixture.
 class P4InfoManagerTest : public testing::Test {

--- a/stratum/hal/lib/p4/p4_match_key_test.cc
+++ b/stratum/hal/lib/p4/p4_match_key_test.cc
@@ -19,12 +19,12 @@
 
 DECLARE_bool(enforce_bytestring_length);
 
+namespace stratum {
+namespace hal {
+
 using ::testing::Combine;
 using ::testing::HasSubstr;
 using ::testing::Range;
-
-namespace stratum {
-namespace hal {
 
 // This class is the P4MatchKey test fixture.
 class P4MatchKeyTest : public testing::Test {

--- a/stratum/hal/lib/p4/p4_static_entry_mapper_test.cc
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper_test.cc
@@ -22,13 +22,13 @@
 
 DECLARE_bool(remap_hidden_table_const_entries);
 
+namespace stratum {
+namespace hal {
+
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::HasSubstr;
 using ::testing::Return;
-
-namespace stratum {
-namespace hal {
 
 // This unnamed namespace hides the text strings that parse into static table
 // update entries for testing.  The tested updates don't need to have complete

--- a/stratum/hal/lib/p4/p4_table_mapper_test.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper_test.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/p4/p4_table_mapper.h"
 
 #include <cstdarg>
@@ -10,22 +9,22 @@
 #include <set>
 #include <string>
 
+#include "absl/memory/memory.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/p4/p4_info_manager.h"
 #include "stratum/hal/lib/p4/p4_static_entry_mapper_mock.h"
 #include "stratum/lib/utils.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/memory/memory.h"
+
+namespace stratum {
+namespace hal {
 
 using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
-
-namespace stratum {
-namespace hal {
 
 MATCHER_P(EqualsProto, proto, "") { return ProtoEqual(arg, proto); }
 
@@ -1618,8 +1617,8 @@ TEST_F(P4TableMapperTest, TestPrePushStaticEntryChangesError) {
       forwarding_pipeline_config_));
   const std::string kErrorMsg = "static-entry-error";
   EXPECT_CALL(*static_entry_mapper_mock_, HandlePrePushChanges(_, _))
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
   ::p4::v1::WriteRequest dummy_static_config;
   ::p4::v1::WriteRequest dummy_out;
   ::util::Status status = p4_table_mapper_->HandlePrePushStaticEntryChanges(
@@ -1659,8 +1658,8 @@ TEST_F(P4TableMapperTest, TestPostPushStaticEntryChangesError) {
       forwarding_pipeline_config_));
   const std::string kErrorMsg = "static-entry-error";
   EXPECT_CALL(*static_entry_mapper_mock_, HandlePostPushChanges(_, _))
-      .WillOnce(Return(
-          ::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
+      .WillOnce(
+          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
   ::p4::v1::WriteRequest dummy_static_config;
   ::p4::v1::WriteRequest dummy_out;
   ::util::Status status = p4_table_mapper_->HandlePostPushStaticEntryChanges(
@@ -1733,25 +1732,21 @@ TEST_F(P4TableMapperTest, TestHiddenTableActionID) {
 }
 
 // Tests null pointer checks.
-TEST_F(P4TableMapperTest,
-       TestNullPtrChecks) {
+TEST_F(P4TableMapperTest, TestNullPtrChecks) {
   ::util::Status status = p4_table_mapper_->MapFlowEntry(
       table_entry_, ::p4::v1::Update::INSERT, nullptr);
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.error_message(),
-              HasSubstr("Null flow_entry!"));
+  EXPECT_THAT(status.error_message(), HasSubstr("Null flow_entry!"));
 
-  status = p4_table_mapper_->MapActionProfileMember(
-      action_profile_member_, nullptr);
+  status =
+      p4_table_mapper_->MapActionProfileMember(action_profile_member_, nullptr);
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.error_message(),
-              HasSubstr("Null mapped_action!"));
+  EXPECT_THAT(status.error_message(), HasSubstr("Null mapped_action!"));
 
-  status = p4_table_mapper_->MapActionProfileGroup(
-      action_profile_group_, nullptr);
+  status =
+      p4_table_mapper_->MapActionProfileGroup(action_profile_group_, nullptr);
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.error_message(),
-              HasSubstr("Null mapped_action!"));
+  EXPECT_THAT(status.error_message(), HasSubstr("Null mapped_action!"));
 }
 
 }  // namespace hal

--- a/stratum/hal/lib/p4/p4_write_request_differ_test.cc
+++ b/stratum/hal/lib/p4/p4_write_request_differ_test.cc
@@ -8,18 +8,18 @@
 
 #include <vector>
 
-#include "google/protobuf/util/message_differencer.h"
 #include "gmock/gmock.h"
+#include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 
-using ::testing::HasSubstr;
-
 namespace stratum {
 namespace hal {
+
+using ::testing::HasSubstr;
 
 // This unnamed namespace hides the text strings that parse into static table
 // update entries for testing.  The test strings are pasted from static entry

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -14,10 +14,10 @@
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
 
-using ::testing::HasSubstr;
-
 namespace stratum {
 namespace hal {
+
+using ::testing::HasSubstr;
 
 TEST(PrintP4ObjectIDTest, TestTableID) {
   const int kBaseID = 0x12345;

--- a/stratum/hal/lib/phal/onlp/onlp_cli.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_cli.cc
@@ -1,24 +1,21 @@
 // Copyright 2019 Dell EMC
 // SPDX-License-Identifier: Apache-2.0
 
-
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
-#include "gflags/gflags.h"
 #include "absl/strings/str_split.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "gflags/gflags.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/phal/onlp/onlp_wrapper.h"
 #include "stratum/lib/macros.h"
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
-
-using namespace std;  // NOLINT
 
 namespace stratum {
 namespace hal {
@@ -29,48 +26,45 @@ namespace onlp {
 class OnlpCli {
  public:
   // All CLI queries are run on the given attribute database.
-  OnlpCli()
-      : onlp_interface_(nullptr) {}
+  OnlpCli() : onlp_interface_(nullptr) {}
 
   // Print OID List
-  ::util::Status  PrintOidList(string use_wrapper,
-    std::string stype, onlp_oid_type_flag_t type) {
-
+  ::util::Status PrintOidList(std::string use_wrapper, std::string stype,
+                              onlp_oid_type_flag_t type) {
     // call onlp directly
     if (use_wrapper == "n") {
-        biglist_t* oid_hdr_list;
+      biglist_t* oid_hdr_list;
 
-        onlp_oid_hdr_get_all(ONLP_OID_CHASSIS, type, 0, &oid_hdr_list);
+      onlp_oid_hdr_get_all(ONLP_OID_CHASSIS, type, 0, &oid_hdr_list);
 
-        biglist_t* curr_node = oid_hdr_list;
-        // std::cout << stype << " OID List:" << std::endl;
-        while (curr_node != nullptr) {
-            onlp_oid_hdr_t* oid_hdr =
-                          reinterpret_cast<onlp_oid_hdr_t*>(curr_node->data);
-            std::cout << "  oid: " << oid_hdr->id << std::endl;
-            curr_node = curr_node->next;
-        }
-        onlp_oid_get_all_free(oid_hdr_list);
+      biglist_t* curr_node = oid_hdr_list;
+      // std::cout << stype << " OID List:" << std::endl;
+      while (curr_node != nullptr) {
+        onlp_oid_hdr_t* oid_hdr =
+            reinterpret_cast<onlp_oid_hdr_t*>(curr_node->data);
+        std::cout << "  oid: " << oid_hdr->id << std::endl;
+        curr_node = curr_node->next;
+      }
+      onlp_oid_get_all_free(oid_hdr_list);
 
-    // using onlp_wrapper
+      // using onlp_wrapper
     } else {
-        ASSIGN_OR_RETURN(
-            std::vector <OnlpOid> OnlpOids,
-            onlp_interface_->GetOidList(type));
-        if (OnlpOids.size() == 0) {
-            std::cout << "no " << stype << " OIDs" << std::endl;
-            return ::util::OkStatus();
-        }
-        std::cout << stype << " OID List:" << std::endl;
-        for (unsigned int i = 0; i < OnlpOids.size(); i++) {
-            std::cout << "  " << i << ": oid: " << OnlpOids[i] << std::endl;
-        }
+      ASSIGN_OR_RETURN(std::vector<OnlpOid> OnlpOids,
+                       onlp_interface_->GetOidList(type));
+      if (OnlpOids.size() == 0) {
+        std::cout << "no " << stype << " OIDs" << std::endl;
+        return ::util::OkStatus();
+      }
+      std::cout << stype << " OID List:" << std::endl;
+      for (unsigned int i = 0; i < OnlpOids.size(); i++) {
+        std::cout << "  " << i << ": oid: " << OnlpOids[i] << std::endl;
+      }
     }
     return ::util::OkStatus();
   }
 
   // Runs the main CLI loop.
-  ::util::Status  RunCli() {
+  ::util::Status RunCli() {
     // Create the OnlpInterface object
     onlp_interface_ = OnlpWrapper::CreateSingleton();
 

--- a/stratum/hal/lib/phal/onlp/onlp_phal_cli.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_phal_cli.cc
@@ -23,8 +23,6 @@
 #include "absl/time/time.h"
 #include "re2/re2.h"
 
-using namespace std;  // NOLINT
-
 namespace stratum {
 namespace hal {
 namespace phal {

--- a/stratum/hal/lib/phal/onlp/onlp_sfp_configurator.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_sfp_configurator.cc
@@ -10,12 +10,12 @@
 
 #include "stratum/hal/lib/common/common.pb.h"
 
-using namespace google::protobuf::util;  // NOLINT
-
 namespace stratum {
 namespace hal {
 namespace phal {
 namespace onlp {
+
+using namespace google::protobuf::util;  // NOLINT
 
 OnlpSfpConfigurator::OnlpSfpConfigurator(
     std::shared_ptr<OnlpSfpDataSource> datasource, AttributeGroup* sfp_group,

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -15,12 +15,12 @@
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 
-using ::pi::fe::proto::DeviceMgr;
-using Code = ::google::rpc::Code;
-
 namespace stratum {
 namespace hal {
 namespace pi {
+
+using ::pi::fe::proto::DeviceMgr;
+using Code = ::google::rpc::Code;
 
 namespace {
 

--- a/stratum/lib/macros_test.cc
+++ b/stratum/lib/macros_test.cc
@@ -2,16 +2,15 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/lib/macros.h"
 
-#include "stratum/lib/test_utils/matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-using ::testing::HasSubstr;
+#include "stratum/lib/test_utils/matchers.h"
 
 namespace stratum {
+
+using ::testing::HasSubstr;
 
 class CommonMacrosTest : public ::testing::Test {
  protected:
@@ -32,17 +31,15 @@ class CommonMacrosTest : public ::testing::Test {
 
 TEST_F(CommonMacrosTest, AppendStatusIfError) {
   ::util::Status status = ::util::OkStatus();
-  APPEND_STATUS_IF_ERROR(
-      status, FuncWithReturnIfError(false, "Message One!     \n"));
+  APPEND_STATUS_IF_ERROR(status,
+                         FuncWithReturnIfError(false, "Message One!     \n"));
   APPEND_STATUS_IF_ERROR(
       status, FuncWithReturnIfError(true, "Message ignored!     \n"));
-  APPEND_STATUS_IF_ERROR(
-      status, FuncWithMakeError("Message Two     "));
+  APPEND_STATUS_IF_ERROR(status, FuncWithMakeError("Message Two     "));
   EXPECT_EQ(ERR_INVALID_PARAM, status.error_code());
   EXPECT_EQ(StratumErrorSpace(), status.error_space());
-  EXPECT_THAT(
-      status.error_message(),
-      HasSubstr("'cond' is false. Message One! Message Two. "));
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("'cond' is false. Message One! Message Two. "));
 }
 
 }  // namespace stratum

--- a/stratum/lib/utils.cc
+++ b/stratum/lib/utils.cc
@@ -22,9 +22,9 @@
 #include "stratum/lib/macros.h"
 #include "stratum/public/lib/error.h"
 
-using ::google::protobuf::util::MessageDifferencer;
-
 namespace stratum {
+
+using ::google::protobuf::util::MessageDifferencer;
 
 ::util::Status WriteProtoToBinFile(const ::google::protobuf::Message& message,
                                    const std::string& filename) {

--- a/stratum/p4c_backends/common/backend_pass_manager_test.cc
+++ b/stratum/p4c_backends/common/backend_pass_manager_test.cc
@@ -18,13 +18,13 @@
 
 DECLARE_string(p4c_fe_options);
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::InSequence;
 using ::testing::Return;
-
-namespace stratum {
-namespace p4c_backends {
 
 class BackendPassManagerTest : public testing::Test {
  protected:

--- a/stratum/p4c_backends/common/p4c_front_mid_real.cc
+++ b/stratum/p4c_backends/common/p4c_front_mid_real.cc
@@ -19,10 +19,10 @@
 #include "external/com_github_p4lang_p4c/lib/error.h"
 #include "external/com_github_p4lang_p4c/lib/gc.h"
 
-using StratumP4cContext = P4CContextWithOptions<CompilerOptions>;
-
 namespace stratum {
 namespace p4c_backends {
+
+using StratumP4cContext = P4CContextWithOptions<CompilerOptions>;
 
 P4cFrontMidReal::P4cFrontMidReal()
     : p4c_context_(new StratumP4cContext),

--- a/stratum/p4c_backends/fpm/action_decoder_test.cc
+++ b/stratum/p4c_backends/fpm/action_decoder_test.cc
@@ -19,10 +19,10 @@
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 
-using ::testing::_;
-
 namespace stratum {
 namespace p4c_backends {
+
+using ::testing::_;
 
 MATCHER_P(EqualsProto, proto, "") { return ProtoEqual(arg, proto); }
 

--- a/stratum/p4c_backends/fpm/annotation_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/annotation_mapper_test.cc
@@ -21,12 +21,12 @@
 
 DECLARE_string(p4c_annotation_map_files);
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::google::protobuf::util::MessageDifferencer;
 using ::testing::Return;
 using ::testing::_;
-
-namespace stratum {
-namespace p4c_backends {
 
 class AnnotationMapperTest : public testing::Test {
  protected:

--- a/stratum/p4c_backends/fpm/control_inspector_test.cc
+++ b/stratum/p4c_backends/fpm/control_inspector_test.cc
@@ -27,15 +27,15 @@
 #include "absl/memory/memory.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::HasSubstr;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::SaveArg;
-
-namespace stratum {
-namespace p4c_backends {
 
 // This test fixture depends on an IRTestHelperJson to generate a set of p4c IR
 // data for test use.  The test parameter is used by some tests as a hit/miss

--- a/stratum/p4c_backends/fpm/hidden_static_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/hidden_static_mapper_test.cc
@@ -23,11 +23,11 @@
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/gtl/map_util.h"
 
-using ::testing::AnyNumber;
-using ::testing::Return;
-
 namespace stratum {
 namespace p4c_backends {
+
+using ::testing::AnyNumber;
+using ::testing::Return;
 
 // This class is the HiddenTableMapper test fixture.
 class HiddenStaticMapperTest : public testing::Test {

--- a/stratum/p4c_backends/fpm/hidden_table_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/hidden_table_mapper_test.cc
@@ -25,12 +25,12 @@
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/lib/macros.h"
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::google::protobuf::util::MessageDifferencer;
 using ::testing::AnyNumber;
 using ::testing::Invoke;
-
-namespace stratum {
-namespace p4c_backends {
 
 // This unnamed namespace defines constants for use by parameterized tests.
 namespace {

--- a/stratum/p4c_backends/fpm/hit_assign_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/hit_assign_mapper_test.cc
@@ -13,10 +13,10 @@
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 
-using ::testing::Values;
-
 namespace stratum {
 namespace p4c_backends {
+
+using ::testing::Values;
 
 // This test fixture depends on an IRTestHelperJson to generate a set of p4c IR
 // data for test use.  See INSTANTIATE_TEST_SUITE_P near the end if this file

--- a/stratum/p4c_backends/fpm/meta_key_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/meta_key_mapper_test.cc
@@ -14,12 +14,12 @@
 #include "gtest/gtest.h"
 #include "absl/strings/match.h"
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::ReturnRef;
-
-namespace stratum {
-namespace p4c_backends {
 
 class MetaKeyMapperTest : public testing::Test {
  protected:

--- a/stratum/p4c_backends/fpm/meter_color_mapper_test.cc
+++ b/stratum/p4c_backends/fpm/meter_color_mapper_test.cc
@@ -20,14 +20,14 @@
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::testing::AnyNumber;
 using ::testing::Combine;
 using ::testing::Range;
 using ::testing::ReturnRef;
 using ::testing::Values;
-
-namespace stratum {
-namespace p4c_backends {
 
 // This test fixture depends on an IRTestHelperJson to generate a set of p4c IR
 // data for test use.

--- a/stratum/p4c_backends/fpm/simple_hit_inspector_test.cc
+++ b/stratum/p4c_backends/fpm/simple_hit_inspector_test.cc
@@ -12,10 +12,10 @@
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 
-using ::testing::Values;
-
 namespace stratum {
 namespace p4c_backends {
+
+using ::testing::Values;
 
 // This test fixture depends on an IRTestHelperJson to generate a set of p4c IR
 // data for test use.  See INSTANTIATE_TEST_SUITE_P near the end if this file

--- a/stratum/p4c_backends/fpm/switch_case_decoder_test.cc
+++ b/stratum/p4c_backends/fpm/switch_case_decoder_test.cc
@@ -18,12 +18,12 @@
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::ReturnRef;
-
-namespace stratum {
-namespace p4c_backends {
 
 // This test fixture depends on an IRTestHelperJson to generate a set of p4c IR
 // data for test use.

--- a/stratum/p4c_backends/fpm/table_hit_inspector_test.cc
+++ b/stratum/p4c_backends/fpm/table_hit_inspector_test.cc
@@ -14,10 +14,10 @@
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 
-using ::testing::Values;
-
 namespace stratum {
 namespace p4c_backends {
+
+using ::testing::Values;
 
 // This test fixture depends on an IRTestHelperJson to generate a set of p4c IR
 // data for test use.  See INSTANTIATE_TEST_SUITE_P near the end if this file

--- a/stratum/p4c_backends/fpm/utils_test.cc
+++ b/stratum/p4c_backends/fpm/utils_test.cc
@@ -23,12 +23,12 @@
 #include "external/com_github_p4lang_p4c/lib/compile_context.h"
 #include "external/com_github_p4lang_p4c/lib/cstring.h"
 
+namespace stratum {
+namespace p4c_backends {
+
 using ::google::protobuf::util::MessageDifferencer;
 using ::testing::_;
 using ::testing::Return;
-
-namespace stratum {
-namespace p4c_backends {
 
 // This test fixture verifies the p4c utility functions.
 class P4cUtilsTest : public testing::Test {


### PR DESCRIPTION
Keeping the using directives as local as possible and not polling the global namespace is good practice.

This PR mostly moves them into the correct namespace without other code changes. To keep the changes small we'll ignore formatting for many touched files.