### PR TITLE
Pad byte strings passed to the SDE

### DIFF
--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -173,6 +173,7 @@ stratum_cc_library(
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/p4:utils",
         "//stratum/lib:constants",
         "//stratum/lib:utils",
         "//stratum/lib/channel",

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -62,11 +62,6 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
   return bytes / 125;
 }
 
-// Returns the number of bytes needed to encode the given number of bits.
-inline constexpr int NumBitsToNumBytes(int num_bits) {
-  return (num_bits + 7) / 8;  // ceil(num_bits/8)
-}
-
 ::util::Status GetField(const bfrt::BfRtTableKey& table_key,
                         std::string field_name, uint64* field_value) {
   bf_rt_id_t field_id;

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -24,6 +24,7 @@
 #include "stratum/hal/lib/barefoot/macros.h"
 #include "stratum/hal/lib/barefoot/utils.h"
 #include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/hal/lib/p4/utils.h"
 #include "stratum/lib/channel/channel.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/utils.h"
@@ -52,10 +53,19 @@ constexpr int _PI_UPDATE_MAX_NAME_SIZE = 100;
 // Helper functions for dealing with the SDE API.
 namespace {
 // Convert kbit/s to bytes/s (* 1000 / 8).
-uint64 KbitsToBytesPerSecond(uint64 kbps) { return kbps * 125; }
+inline constexpr uint64 KbitsToBytesPerSecond(uint64 kbps) {
+  return kbps * 125;
+}
 
 // Convert bytes/s to kbit/s (/ 1000 * 8).
-uint64 BytesPerSecondToKbits(uint64 bytes) { return bytes / 125; }
+inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
+  return bytes / 125;
+}
+
+// Returns the number of bytes needed to encode the given number of bits.
+inline constexpr int NumBitsToNumBytes(int num_bits) {
+  return (num_bits + 7) / 8;  // ceil(num_bits/8)
+}
 
 ::util::Status GetField(const bfrt::BfRtTableKey& table_key,
                         std::string field_name, uint64* field_value) {
@@ -394,7 +404,7 @@ template <typename T>
         break;
       }
       case bfrt::DataType::BYTE_STREAM: {
-        std::string v((field_size + 7) / 8, '\x00');
+        std::string v(NumBitsToNumBytes(field_size), '\x00');
         RETURN_IF_BFRT_ERROR(table_data->getValue(
             field_id, v.size(),
             reinterpret_cast<uint8*>(gtl::string_as_array(&v))));
@@ -424,37 +434,64 @@ template <typename T>
 }  // namespace
 
 ::util::Status TableKey::SetExact(int id, const std::string& value) {
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_key_->tableGet(&table));
+  size_t field_size_bits;
+  RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
+  std::string v = P4RuntimeByteStringToPaddedByteString(
+      value, NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_key_->setValue(
-      id, reinterpret_cast<const uint8*>(value.data()), value.size()));
+      id, reinterpret_cast<const uint8*>(v.data()), v.size()));
 
   return ::util::OkStatus();
 }
 
 ::util::Status TableKey::SetTernary(int id, const std::string& value,
                                     const std::string& mask) {
-  DCHECK_EQ(value.size(), mask.size());
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_key_->tableGet(&table));
+  size_t field_size_bits;
+  RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
+  std::string v = P4RuntimeByteStringToPaddedByteString(
+      value, NumBitsToNumBytes(field_size_bits));
+  std::string m = P4RuntimeByteStringToPaddedByteString(
+      mask, NumBitsToNumBytes(field_size_bits));
+  DCHECK_EQ(v.size(), m.size());
   RETURN_IF_BFRT_ERROR(table_key_->setValueandMask(
-      id, reinterpret_cast<const uint8*>(value.data()),
-      reinterpret_cast<const uint8*>(mask.data()), value.size()));
+      id, reinterpret_cast<const uint8*>(v.data()),
+      reinterpret_cast<const uint8*>(m.data()), v.size()));
 
   return ::util::OkStatus();
 }
 
 ::util::Status TableKey::SetLpm(int id, const std::string& prefix,
                                 uint16 prefix_length) {
-  RETURN_IF_BFRT_ERROR(
-      table_key_->setValueLpm(id, reinterpret_cast<const uint8*>(prefix.data()),
-                              prefix_length, prefix.size()));
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_key_->tableGet(&table));
+  size_t field_size_bits;
+  RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
+  std::string p = P4RuntimeByteStringToPaddedByteString(
+      prefix, NumBitsToNumBytes(field_size_bits));
+  RETURN_IF_BFRT_ERROR(table_key_->setValueLpm(
+      id, reinterpret_cast<const uint8*>(p.data()), prefix_length, p.size()));
 
   return ::util::OkStatus();
 }
 
 ::util::Status TableKey::SetRange(int id, const std::string& low,
                                   const std::string& high) {
-  DCHECK_EQ(low.size(), high.size());
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_key_->tableGet(&table));
+  size_t field_size_bits;
+  RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
+  std::string l = P4RuntimeByteStringToPaddedByteString(
+      low, NumBitsToNumBytes(field_size_bits));
+  std::string h = P4RuntimeByteStringToPaddedByteString(
+      high, NumBitsToNumBytes(field_size_bits));
+  DCHECK_EQ(l.size(), h.size());
   RETURN_IF_BFRT_ERROR(table_key_->setValueRange(
-      id, reinterpret_cast<const uint8*>(low.data()),
-      reinterpret_cast<const uint8*>(high.data()), low.size()));
+      id, reinterpret_cast<const uint8*>(l.data()),
+      reinterpret_cast<const uint8*>(h.data()), l.size()));
 
   return ::util::OkStatus();
 }
