### PR TITLE
Implement a dummy health indicator handler in all switches

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -724,6 +724,14 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
           TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
       break;
     }
+    case DataRequest::Request::kHealthIndicator: {
+      // Find current port health indicator (LED) for port located at:
+      // - node_id: req.health_indicator().node_id()
+      // - port_id: req.health_indicator().port_id()
+      // and then write it into the response.
+      resp.mutable_health_indicator()->set_state(HEALTH_STATE_UNKNOWN);
+      break;
+    }
     default:
       RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
   }

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -547,7 +547,22 @@ TEST_F(BFChassisManagerTest, GetPortData) {
                   &DataResponse::sdn_port_id, &DataResponse::has_sdn_port_id,
                   &SdnPortId::port_id, sdkPortId);
 
-  // Unsupprorted
+  // Forwarding Viability
+  GetPortDataTest(bf_chassis_manager_.get(), kNodeId, portId,
+                  &DataRequest::Request::mutable_forwarding_viability,
+                  &DataResponse::forwarding_viability,
+                  &DataResponse::has_forwarding_viability,
+                  &ForwardingViability::state,
+                  TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
+
+  // Health Indicator
+  GetPortDataTest(bf_chassis_manager_.get(), kNodeId, portId,
+                  &DataRequest::Request::mutable_health_indicator,
+                  &DataResponse::health_indicator,
+                  &DataResponse::has_health_indicator, &HealthIndicator::state,
+                  HEALTH_STATE_UNKNOWN);
+
+  // Unsupported
   DataRequest::Request req;
   req.mutable_lacp_router_mac()->set_node_id(kNodeId);
   req.mutable_lacp_router_mac()->set_port_id(portId);

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -259,6 +259,7 @@ namespace {
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kForwardingViability:
+      case DataRequest::Request::kHealthIndicator:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kFrontPanelPortInfo:
       case DataRequest::Request::kLoopbackStatus:

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -205,6 +205,7 @@ BfrtSwitch::~BfrtSwitch() {}
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kForwardingViability:
+      case DataRequest::Request::kHealthIndicator:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kFrontPanelPortInfo:
       case DataRequest::Request::kLoopbackStatus:

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -345,7 +345,7 @@ BcmSwitch::~BcmSwitch() {}
         // - node_id: req.health_indicator().node_id()
         // - port_id: req.health_indicator().port_id()
         // and then write it into the response.
-        resp.mutable_health_indicator()->set_state(HEALTH_STATE_GOOD);
+        resp.mutable_health_indicator()->set_state(HEALTH_STATE_UNKNOWN);
         break;
       case DataRequest::Request::kForwardingViability:
         // Find current port forwarding viable state for port located at:

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -283,6 +283,14 @@ namespace {
           TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
       break;
     }
+    case DataRequest::Request::kHealthIndicator: {
+      // Find current port health indicator (LED) for port located at:
+      // - node_id: req.health_indicator().node_id()
+      // - port_id: req.health_indicator().port_id()
+      // and then write it into the response.
+      resp.mutable_health_indicator()->set_state(HEALTH_STATE_UNKNOWN);
+      break;
+    }
     case Request::kAutonegStatus: {
       ASSIGN_OR_RETURN(auto* singleton,
                        GetSingletonPort(request.autoneg_status().node_id(),

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -179,6 +179,7 @@ Bmv2Switch::~Bmv2Switch() {}
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
+      case DataRequest::Request::kHealthIndicator:
       case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kSdnPortId:

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -241,6 +241,14 @@ namespace {
           TRUNK_MEMBER_BLOCK_STATE_UNKNOWN);
       break;
     }
+    case DataRequest::Request::kHealthIndicator: {
+      // Find current port health indicator (LED) for port located at:
+      // - node_id: req.health_indicator().node_id()
+      // - port_id: req.health_indicator().port_id()
+      // and then write it into the response.
+      resp.mutable_health_indicator()->set_state(HEALTH_STATE_UNKNOWN);
+      break;
+    }
     case Request::kAutonegStatus: {
       ASSIGN_OR_RETURN(auto* singleton,
                        GetSingletonPort(request.autoneg_status().node_id(),

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -188,6 +188,7 @@ NP4Switch::~NP4Switch() {}
       case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kForwardingViability:
+      case DataRequest::Request::kHealthIndicator:
       case DataRequest::Request::kAutonegStatus:
       case DataRequest::Request::kSdnPortId:
         resp = np4_chassis_manager_->GetPortData(req);


### PR DESCRIPTION
Not handling the HealthIndicator request type in the switch interface leads to undesirable errors in the log. This normalizes the behavior across all switches, which now return `HEALTH_STATE_UNKNOWN`.

This behavior is in line with our decision that all SwitchInterface implementations must implement all message types.