### PR TITLE
Move default pipeline config to /etc/stratum and package it

### DIFF
--- a/stratum/hal/config/BUILD
+++ b/stratum/hal/config/BUILD
@@ -49,6 +49,7 @@ filegroup(
     ]) + [
         "bcm_hardware_specs.pb.txt",
         "dummy_serdes_db.pb.txt",
+        "pipeline_cfg.pb.txt",
     ],
 )
 

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -28,7 +28,7 @@
 #include "stratum/public/lib/error.h"
 
 DEFINE_string(forwarding_pipeline_configs_file,
-              "/var/run/stratum/pipeline_cfg.pb.txt",
+              "/etc/stratum/pipeline_cfg.pb.txt",
               "The latest set of verified ForwardingPipelineConfig protos "
               "pushed to the switch. This file is updated whenever "
               "ForwardingPipelineConfig proto for switching node is added or "

--- a/stratum/tools/stratum-replay/README.md
+++ b/stratum/tools/stratum-replay/README.md
@@ -22,7 +22,7 @@ the pipeline config.
 
 ```
 -write_req_log_file=/var/log/stratum/p4_writes.pb.txt
--forwarding_pipeline_configs_file=/var/run/stratum/pipeline_cfg.pb.txt
+-forwarding_pipeline_configs_file=/etc/stratum/pipeline_cfg.pb.txt
 ```
 
 If you override any flags above, make sure to use a non-empty and valid path.
@@ -49,7 +49,7 @@ Next, we can use `docker cp` command to copy files we need
 
 ```
 $ docker cp 4c615277261d:/var/log/stratum/p4_writes.pb.txt .
-$ docker cp 4c615277261d:/var/run/stratum/pipeline_cfg.pb.txt .
+$ docker cp 4c615277261d:/etc/stratum/pipeline_cfg.pb.txt .
 ```
 
 You should be able to see those files in the current working directory.


### PR DESCRIPTION
This PR moves the default location of the pipeline config file (`-forwarding_pipeline_configs_file`) from `/var/run/stratum` to `/etc/stratum` and packages it as an empty file to silence an error message at startup.

Rationale:
- [P4RT spec](https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html#sec-restarts) is not completely clear on the pipeline across restarts (pipeline _state_ must be cleared)
- ChassisConfig also resides under `/etc` and is modified at runtime by Stratum (gNMI set), so there is no concern about doing the same with the pipeline
- `/var/run/` files cannot be included in a Debian package because it's created at runtime
-  `-forwarding_pipeline_configs_file` remains configurable
- Fixes the `StratumErrorSpace::ERR_FILE_NOT_FOUND: /var/run/stratum/pipeline_cfg.pb.txt not found.` error on first start
  - The code already handles the empty file case with a warning: https://github.com/stratum/stratum/blob/e004b0aede22d5c86ffef55bcb2f5f76a82bdc8b/stratum/hal/lib/common/p4_service.cc#L141-L145