@@ -476,7 +513,7 @@ template <typename T>
   size_t field_size_bits;
   RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
   value->clear();
-  value->resize((field_size_bits + 7) / 8);
+  value->resize(NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_key_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
@@ -491,9 +528,9 @@ template <typename T>
   size_t field_size_bits;
   RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
   value->clear();
-  value->resize((field_size_bits + 7) / 8);
+  value->resize(NumBitsToNumBytes(field_size_bits));
   mask->clear();
-  mask->resize((field_size_bits + 7) / 8);
+  mask->resize(NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_key_->getValueandMask(
       id, value->size(), reinterpret_cast<uint8*>(gtl::string_as_array(value)),
       reinterpret_cast<uint8*>(gtl::string_as_array(mask))));
@@ -508,7 +545,7 @@ template <typename T>
   size_t field_size_bits;
   RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
   prefix->clear();
-  prefix->resize((field_size_bits + 7) / 8);
+  prefix->resize(NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_key_->getValueLpm(
       id, prefix->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(prefix)), prefix_length));
@@ -523,9 +560,9 @@ template <typename T>
   size_t field_size_bits;
   RETURN_IF_BFRT_ERROR(table->keyFieldSizeGet(id, &field_size_bits));
   low->clear();
-  low->resize((field_size_bits + 7) / 8);
+  low->resize(NumBitsToNumBytes(field_size_bits));
   high->clear();
-  high->resize((field_size_bits + 7) / 8);
+  high->resize(NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_key_->getValueRange(
       id, low->size(), reinterpret_cast<uint8*>(gtl::string_as_array(low)),
       reinterpret_cast<uint8*>(gtl::string_as_array(high))));
@@ -555,8 +592,23 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
 }
 
 ::util::Status TableData::SetParam(int id, const std::string& value) {
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_data_->getParent(&table));
+  bf_rt_id_t action_id = 0;
+  if (table->actionIdApplicable()) {
+    RETURN_IF_BFRT_ERROR(table_data_->actionIdGet(&action_id));
+  }
+  size_t field_size_bits;
+  if (action_id) {
+    RETURN_IF_BFRT_ERROR(
+        table->dataFieldSizeGet(id, action_id, &field_size_bits));
+  } else {
+    RETURN_IF_BFRT_ERROR(table->dataFieldSizeGet(id, &field_size_bits));
+  }
+  std::string p = P4RuntimeByteStringToPaddedByteString(
+      value, NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_data_->setValue(
-      id, reinterpret_cast<const uint8*>(value.data()), value.size()));
+      id, reinterpret_cast<const uint8*>(p.data()), p.size()));
 
   return ::util::OkStatus();
 }
@@ -568,14 +620,15 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   if (table->actionIdApplicable()) {
     RETURN_IF_BFRT_ERROR(table_data_->actionIdGet(&action_id));
   }
-  size_t field_size;
+  size_t field_size_bits;
   if (action_id) {
-    RETURN_IF_BFRT_ERROR(table->dataFieldSizeGet(id, action_id, &field_size));
+    RETURN_IF_BFRT_ERROR(
+        table->dataFieldSizeGet(id, action_id, &field_size_bits));
   } else {
-    RETURN_IF_BFRT_ERROR(table->dataFieldSizeGet(id, &field_size));
+    RETURN_IF_BFRT_ERROR(table->dataFieldSizeGet(id, &field_size_bits));
   }
   value->clear();
