### PR TITLE
Reject table entry writes to const tables in BfrtTableManager

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -316,10 +316,17 @@ struct RegisterClearThreadData {
       << "Invalid update type " << type;
 
   absl::ReaderMutexLock l(&lock_);
+  ASSIGN_OR_RETURN(auto table,
+                   p4_info_manager_->FindTableByID(table_entry.table_id()));
   ASSIGN_OR_RETURN(uint32 table_id,
                    bf_sde_interface_->GetBfRtId(table_entry.table_id()));
 
   if (!table_entry.is_default_action()) {
+    if (table.is_const_table()) {
+      RETURN_ERROR(ERR_PERMISSION_DENIED)
+          << "Can't write to table " << table.preamble().name()
+          << " because it has const entries.";
+    }
     ASSIGN_OR_RETURN(auto table_key,
                      bf_sde_interface_->CreateTableKey(table_id));
     RETURN_IF_ERROR(BuildTableKey(table_entry, table_key.get()));


### PR DESCRIPTION
> The only write updates which are allowed for constant tables are MODIFY operations on direct resources, and the default action (assuming the default action itself is not constant). If the P4Runtime client attempts to perform any other kind of write update on a constant table the server must return a PERMISSION_DENIED error.

https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html#sec-constant-tables