### PR TITLE
Fix a unreachable code error with clang on MacOS

### DIFF
--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -74,7 +74,7 @@ std::string AddP4ObjectReferenceString(const std::string& log_p4_object) {
 }
 
 std::string Uint64ToByteStream(uint64 val) {
-  uint64 tmp = (htonl(1) == 1)
+  uint64 tmp = (htonl(1) == (1))
                    ? val
                    : (static_cast<uint64>(htonl(val)) << 32) | htonl(val >> 32);
   std::string bytes = "";


### PR DESCRIPTION
Depending on the endianness of the platform, one or the other code path will never be executed. This fix silences the compiler warning.

```
stratum/hal/lib/p4/utils.cc:78:22: error: code will never be executed [-Werror,-Wunreachable-code]
                   ? val
                     ^~~
stratum/hal/lib/p4/utils.cc:77:29: note: silence by adding parentheses to mark code as explicitly dead
  uint64 tmp = (htonl(1) == 1)
                            ^
                            /* DISABLES CODE */ ( )
```