### PR TITLE
Try to demote all SDE errors to warnings

### DIFF
--- a/stratum/hal/lib/barefoot/macros.h
+++ b/stratum/hal/lib/barefoot/macros.h
@@ -72,11 +72,11 @@ class BooleanBfStatus {
 
 // A macro for simplify checking and logging the return value of a SDE function
 // call.
-#define RETURN_IF_BFRT_ERROR(expr)                            \
-  if (const BooleanBfStatus __ret = BooleanBfStatus(expr)) {  \
-  } else /* NOLINT */                                         \
-    return MAKE_ERROR(__ret.error_code())                     \
-           << "'" << #expr << "' failed with error message: " \
+#define RETURN_IF_BFRT_ERROR(expr)                                            \
+  if (const BooleanBfStatus __ret = BooleanBfStatus(expr)) {                  \
+  } else /* NOLINT */                                                         \
+    return MAKE_ERROR(__ret.error_code()).severity(WARNING).without_logging() \
+           << "'" << #expr << "' failed with error message: "                 \
            << FixMessage(bf_err_str(__ret.status()))
 
 // A macro for simplify creating a new error or appending new info to an


### PR DESCRIPTION
# This is WIP


Due to bugs in ONOS, invalid P4RT requests will be issued during normal operation (adding entries that already exist, deleting action profile groups with members, ...). These show up in the Stratum logs and trigger alarms in our monitoring suite. Concerns have been raised to demote these to warnings instead, as this is currently blocking the rollout of an automated alerting system.

### Background

The ubiquitous [`RETURN_IF_BFRT_ERROR`](https://github.com/stratum/stratum/blob/main/stratum/hal/lib/barefoot/macros.h#L74-L75) macro does not allow setting the severity level on a case-by-case basis, but always creates an `ERROR`. Same applies to `MAKE_ERROR`, `RETURN_IF_ERROR` and `CHECK_RETURN_IF_FALSE`/`RET_CHECK`.

### Attempted solutions

#### Reducing the severity inside the `RETURN_IF_BFRT_ERROR` macro
`MakeErrorStream` provides a function to set the severity of it: `.severity(WARNING)`.
**This changes the severity for ALL SDE function calls**, including requests issued over gNMI, internal bugs, etc.

Unfortunately, our implementations does not seem to support it, as messages continued to be logged with the `ERROR` level (note the `E` at the start of line):

```
E20210318 20:35:19.709548 13916 bf_sde_wrapper.cc:2934] StratumErrorSpace::ERR_ENTRY_NOT_FOUND: 'table->tableEntryGet( *real_session->bfrt_session_, bf_dev_tgt, *real_table_key->table_key_, bfrt::BfRtTable::BfRtTableGetFlag::GET_FROM_SW, real_table_data->table_data_.get())' failed with error message: Object not found.
E20210318 20:35:19.709679 13916 bfrt_table_manager.cc:522] Return Error: bf_sde_interface_->GetTableEntry( device_, session, table_id, table_key.get(), table_data.get()) failed with StratumErrorSpace::ERR_ENTRY_NOT_FOUND: 'table->tableEntryGet( *real_session->bfrt_session_, bf_dev_tgt, *real_table_key->table_key_, bfrt::BfRtTable::BfRtTableGetFlag::GET_FROM_SW, real_table_data->table_data_.get())' failed with error message: Object not found.
E20210318 20:35:19.709967 13916 bfrt_node.cc:324] StratumErrorSpace::ERR_AT_LEAST_ONE_OPER_FAILED: One or more read operations failed.
E20210318 20:35:19.710099 13916 p4_service.cc:338] Failed to read forwarding entries from node 1: One or more read operations failed.
```

#### Disabling logging in the `RETURN_IF_BFRT_ERROR` macro
Similar to the attempt above, this disables logging of SDE errors completely: `.without_logging()`

This seems to work and the first line from the log disappears. But, the other callers further up the stack are still logging the error:

```
E20210318 22:15:59.664705 17772 bfrt_table_manager.cc:522] Return Error: bf_sde_interface_->GetTableEntry( device_, session, table_id, table_key.get(), table_data.get()) failed with StratumErrorSpace::ERR_ENTRY_NOT_FOUND: 'table->tableEntryGet( *real_session->bfrt_session_, bf_dev_tgt, *real_table_key->table_key_, bfrt::BfRtTable::BfRtTableGetFlag::GET_FROM_SW, real_table_data->table_data_.get())' failed with error message: Object not found.
E20210318 22:15:59.664832 17772 bfrt_node.cc:324] StratumErrorSpace::ERR_AT_LEAST_ONE_OPER_FAILED: One or more read operations failed.
E20210318 22:15:59.664881 17772 p4_service.cc:338] Failed to read forwarding entries from node 1: One or more read operations failed.
```

Even if we successfully manage to either demote or suppress some errors, the managers, node and p4 service will still report them and trigger the alarms:

https://github.com/stratum/stratum/blob/97816b4f783c180c7250fd585d7989ebd9d2f8f3/stratum/hal/lib/barefoot/bfrt_table_manager.cc#L521

https://github.com/stratum/stratum/blob/ff802f0759756f1c711714716e028896f34da159/stratum/hal/lib/barefoot/bfrt_node.cc#L324-L325

https://github.com/stratum/stratum/blob/870ffc4e0a370d5a8644eb73c0a5396e5370243d/stratum/hal/lib/common/p4_service.cc#L338-L339

Further, in those places we don't have any context (i.e. "this was a duplicate insert", "this failed because the ASIC is gone", "this hit a timeout, try again later") anymore, and no criteria to conditionally adjust the level.

### Summary

The error handling and logging framework seem to operate on a "ask for permission", rather than "ask for forgiveness" principle. Unexpected errors are not supposed to happen, ever, and are assumed to be exceptional/bugs (not necessarily in Stratum, but the whole system) and _require_ fixing. A lot of the facilities are explicitly designed to make these rare cases as visible and loud as possible. For expected, but transient, errors glog provides [conditional/occasional logging](https://github.com/google/glog/blob/master/README.rst#conditional-occasional-logging) with `LOG_IF`, `LOG_EVERY_N` and `LOG_FIRST_N`, but these don't seem relevant to this issue.

### References

Aether ticket: [AETHER-1393](https://jira.opennetworking.org/browse/AETHER-1393)
Previous error logging workaround: https://github.com/stratum/stratum/pull/496
https://testing.googleblog.com/2013/06/optimal-logging.html