### PR TITLE
Log the SDE version on SdeWrapper creation

### DIFF
--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -149,6 +149,7 @@ void registerDeviceMgrLogger() {
   const OperationMode mode =
       is_sw_model ? OPERATION_MODE_SIM : OPERATION_MODE_STANDALONE;
   VLOG(1) << "Detected is_sw_model: " << is_sw_model;
+  VLOG(1) << "SDE version: " << bf_sde_wrapper->GetSdeVersion();
   auto bf_chassis_manager =
       BFChassisManager::CreateInstance(mode, phal_impl, bf_sde_wrapper);
   auto bf_switch =

--- a/stratum/hal/bin/barefoot/main_bfrt.cc
+++ b/stratum/hal/bin/barefoot/main_bfrt.cc
@@ -88,6 +88,7 @@ namespace barefoot {
   const OperationMode mode =
       is_sw_model ? OPERATION_MODE_SIM : OPERATION_MODE_STANDALONE;
   VLOG(1) << "Detected is_sw_model: " << is_sw_model;
+  VLOG(1) << "SDE version: " << bf_sde_wrapper->GetSdeVersion();
 
   auto bfrt_table_manager =
       BfrtTableManager::CreateInstance(mode, bf_sde_wrapper, device_id);

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -225,6 +225,9 @@ class BfSdeInterface {
   // Return the chip type as a string.
   virtual std::string GetBfChipType(int device) const = 0;
 
+  // Return the SDE version string.
+  virtual std::string GetSdeVersion() const = 0;
+
   // Send a packet to the PCIe CPU port.
   virtual ::util::Status TxPacket(int device, const std::string& packet) = 0;
 

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -97,6 +97,7 @@ class BfSdeMock : public BfSdeInterface {
   MOCK_METHOD2(SetTmCpuPort, ::util::Status(int device, int port));
   MOCK_METHOD1(IsSoftwareModel, ::util::StatusOr<bool>(int device));
   MOCK_CONST_METHOD1(GetBfChipType, std::string(int device));
+  MOCK_CONST_METHOD0(GetSdeVersion, std::string());
   MOCK_METHOD2(TxPacket, ::util::Status(int device, const std::string& packet));
   MOCK_METHOD1(StartPacketIo, ::util::Status(int device));
   MOCK_METHOD1(StopPacketIo, ::util::Status(int device));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -1135,6 +1135,22 @@ std::string BfSdeWrapper::GetBfChipType(int device) const {
   }
 }
 
+std::string BfSdeWrapper::GetSdeVersion() const {
+#if defined(SDE_9_1_0)
+  return "9.1.0";
+#elif defined(SDE_9_2_0)
+  return "9.2.0";
+#elif defined(SDE_9_3_0)
+  return "9.3.0";
+#elif defined(SDE_9_3_1)
+  return "9.3.1";
+#elif defined(SDE_9_4_0)
+  return "9.4.0";
+#else
+#error Unsupported SDE version
+#endif
+}
+
 ::util::StatusOr<uint32> BfSdeWrapper::GetPortIdFromPortKey(
     int device, const PortKey& port_key) {
   const int port = port_key.port;

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -174,6 +174,7 @@ class BfSdeWrapper : public BfSdeInterface {
   ::util::Status SetTmCpuPort(int device, int port) override;
   ::util::StatusOr<bool> IsSoftwareModel(int device) override;
   std::string GetBfChipType(int device) const override;
+  std::string GetSdeVersion() const override;
   ::util::Status TxPacket(int device, const std::string& packet) override;
   ::util::Status StartPacketIo(int device) override;
   ::util::Status StopPacketIo(int device) override;


### PR DESCRIPTION
Currently the runtime logs do not contain the SDE version. This change logs it once on startup with level `INFO`.

There are two possible places to implement the log:

- `BfSdeWrapper::CreateSingleton()`
  - It's always logged, users can't forget it
  - Not configurable (level, time) 
  - Single place to update/fix/keep track of
  - No precedence: we don't log non-errors in `CreateSingleton`
- `main.cc/main_bfrt.cc`: Log in main by calling the public `GetSdeVersion()` function
  - Logging is callers responsibility, more flexible
  - Makes SDE version publicly available, other modules might want to implement dependent behavior in the future
  - Precedence: `GetBfChipType`, `IsSoftwareModel`
