### PR TITLE
Reject P4RT reads or writes before a pipeline has been pushed in Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -123,10 +123,19 @@ BfrtNode::~BfrtNode() = default;
 
 ::util::Status BfrtNode::Shutdown() {
   absl::WriterMutexLock l(&lock_);
-  // TODO(max): do we need to de-init the ASIC or SDE?
+  auto status = ::util::OkStatus();
+  // TODO(max): Check if we need to de-init the ASIC or SDE
+  // TODO(max): Enable other Shutdown calls once implemented.
+  // APPEND_STATUS_IF_ERROR(status, bfrt_table_manager_->Shutdown());
+  // APPEND_STATUS_IF_ERROR(status, bfrt_action_profile_manager_->Shutdown());
+  APPEND_STATUS_IF_ERROR(status, bfrt_packetio_manager_->Shutdown());
+  // APPEND_STATUS_IF_ERROR(status, bfrt_pre_manager_->Shutdown());
+  // APPEND_STATUS_IF_ERROR(status, bfrt_counter_manager_->Shutdown());
+
   pipeline_initialized_ = false;
   initialized_ = false;  // Set to false even if there is an error
-  return ::util::OkStatus();
+
+  return status;
 }
 
 ::util::Status BfrtNode::Freeze() { return ::util::OkStatus(); }

--- a/stratum/hal/lib/barefoot/bfrt_node.h
+++ b/stratum/hal/lib/barefoot/bfrt_node.h
@@ -43,9 +43,9 @@ class BfrtNode final {
   ::util::Status CommitForwardingPipelineConfig() LOCKS_EXCLUDED(lock_);
   ::util::Status VerifyForwardingPipelineConfig(
       const ::p4::v1::ForwardingPipelineConfig& config) const;
-  ::util::Status Shutdown();
-  ::util::Status Freeze();
-  ::util::Status Unfreeze();
+  ::util::Status Shutdown() LOCKS_EXCLUDED(lock_);
+  ::util::Status Freeze() LOCKS_EXCLUDED(lock_);
+  ::util::Status Unfreeze() LOCKS_EXCLUDED(lock_);
   ::util::Status WriteForwardingEntries(const ::p4::v1::WriteRequest& req,
                                         std::vector<::util::Status>* results)
       LOCKS_EXCLUDED(lock_);
@@ -105,7 +105,10 @@ class BfrtNode final {
   // Mutex used for exclusive access to rx_writer_.
   mutable absl::Mutex rx_writer_lock_;
 
+  // Flag indicating whether the pipeline has been pushed.
   bool pipeline_initialized_ GUARDED_BY(lock_);
+
+  // Flag indicating whether the chip is initialized.
   bool initialized_ GUARDED_BY(lock_);
 
   // Managers. Not owned by this class.

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -93,7 +93,7 @@ class SwitchInterface {
   // PushForwardingPipelineConfig() calls VerifyForwardingPipelineConfig() to
   // verify the forwarding config before pushing anything to the hardware. Also,
   // this funcation can be called at any point before/after the switch is
-  // initialize or the chassis config is pushed.
+  // initialized or the chassis config is pushed.
   virtual ::util::Status VerifyForwardingPipelineConfig(
       uint64 node_id, const ::p4::v1::ForwardingPipelineConfig& config) = 0;
 


### PR DESCRIPTION
Stratum-bfrt did not check for a pipeline and thus segfaulted on a null pointer. This PR adds the appropriate check to all public functions.