### PR TITLE
Cross reference TAI, BCM and main.p4 READMEs

### DIFF
--- a/stratum/docs/tai/README.md
+++ b/stratum/docs/tai/README.md
@@ -4,7 +4,7 @@ Copyright 2020-present Open Networking Foundation
 
 SPDX-License-Identifier: Apache-2.0
 -->
-# Transponder Abstraction Interface(TAI) support
+# Transponder Abstraction Interface (TAI) support
 
 This document provides an overview of the [TAI library](https://github.com/Telecominfraproject/oopt-tai) and interaction with TAI library wrapper and Stratum.
 
@@ -32,7 +32,7 @@ To build PHAL with the TAI backend, add the following define to all Bazel build 
 
 `bazel build --define phal_with_tai=true //stratum/...`
 
-Follow the relevant build instructions for [Broadcom chips](stratum/hal/bin/bcm/standalone/README.md) as usual.
+Follow the relevant build instructions for [Broadcom chips](/stratum/hal/bin/bcm/standalone/README.md) as usual.
 
 ### Additional TAI Switch Setup
 

--- a/stratum/docs/tai/README.md
+++ b/stratum/docs/tai/README.md
@@ -180,7 +180,7 @@ message PhalDB {
 ```
 > Note that we are not supprting configuring the Hoet Interface in TAI for now. This may be a future task that contributed by the community.
 
-## Supported OpenConfig models(gNMI paths)
+## Supported OpenConfig models (gNMI paths)
 
 The OpenConfig model provides an optical channel configuration. Below are YANG models on GitHub we are using for TAI support:
 
@@ -276,7 +276,7 @@ Find the full TAI attributes' list here:
 | 2         | `MODULATION_FORMAT_DP_16_QAM` |
 | 3         | `MODULATION_FORMAT_DP_8_QAM`  |
 
-## Todos
+## TODOs
 
 ### ChasisConfig to OpenConfig conversion and vise versa
 

--- a/stratum/docs/tai/README.md
+++ b/stratum/docs/tai/README.md
@@ -8,6 +8,9 @@ SPDX-License-Identifier: Apache-2.0
 
 This document provides an overview of the [TAI library](https://github.com/Telecominfraproject/oopt-tai) and interaction with TAI library wrapper and Stratum.
 
+For instructions on a specific platform or chip, refer to their
+[docs](/README.md#platforms).
+
 ## The Overview
 
 Figure below shows the overview of components which related to TAI support, we will cover these components from bottom to the top in following sections.
@@ -32,7 +35,7 @@ To build PHAL with the TAI backend, add the following define to all Bazel build 
 
 `bazel build --define phal_with_tai=true //stratum/...`
 
-Follow the relevant build instructions for [Broadcom chips](/stratum/hal/bin/bcm/standalone/README.md) as usual.
+Follow the relevant build instructions for [Broadcom chips](/stratum/hal/bin/bcm/standalone/README.md#compile-from-source) as usual.
 
 ### Additional TAI Switch Setup
 

--- a/stratum/hal/bin/bcm/standalone/README.md
+++ b/stratum/hal/bin/bcm/standalone/README.md
@@ -116,6 +116,13 @@ uses the correct ones for the platform.
 If you followed the build instructions, these should be on the switch under `/etc/stratum/stratum_configs`.
 Depending on your actual cabling, setup or hardware, you'll have to adjust the config files.
 
+### Pushing a Pipeline
+
+Before P4Runtime requests can be sent to program the data plane, a pipeline has
+to be pushed to the switch. We provide a reference pipeline for Broadcom based
+switches called [main.p4](/stratum/pipelines/main/main.p4). Refer to its
+[README](/stratum/pipelines/main/README.md) for further instructions.
+
 ### Manual SDK setup on the switch
 
 **ONLY needed when not using Docker or the start script!**

--- a/stratum/pipelines/main/README.md
+++ b/stratum/pipelines/main/README.md
@@ -41,6 +41,13 @@ In a production setup this is the job of a SDN controller like [ONOS](https://gi
 
 For testing and exploration purposes a tool like [p4runtime-shell](https://github.com/p4lang/p4runtime-shell) is useful.
 
+```
+./p4runtime-sh-docker \
+  --grpc-addr <switch ip>:9339 \
+  --device-id 1 --election-id 0,1 \
+  --config <path to main.p4info>,<path to main.pb.bin>
+```
+
 ## More information on the p4c-fpm compiler
 
 See: [p4c-fpm README](../../p4c_backends/README.md)


### PR DESCRIPTION
The READMEs we have on BCM, TAI and main.p4 benefit from being cross referenced. This avoids duplication of information and improves visibility.