-  value->resize((field_size + 7) / 8);
+  value->resize(NumBitsToNumBytes(field_size_bits));
   RETURN_IF_BFRT_ERROR(table_data_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
@@ -2172,12 +2225,12 @@ namespace {
   // parent table and pipeline. We cannot use just "f1" as the field name.
   bf_rt_id_t field_id;
   ASSIGN_OR_RETURN(field_id, GetRegisterDataFieldId(table));
-  size_t data_field_size;
-  RETURN_IF_BFRT_ERROR(table->dataFieldSizeGet(field_id, &data_field_size));
-  // The SDE expects any array with the full width.
-  std::string value((data_field_size + 7) / 8, '\x00');
-  value.replace(value.size() - register_data.size(), register_data.size(),
-                register_data);
+  size_t data_field_size_bits;
+  RETURN_IF_BFRT_ERROR(
+      table->dataFieldSizeGet(field_id, &data_field_size_bits));
+  // The SDE expects a string with the full width.
+  std::string value = P4RuntimeByteStringToPaddedByteString(
+      register_data, data_field_size_bits);
   RETURN_IF_BFRT_ERROR(table_data->setValue(
       field_id, reinterpret_cast<const uint8*>(value.data()), value.size()));
 

--- a/stratum/hal/lib/barefoot/utils.cc
+++ b/stratum/hal/lib/barefoot/utils.cc
@@ -57,11 +57,11 @@ bool IsDontCareMatch(const ::p4::v1::FieldMatch::Optional& optional) {
 }
 
 std::string RangeDefaultLow(size_t bitwidth) {
-  return std::string((bitwidth + 7) / 8, '\x00');
+  return std::string(NumBitsToNumBytes(bitwidth), '\x00');
 }
 
 std::string RangeDefaultHigh(size_t bitwidth) {
-  const size_t nbytes = (bitwidth + 7) / 8;
+  const size_t nbytes = NumBitsToNumBytes(bitwidth);
   std::string high(nbytes, '\xff');
   size_t zero_nbits = (nbytes * 8) - bitwidth;
   char mask = 0xff >> zero_nbits;
@@ -78,6 +78,10 @@ std::string RangeDefaultHigh(size_t bitwidth) {
 ::util::StatusOr<int32> ConvertPriorityFromBfrtToP4rt(uint64 priority) {
   CHECK_RETURN_IF_FALSE(priority <= kMaxPriority);
   return static_cast<int32>(kMaxPriority - priority);
+}
+
+int NumBitsToNumBytes(int num_bits) {
+  return (num_bits + 7) / 8;  // ceil(num_bits/8)
 }
 
 }  // namespace barefoot

--- a/stratum/hal/lib/barefoot/utils.h
+++ b/stratum/hal/lib/barefoot/utils.h
@@ -43,6 +43,10 @@ std::string RangeDefaultHigh(size_t bitwidth);
 ::util::StatusOr<uint64> ConvertPriorityFromP4rtToBfrt(int32 priority);
 ::util::StatusOr<int32> ConvertPriorityFromBfrtToP4rt(uint64 priority);
 
+// Returns the number of bytes needed to encode the given number of bits in a
+// byte string.
+int NumBitsToNumBytes(int num_bits);
+
 }  // namespace barefoot
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -97,6 +97,18 @@ std::string Uint32ToByteStream(uint32 val) {
   return bytes;
 }
 
+std::string P4RuntimeByteStringToPaddedByteString(std::string byte_string,
+                                                  size_t num_bytes) {
+  if (byte_string.size() > num_bytes) {
+    byte_string.erase(0, byte_string.size() - num_bytes);
+  } else {
+    byte_string.insert(0, num_bytes - byte_string.size(), '\x00');
+  }
+  DCHECK_EQ(num_bytes, byte_string.size());
+
+  return byte_string;
+}
+
 std::string P4RuntimeGrpcStatusToString(const ::grpc::Status& status) {
   std::stringstream ss;
   if (!status.error_details().empty()) {

--- a/stratum/hal/lib/p4/utils.h
+++ b/stratum/hal/lib/p4/utils.h
@@ -43,6 +43,12 @@ std::string PrintP4ObjectID(int object_id);
 std::string Uint64ToByteStream(uint64 val);
 std::string Uint32ToByteStream(uint32 val);
 
+// Pads a P4Runtime byte string with zeros up to the given width. Surplus bytes
+// will be truncated at the front. The returned string will always be exactly as
+// long as requested.
+std::string P4RuntimeByteStringToPaddedByteString(std::string byte_string,
+                                                  size_t num_bytes);
+
 // Helper to convert a gRPC status with error details to a string. Assumes
 // ::grpc::Status includes a binary error detail which is encoding a serialized
 // version of ::google::rpc::Status proto in which the details are captured

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -62,6 +62,21 @@ TEST(PrintP4ObjectIDTest, TestInvalidID) {
   EXPECT_THAT(print_id, HasSubstr("INVALID"));
 }
 
+TEST(ByteStringTest, P4RuntimeByteStringToPaddedByteStringCorrect) {
+  EXPECT_EQ(std::string("\xab", 1),
+            P4RuntimeByteStringToPaddedByteString("\xab", 1));
+  EXPECT_EQ(std::string("\x00\xab", 2),
+            P4RuntimeByteStringToPaddedByteString("\xab", 2));
+  EXPECT_EQ(std::string("\x00\x00\x00", 3),
+            P4RuntimeByteStringToPaddedByteString("\x00", 3));
+  EXPECT_EQ(std::string("\x00\x00", 2),
+            P4RuntimeByteStringToPaddedByteString("", 2));
+  EXPECT_EQ(std::string("\xef", 1),
+            P4RuntimeByteStringToPaddedByteString("\xab\xcd\xef", 1));
+  EXPECT_EQ(std::string("", 0),
+            P4RuntimeByteStringToPaddedByteString("\xab", 0));
+}
+
 // This test fixture provides a common P4PipelineConfig for these tests.
 class TableMapValueTest : public testing::Test {
  protected:


### PR DESCRIPTION
Byte strings passed to the SDE must match the length of field being set exactly.

This change allows accepting canonical P4RT byte strings and safeguards against malformed (i.e. too large) input strings.

The P4RT read path and topics like rw-symmetry are not affected by this.