### PR TITLE
Implement a dummy MacAddress handler in all switches

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -641,6 +641,15 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       resp.mutable_admin_status()->set_state(config->admin_state);
       break;
     }
+    case Request::kMacAddress: {
+      // TODO(unknown) Find out why the controller needs it.
+      // Find MAC address of port located at:
+      // - node_id: req.mac_address().node_id()
+      // - port_id: req.mac_address().port_id()
+      // and then write it into the response.
+      resp.mutable_mac_address()->set_mac_address(0ull);
+      break;
+    }
     case Request::kPortSpeed: {
       ASSIGN_OR_RETURN(auto* config,
                        GetPortConfig(request.port_speed().node_id(),

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -254,6 +254,7 @@ namespace {
     switch (req.request_case()) {
       case DataRequest::Request::kOperStatus:
       case DataRequest::Request::kAdminStatus:
+      case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -200,6 +200,7 @@ BfrtSwitch::~BfrtSwitch() {}
     switch (req.request_case()) {
       case DataRequest::Request::kOperStatus:
       case DataRequest::Request::kAdminStatus:
+      case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -328,7 +328,7 @@ BcmSwitch::~BcmSwitch() {}
         // - node_id: req.mac_address().node_id()
         // - port_id: req.mac_address().port_id()
         // and then write it into the response.
-        resp.mutable_mac_address()->set_mac_address(0x112233445566ull);
+        resp.mutable_mac_address()->set_mac_address(0ull);
         break;
       case DataRequest::Request::kPortCounters: {
         // Find current port counters for port located at:

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -243,6 +243,15 @@ namespace {
           singleton->config_params().admin_state());
       break;
     }
+    case Request::kMacAddress: {
+      // TODO(unknown) Find out why the controller needs it.
+      // Find MAC address of port located at:
+      // - node_id: req.mac_address().node_id()
+      // - port_id: req.mac_address().port_id()
+      // and then write it into the response.
+      resp.mutable_mac_address()->set_mac_address(0ull);
+      break;
+    }
     case Request::kPortSpeed: {
       ASSIGN_OR_RETURN(auto* singleton,
                        GetSingletonPort(request.port_speed().node_id(),

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -175,6 +175,7 @@ Bmv2Switch::~Bmv2Switch() {}
     switch (req.request_case()) {
       case DataRequest::Request::kOperStatus:
       case DataRequest::Request::kAdminStatus:
+      case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -201,6 +201,15 @@ namespace {
           singleton->config_params().admin_state());
       break;
     }
+    case Request::kMacAddress: {
+      // TODO(unknown) Find out why the controller needs it.
+      // Find MAC address of port located at:
+      // - node_id: req.mac_address().node_id()
+      // - port_id: req.mac_address().port_id()
+      // and then write it into the response.
+      resp.mutable_mac_address()->set_mac_address(0ull);
+      break;
+    }
     case Request::kPortSpeed: {
       ASSIGN_OR_RETURN(auto* singleton,
                        GetSingletonPort(request.port_speed().node_id(),

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -183,6 +183,7 @@ NP4Switch::~NP4Switch() {}
     switch (req.request_case()) {
       case DataRequest::Request::kOperStatus:
       case DataRequest::Request::kAdminStatus:
+      case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:


### PR DESCRIPTION
Not handling the MacAddress request type in the switch interface leads to undesirable errors in the log. This normalizes the behavior across all switches, which now return `00:00:00:00:00:00`.

This behavior is in line with our decision that all SwitchInterface implementations must implement all message types.