### PR TITLE
Implement hardware-port as leaf reference

### DIFF
--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1190,11 +1190,6 @@ message AutonegotiationStatus {
   TriState state = 1;
 }
 
-// Wrapper around the hardware port.
-message HardwarePort {
-  string name = 1;
-}
-
 // Wrapper around the FEC mode.
 message FecStatus {
   FecMode mode = 1;
@@ -1288,7 +1283,6 @@ message DataResponse {
     HealthIndicator health_indicator = 14;
     AutonegotiationStatus autoneg_status = 15;
     FrontPanelPortInfo front_panel_port_info = 16;
-    HardwarePort hardware_port = 17;
     FecStatus fec_status = 18;
     OpticalTransceiverInfo optical_transceiver_info = 19;
     LoopbackStatus loopback_status = 20;

--- a/stratum/hal/lib/dummy/dummy_node.cc
+++ b/stratum/hal/lib/dummy/dummy_node.cc
@@ -292,10 +292,6 @@ bool DummyNode::DummyNodeEventWriter::Write(const DummyNodeEventPtr& msg) {
       resp.mutable_health_indicator()->set_state(
           port_status.health_indicator.state());
       break;
-    case Request::kHardwarePort:
-      // FIXME(Yi Tseng): Sets hardware port name
-      resp.mutable_hardware_port()->set_name("");
-      break;
     default:
       return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet!";
   }

--- a/stratum/hal/lib/dummy/dummy_switch.cc
+++ b/stratum/hal/lib/dummy/dummy_switch.cc
@@ -248,7 +248,6 @@ namespace dummy_switch {
       case Request::kPortCounters:
       case Request::kForwardingViability:
       case Request::kHealthIndicator:
-      case Request::kHardwarePort:
         status_or_resp = dummy_node->RetrievePortData(req);
         break;
       case Request::kMemoryErrorAlarm:


### PR DESCRIPTION
This removes the field from the SwitchInterface and fixes the errors when querying it on unsupported switches.