### PR TITLE
Add linter for markdown and run during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,17 @@ jobs:
           name: Run reuse
           command: reuse lint
 
+  markdown-lint-check:
+    # We use the machine executor because mounting folders is not possible with
+    # CircleCi remote docker:
+    # https://circleci.com/docs/2.0/building-docker-images/#separation-of-environmentss
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Lint markdown files
+          command: .circleci/lint-markdown.sh
+
 workflows:
   version: 2
   build_and_test:
@@ -350,6 +361,7 @@ workflows:
       - coverage
       - lint-and-style-check
       - license-check
+      - markdown-lint-check
   docker-publish:
     jobs:
       - publish-docker-build:

--- a/.circleci/lint-markdown.sh
+++ b/.circleci/lint-markdown.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright 2021-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) markdownlint/markdownlint -v --rules MD013 .

--- a/.circleci/lint-markdown.sh
+++ b/.circleci/lint-markdown.sh
@@ -11,6 +11,9 @@ KNOWN_FILES=(
   "CONTRIBUTING.md"
 )
 
+# For all available rules, see:
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+
 docker run --rm -v $(pwd):$(pwd) -w $(pwd) markdownlint/markdownlint \
   -v --rules MD013 \
   ${KNOWN_FILES[*]}

--- a/.circleci/lint-markdown.sh
+++ b/.circleci/lint-markdown.sh
@@ -5,4 +5,12 @@
 
 set -ex
 
-docker run --rm -v $(pwd):$(pwd) -w $(pwd) markdownlint/markdownlint -v --rules MD013 .
+# TODO(max): add more files to the checklist over time.
+KNOWN_FILES=(
+  "README.md"
+  "CONTRIBUTING.md"
+)
+
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) markdownlint/markdownlint \
+  -v --rules MD013 \
+  ${KNOWN_FILES[*]}

--- a/.circleci/lint-markdown.sh
+++ b/.circleci/lint-markdown.sh
@@ -15,5 +15,5 @@ KNOWN_FILES=(
 # https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
 
 docker run --rm -v $(pwd):$(pwd) -w $(pwd) markdownlint/markdownlint \
-  -v --rules MD013 \
+  -v --rules MD009,MD010,MD011,MD013,MD018,MD019,MD047 \
   ${KNOWN_FILES[*]}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,33 +24,61 @@ again.
 
 ### General Information
 
-Stratum follows [Google's Engineering Practices](https://google.github.io/eng-practices/review/developer/), [C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and [unit test rules](stratum/docs/testing.md). Use these documents as a guide when submitting code.
+Stratum follows [Google's Engineering Practices](https://google.github.io/eng-practices/review/developer/),
+[C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and
+[unit test rules](stratum/docs/testing.md). Use these documents as a guide when
+submitting code.
 
 Some additional points:
 
- - Submit your changes early and often. GitHub has [Draft PRs](https://github.blog/2019-02-14-introducing-draft-pull-requests/) that allow you to share your code with others during development. Input and corrections early in the process prevent huge changes later.
+ - Submit your changes early and often. GitHub has
+   [Draft PRs](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+   that allow you to share your code with others during development. Input and
+   corrections early in the process prevent huge changes later.
 
- - Stratum uses a [squash and rebase](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) model. You do **not** have to do this by hand! GitHub will guide you through it, if possible.
+ - Stratum uses a [squash and rebase](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
+   model. You do **not** have to do this by hand! GitHub will guide you through
+   it, if possible.
 
- - Consider opening a separate issue describing the technical details there and [link it to the PR](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords). This keeps code review and design discussions clean.
+ - Consider opening a separate issue describing the technical details there and
+   [link it to the PR](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
+   This keeps code review and design discussions clean.
 
 ### Steps to Follow
 
-1. Fork Stratum into your personal or organization account via the fork button on GitHub.
+1. Fork Stratum into your personal or organization account via the fork button
+   on GitHub.
 
 2. Make your code changes.
 
-3. Pass all unit tests locally. Create new tests for new code and **add the targets to the [build-targets.txt](.circleci/build-targets.txt) and [test-targets.txt](.circleci/test-targets.txt) files** in the same PR, so CI can pick them up! Execute the following command in the Stratum root directory to run all currently enabled tests: `xargs -a .circleci/test-targets.txt bazel test`
+3. Pass all unit tests locally. Create new tests for new code and **add the
+   targets to the [build-targets.txt](.circleci/build-targets.txt) and
+   [test-targets.txt](.circleci/test-targets.txt) files** in the same PR, so CI
+   can pick them up! Execute the following command in the Stratum root directory
+   to run all currently enabled tests:
+   `xargs -a .circleci/test-targets.txt bazel test`
 
-4. Check code style compliance with `cpplint` and `clang-format` (pre-installed in development docker container). If you're editing Bazel files, consider [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier) as well (also pre-installed).
+4. Check code style compliance with `cpplint` and `clang-format`
+   (pre-installed in development docker container). If you're editing Bazel
+   files, consider [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier)
+   as well (also pre-installed).
 
-5. Create a [Pull Request](https://github.com/stratum/stratum/compare). Consider [allowing maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make changes if you want direct assistance from maintainers.
+5. Create a [Pull Request](https://github.com/stratum/stratum/compare). Consider
+   [allowing maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
+   to make changes if you want direct assistance from maintainers.
 
-6. Wait for [CI checks](https://circleci.com/gh/stratum/stratum) to pass. You can check the [coverage report](https://codecov.io/gh/stratum/stratum) after they ran. Repeat steps 3. and 4. as necessary. **Passing CI is mandatory.** If the CI check does not run automatically, make sure you [unfollow your fork](https://support.circleci.com/hc/en-us/articles/360008097173) on CircleCI.
+6. Wait for [CI checks](https://circleci.com/gh/stratum/stratum) to pass. You
+   can check the [coverage report](https://codecov.io/gh/stratum/stratum) after
+   they ran. Repeat steps 3. and 4. as necessary. **Passing CI is mandatory.**
+   If the CI check does not run automatically, make sure you [unfollow your fork](https://support.circleci.com/hc/en-us/articles/360008097173)
+   on CircleCI.
 
-7. Await review. Everyone can comment on code changes, but only Collaborators and above can give final review approval. **All changes must get at least one approval**. Join one of the [communication channels](https://wiki.opennetworking.org/display/COM/Stratum+Wiki+Home+Page) to request a review or to bring additional attention to your PR.
+7. Await review. Everyone can comment on code changes, but only Collaborators
+   and above can give final review approval. **All changes must get at least one
+   approval**. Join one of the [communication channels](https://wiki.opennetworking.org/display/COM/Stratum+Wiki+Home+Page)
+   to request a review or to bring additional attention to your PR.
 
 ## Community Guidelines
 
-This project follows [Google's Open Source Community
-Guidelines](https://opensource.google.com/conduct/) and ONF's [Code of Conduct](CODE_OF_CONDUCT.md).
+This project follows [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/)
+and ONF's [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This PR adds a linter for markdown files: https://github.com/markdownlint/markdownlint

The rule set is configurable and, considering the state of our files, allow ramping up the strictness over time.
Initially we only enforce the line length rule and fix the main README and CONTRIBUTING files accordingly.

Despite the tempting offerings (i.e. lures into vendor lock-in) in form of [GitHub actions](https://github.com/github/super-linter), the check is implemented as a plain bash script and using Docker.  Users will have no problems running CI locally:

```bash
.circleci/lint-markdown.sh
```
