### PR TITLE
Implement a dummy ForwardingViability handler in all switches

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -706,6 +706,15 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       resp.mutable_sdn_port_id()->set_port_id(sdk_port_id);
       break;
     }
+    case Request::kForwardingViability: {
+      // Find current port forwarding viable state for port located at:
+      // - node_id: req.forwarding_viable().node_id()
+      // - port_id: req.forwarding_viable().port_id()
+      // and then write it into the response.
+      resp.mutable_forwarding_viability()->set_state(
+          TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
+      break;
+    }
     default:
       RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
   }

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -257,6 +257,7 @@ namespace {
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
+      case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kFrontPanelPortInfo:
       case DataRequest::Request::kLoopbackStatus:
@@ -280,7 +281,7 @@ namespace {
             MAKE_ERROR(ERR_UNIMPLEMENTED)
             << "DataRequest field "
             << req.descriptor()->FindFieldByNumber(req.request_case())->name()
-            << " is not supported yet: " << req.ShortDebugString() << ".";
+            << " is not supported yet!";
         break;
     }
     if (status.ok()) {

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -203,6 +203,7 @@ BfrtSwitch::~BfrtSwitch() {}
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
+      case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kFrontPanelPortInfo:
       case DataRequest::Request::kLoopbackStatus:
@@ -231,9 +232,9 @@ BfrtSwitch::~BfrtSwitch() {}
       default:
         status =
             MAKE_ERROR(ERR_UNIMPLEMENTED)
-            << "Request type "
+            << "DataRequest field "
             << req.descriptor()->FindFieldByNumber(req.request_case())->name()
-            << " is not supported yet: " << req.ShortDebugString() << ".";
+            << " is not supported yet!";
         break;
     }
     if (status.ok()) {

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -353,7 +353,7 @@ BcmSwitch::~BcmSwitch() {}
         // - port_id: req.forwarding_viable().port_id()
         // and then write it into the response.
         resp.mutable_forwarding_viability()->set_state(
-            TRUNK_MEMBER_BLOCK_STATE_FORWARDING);
+            TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
         break;
       case DataRequest::Request::kMemoryErrorAlarm: {
         // Find current state of memory-error alarm

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -265,6 +265,15 @@ namespace {
                                       resp.mutable_port_counters()));
       break;
     }
+    case DataRequest::Request::kForwardingViability: {
+      // Find current port forwarding viable state for port located at:
+      // - node_id: req.forwarding_viable().node_id()
+      // - port_id: req.forwarding_viable().port_id()
+      // and then write it into the response.
+      resp.mutable_forwarding_viability()->set_state(
+          TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
+      break;
+    }
     case Request::kAutonegStatus: {
       ASSIGN_OR_RETURN(auto* singleton,
                        GetSingletonPort(request.autoneg_status().node_id(),

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -178,6 +178,7 @@ Bmv2Switch::~Bmv2Switch() {}
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
+      case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kSdnPortId:
         resp = bmv2_chassis_manager_->GetPortData(req);
@@ -187,7 +188,7 @@ Bmv2Switch::~Bmv2Switch() {}
             MAKE_ERROR(ERR_UNIMPLEMENTED)
             << "DataRequest field "
             << req.descriptor()->FindFieldByNumber(req.request_case())->name()
-            << " is not supported yet: " << req.ShortDebugString() << ".";
+            << " is not supported yet!";
         break;
     }
     if (resp.ok()) {

--- a/stratum/hal/lib/dummy/dummy_switch.cc
+++ b/stratum/hal/lib/dummy/dummy_switch.cc
@@ -234,10 +234,10 @@ namespace dummy_switch {
   if (node_id != 0) {
     ASSIGN_OR_RETURN(dummy_node, GetDummyNode(node_id));
   }
-  for (const auto& request : requests.requests()) {
+  for (const auto& req : requests.requests()) {
     DataResponse resp;
     ::util::StatusOr<DataResponse> status_or_resp;
-    switch (request.request_case()) {
+    switch (req.request_case()) {
       case Request::kOperStatus:
       case Request::kAdminStatus:
       case Request::kMacAddress:
@@ -249,21 +249,21 @@ namespace dummy_switch {
       case Request::kForwardingViability:
       case Request::kHealthIndicator:
       case Request::kHardwarePort:
-        status_or_resp = dummy_node->RetrievePortData(request);
+        status_or_resp = dummy_node->RetrievePortData(req);
         break;
       case Request::kMemoryErrorAlarm:
       case Request::kFlowProgrammingExceptionAlarm:
       case Request::kNodeInfo:
-        status_or_resp = chassis_mgr_->RetrieveChassisData(request);
+        status_or_resp = chassis_mgr_->RetrieveChassisData(req);
         break;
       case Request::kPortQosCounters:
-        status_or_resp = dummy_node->RetrievePortQosData(request);
+        status_or_resp = dummy_node->RetrievePortQosData(req);
         break;
       case Request::kFrontPanelPortInfo: {
         FrontPanelPortInfo front_panel_port_info;
         std::pair<uint64, uint32> node_port_pair =
-            std::make_pair(request.front_panel_port_info().node_id(),
-                           request.front_panel_port_info().port_id());
+            std::make_pair(req.front_panel_port_info().node_id(),
+                           req.front_panel_port_info().port_id());
         int slot = node_port_id_to_slot[node_port_pair];
         int port = node_port_id_to_port[node_port_pair];
         ::util::Status status = phal_interface_->GetFrontPanelPortInfo(
@@ -277,8 +277,8 @@ namespace dummy_switch {
       }
       case DataRequest::Request::kOpticalTransceiverInfo: {
         ::util::Status status = phal_interface_->GetOpticalTransceiverInfo(
-            request.optical_transceiver_info().module(),
-            request.optical_transceiver_info().network_interface(),
+            req.optical_transceiver_info().module(),
+            req.optical_transceiver_info().network_interface(),
             resp.mutable_optical_transceiver_info());
         if (status.ok()) {
           status_or_resp = resp;
@@ -288,18 +288,15 @@ namespace dummy_switch {
         break;
       }
       case DataRequest::Request::kSdnPortId:
-        resp.mutable_sdn_port_id()->set_port_id(
-            request.sdn_port_id().port_id());
+        resp.mutable_sdn_port_id()->set_port_id(req.sdn_port_id().port_id());
         status_or_resp = resp;
         break;
       default:
         status_or_resp =
             MAKE_ERROR(ERR_UNIMPLEMENTED)
             << "DataRequest field "
-            << request.descriptor()
-                   ->FindFieldByNumber(request.request_case())
-                   ->name()
-            << " is not supported yet: " << request.ShortDebugString() << ".";
+            << req.descriptor()->FindFieldByNumber(req.request_case())->name()
+            << " is not supported yet!";
         break;
     }
     if (status_or_resp.ok()) writer->Write(status_or_resp.ValueOrDie());

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -223,6 +223,15 @@ namespace {
                                       resp.mutable_port_counters()));
       break;
     }
+    case Request::kForwardingViability: {
+      // Find current port forwarding viable state for port located at:
+      // - node_id: req.forwarding_viable().node_id()
+      // - port_id: req.forwarding_viable().port_id()
+      // and then write it into the response.
+      resp.mutable_forwarding_viability()->set_state(
+          TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
+      break;
+    }
     case Request::kAutonegStatus: {
       ASSIGN_OR_RETURN(auto* singleton,
                        GetSingletonPort(request.autoneg_status().node_id(),

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -186,6 +186,7 @@ NP4Switch::~NP4Switch() {}
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
+      case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kSdnPortId:
         resp = np4_chassis_manager_->GetPortData(req);


### PR DESCRIPTION
Not handling the `ForwardingViability` request type in the switch interface leads to undesirable errors in the log. This PR normalizes the behavior across all `SwitchInterface` implementations with stratum-bcm, where we now always return `TRUNK_MEMBER_BLOCK_STATE_UNKNOWN`.

This behavior is in line with our decision that all `SwitchInterface` implementations must implement all message types.