### PR TITLE
Fix zero byte string bug in IsDontCareMatch for ranges

### DIFF
--- a/stratum/hal/lib/barefoot/utils.cc
+++ b/stratum/hal/lib/barefoot/utils.cc
@@ -1,11 +1,12 @@
 // Copyright 2020-present Open Networking Foundation
+// Copyright 2021 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/barefoot/utils.h"
 
+#include <algorithm>
 #include <utility>
 
-#include "absl/strings/strip.h"
 #include "stratum/hal/lib/barefoot/bfrt_constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/public/lib/error.h"
@@ -27,27 +28,18 @@ bool IsDontCareMatch(const ::p4::v1::FieldMatch::Ternary& ternary) {
 
 namespace {
 // Strip leading zeros from a string, but keep at least one byte.
-absl::string_view StripLeadingZeroBytes(const std::string& str) {
-  absl::string_view normalized(str);
-  while (normalized.size() > 1 && absl::StartsWith(normalized, "\x00")) {
-    normalized.remove_prefix(1);
-  }
-  return normalized;
+std::string StripLeadingZeroBytes(std::string str) {
+  str.erase(0, std::min(str.find_first_not_of('\x00'), str.size() - 1));
+  return str;
 }
 }  // namespace
 
 // For BFRT we explicitly insert the "don't care" range match as the
 // [minimum, maximum] value range.
+// TODO(max): why are we not stripping the high bytes too?
 bool IsDontCareMatch(const ::p4::v1::FieldMatch::Range& range,
                      int field_width) {
-  // Ignore leading zero bytes.
-  absl::string_view normalized_low(range.low());
-  while (normalized_low.size() > 1 &&
-         absl::StartsWith(normalized_low, "\x00")) {
-    normalized_low.remove_prefix(1);
-  }
-
-  return normalized_low ==
+  return StripLeadingZeroBytes(range.low()) ==
              StripLeadingZeroBytes(RangeDefaultLow(field_width)) &&
          range.high() == RangeDefaultHigh(field_width);
 }

--- a/stratum/hal/lib/barefoot/utils_test.cc
+++ b/stratum/hal/lib/barefoot/utils_test.cc
@@ -160,6 +160,12 @@ TEST(IsDontCareMatchTest, ClassifyRangeMatch) {
     m.set_high("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", 10);
     EXPECT_FALSE(IsDontCareMatch(m, 81)) << m.DebugString();
   }
+  {
+    ::p4::v1::FieldMatch::Range m;
+    m.set_low("\x00\x40\x00", 3);
+    m.set_high("\x03\xFF\xFF", 3);
+    EXPECT_FALSE(IsDontCareMatch(m, 18)) << m.DebugString();
+  }
 }
 
 TEST(IsDontCareMatchTest, RejectAllOptionalMatch) {

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -68,7 +68,7 @@ TEST(ByteStringTest, P4RuntimeByteStringToPaddedByteStringCorrect) {
   EXPECT_EQ(std::string("\x00\xab", 2),
             P4RuntimeByteStringToPaddedByteString("\xab", 2));
   EXPECT_EQ(std::string("\x00\x00\x00", 3),
-            P4RuntimeByteStringToPaddedByteString("\x00", 3));
+            P4RuntimeByteStringToPaddedByteString(std::string("\x00", 1), 3));
   EXPECT_EQ(std::string("\x00\x00", 2),
             P4RuntimeByteStringToPaddedByteString("", 2));
   EXPECT_EQ(std::string("\xef", 1),


### PR DESCRIPTION
`std::string("\x00")` will surprisingly create an empty string `""`, not a one byte string containing a single zero byte character. As a result, `absl::StartsWith(..., "\x00")` will always return true and trim the whole lower range match down to a single byte. If this last byte is a zero, the match will incorrectly classified as "don't care".
Also see the Notes section of [basic_string](https://en.cppreference.com/w/cpp/string/basic_string/basic_string).