### PR TITLE
Use `RE2` for yang mac-address parsing

### DIFF
--- a/stratum/hal/bin/dummy/dummy_cli.cc
+++ b/stratum/hal/bin/dummy/dummy_cli.cc
@@ -101,9 +101,9 @@ class DummyCli {
   }
 
   ::util::StatusOr<MacAddress> ParseMacAddress(const std::string& arg) {
-    RET_CHECK(IsMacAddressValid(arg));
+    ASSIGN_OR_RETURN(uint64 mac_address, YangStringToMacAddress(arg));
     MacAddress ma;
-    ma.set_mac_address(YangStringToMacAddress(arg));
+    ma.set_mac_address(mac_address);
     return ma;
   }
 

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -731,6 +731,7 @@ stratum_cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -282,7 +282,7 @@ uint64 ConvertStringToSpeedBps(const std::string& speed_string) {
   } else if (speed_string == "SPEED_100GB") {
     return kHundredGigBps;
   } else {
-    return 0LL;
+    return 0ull;
   }
 }
 

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -318,10 +318,10 @@ bool ConvertTrunkMemberBlockStateToBool(const TrunkMemberBlockState& state) {
 }
 
 std::string MacAddressToYangString(const uint64& mac_address) {
-  return absl::StrFormat("%x:%x:%x:%x:%x:%x", (mac_address >> 40) & 0xFF,
-                         (mac_address >> 32) & 0xFF, (mac_address >> 24) & 0xFF,
-                         (mac_address >> 16) & 0xFF, (mac_address >> 8) & 0xFF,
-                         mac_address & 0xFF);
+  return absl::StrFormat("%02x:%02x:%02x:%02x:%02x:%02x",
+                         (mac_address >> 40) & 0xFF, (mac_address >> 32) & 0xFF,
+                         (mac_address >> 24) & 0xFF, (mac_address >> 16) & 0xFF,
+                         (mac_address >> 8) & 0xFF, mac_address & 0xFF);
 }
 
 ::util::StatusOr<uint64> YangStringToMacAddress(std::string yang_string) {

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -323,16 +323,16 @@ std::string MacAddressToYangString(const uint64& mac_address) {
                          (mac_address >> 8) & 0xFF, mac_address & 0xFF);
 }
 
-::util::StatusOr<uint64> YangStringToMacAddress(std::string yang_string) {
+::util::StatusOr<uint64> YangStringToMacAddress(
+    const std::string& yang_string) {
   RET_CHECK(
       RE2::FullMatch(yang_string, R"#(^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$)#"))
       << "Provided string " << yang_string << " is not a valid MAC address.";
-  // Remove colons.
-  absl::StrReplaceAll({{":", ""}}, &yang_string);
   uint64 mac_address;
-  // We rather use an absl internal function than strtoull.
-  RET_CHECK(absl::numbers_internal::safe_strtou64_base(yang_string,
-                                                       &mac_address, 16));
+  // Remove colons and parse as hex number.
+  // We'd rather use an Abseil internal function than std::strtoull.
+  RET_CHECK(absl::numbers_internal::safe_strtou64_base(
+      absl::StrReplaceAll(yang_string, {{":", ""}}), &mac_address, 16));
 
   return mac_address;
 }

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -431,6 +431,8 @@ std::string ConvertHwStateToPresentString(const HwState& hw_state) {
 
 uint64 ConvertHzToMHz(const uint64& val) { return val / 1000000; }
 
+uint64 ConvertMHzToHz(const uint64& val) { return val * 1000000; }
+
 ::util::Status ConvertStringToLogSeverity(const std::string& severity_string,
                                           LoggingConfig* logging_config) {
   if (severity_string == "CRITICAL") {

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -6,7 +6,6 @@
 
 #include <cfenv>  // NOLINT
 #include <cmath>
-#include <regex>    // NOLINT
 #include <sstream>  // IWYU pragma: keep
 
 #include "absl/strings/str_replace.h"

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -324,15 +324,15 @@ std::string MacAddressToYangString(const uint64& mac_address) {
 }
 
 ::util::StatusOr<uint64> YangStringToMacAddress(std::string yang_string) {
-  CHECK_RETURN_IF_FALSE(
+  RET_CHECK(
       RE2::FullMatch(yang_string, R"#(^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$)#"))
       << "Provided string " << yang_string << " is not a valid MAC address.";
   // Remove colons.
   absl::StrReplaceAll({{":", ""}}, &yang_string);
   uint64 mac_address;
   // We rather use an absl internal function than strtoull.
-  CHECK_RETURN_IF_FALSE(absl::numbers_internal::safe_strtou64_base(
-      yang_string, &mac_address, 16));
+  RET_CHECK(absl::numbers_internal::safe_strtou64_base(yang_string,
+                                                       &mac_address, 16));
 
   return mac_address;
 }

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -194,7 +194,7 @@ std::string MacAddressToYangString(const uint64& mac_address);
 
 // A helper function that convert data received from the gNMI interface into a
 // format expected by the HAL (MAC addresses are expected to be uint64).
-::util::StatusOr<uint64> YangStringToMacAddress(std::string yang_string);
+::util::StatusOr<uint64> YangStringToMacAddress(const std::string& yang_string);
 
 // A helper function that check if autoneg state is enabled.
 bool IsPortAutonegEnabled(const TriState& state);

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -193,12 +193,8 @@ bool ConvertTrunkMemberBlockStateToBool(const TrunkMemberBlockState& state);
 std::string MacAddressToYangString(const uint64& mac_address);
 
 // A helper function that convert data received from the gNMI interface into a
-// format expected by the HAL (MAC addresses are expected to be
-// uint64).
-uint64 YangStringToMacAddress(const std::string& yang_string);
-
-// A helper function that check if string of mac_address is valid.
-bool IsMacAddressValid(const std::string& mac_address);
+// format expected by the HAL (MAC addresses are expected to be uint64).
+::util::StatusOr<uint64> YangStringToMacAddress(std::string yang_string);
 
 // A helper function that check if autoneg state is enabled.
 bool IsPortAutonegEnabled(const TriState& state);

--- a/stratum/hal/lib/common/utils_test.cc
+++ b/stratum/hal/lib/common/utils_test.cc
@@ -157,6 +157,14 @@ TEST(CommonUtilsTest, YangStringToMacAddress) {
               IsOkAndHolds(0x000000111111ul));
   EXPECT_THAT(YangStringToMacAddress("0:0:0:0:0:0").status(),
               StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("11:22:33:44:55:66:77").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("11;22;33;44;55;66").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("11-22-33-44-55-66").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("st:ra:tu:mr:oc:ks").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
   EXPECT_THAT(YangStringToMacAddress("0").status(),
               StatusIs(_, ERR_INVALID_PARAM, _));
   EXPECT_THAT(YangStringToMacAddress("").status(),

--- a/stratum/hal/lib/common/utils_test.cc
+++ b/stratum/hal/lib/common/utils_test.cc
@@ -19,6 +19,9 @@ namespace stratum {
 namespace hal {
 
 using ::google::protobuf::util::MessageDifferencer;
+using test_utils::IsOkAndHolds;
+using test_utils::StatusIs;
+using ::testing::_;
 
 TEST(CommonUtilsTest, PrintNodeForEmptyNodeProto) {
   Node node;
@@ -134,6 +137,34 @@ TEST(CommonUtilsTest, PrintPortState) {
   EXPECT_EQ("DOWN", PrintPortState(PORT_STATE_DOWN));
   EXPECT_EQ("FAILED", PrintPortState(PORT_STATE_FAILED));
   EXPECT_EQ("UNKNOWN", PrintPortState(PORT_STATE_UNKNOWN));
+}
+
+TEST(CommonUtilsTest, MacAddressToYangString) {
+  EXPECT_EQ("00:00:00:00:00:00", MacAddressToYangString(0ul));
+  EXPECT_EQ("11:22:33:44:55:66", MacAddressToYangString(0x112233445566ul));
+  EXPECT_EQ("01:02:03:04:05:06", MacAddressToYangString(0x010203040506ul));
+  EXPECT_EQ("00:00:00:11:11:11", MacAddressToYangString(0x000000111111ul));
+  EXPECT_EQ("11:22:33:44:55:66", MacAddressToYangString(0xffff112233445566ul));
+}
+
+TEST(CommonUtilsTest, YangStringToMacAddress) {
+  EXPECT_THAT(YangStringToMacAddress("00:00:00:00:00:00"), IsOkAndHolds(0ul));
+  EXPECT_THAT(YangStringToMacAddress("01:02:03:04:05:06"),
+              IsOkAndHolds(0x010203040506ul));
+  EXPECT_THAT(YangStringToMacAddress("11:22:33:44:55:66"),
+              IsOkAndHolds(0x112233445566ul));
+  EXPECT_THAT(YangStringToMacAddress("00:00:00:11:11:11"),
+              IsOkAndHolds(0x000000111111ul));
+  EXPECT_THAT(YangStringToMacAddress("0:0:0:0:0:0").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("0").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("123").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
+  EXPECT_THAT(YangStringToMacAddress("112233445566").status(),
+              StatusIs(_, ERR_INVALID_PARAM, _));
 }
 
 TEST(PortUtilsTest, BuildSingletonPort) {

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -1696,9 +1696,9 @@ void SetUpInterfacesInterfaceEthernetStateAutoNegotiate(uint64 node_id,
 // "&DataResponse::PortCounters::message", where message field in
 // DataResponse::Counters.
 TreeNodeEventHandler GetPollCounterFunctor(uint64 node_id, uint32 port_id,
-                                           YangParseTree* tree,
                                            uint64 (PortCounters::*func_ptr)()
-                                               const) {
+                                               const,
+                                           YangParseTree* tree) {
   return [tree, node_id, port_id, func_ptr](const GnmiEvent& event,
                                             const ::gnmi::Path& path,
                                             GnmiSubscribeStream* stream) {
@@ -1733,7 +1733,7 @@ void SetUpInterfacesInterfaceStateCountersInOctets(uint64 node_id,
                                                    TreeNode* node,
                                                    YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::in_octets);
+      GetPollCounterFunctor(node_id, port_id, &PortCounters::in_octets, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInOctets);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1756,7 +1756,7 @@ void SetUpInterfacesInterfaceStateCountersOutOctets(uint64 node_id,
                                                     TreeNode* node,
                                                     YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::out_octets);
+      GetPollCounterFunctor(node_id, port_id, &PortCounters::out_octets, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutOctets);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1778,8 +1778,8 @@ void SetUpInterfacesInterfaceStateCountersInUnicastPkts(uint64 node_id,
                                                         uint32 port_id,
                                                         TreeNode* node,
                                                         YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::in_unicast_pkts);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::in_unicast_pkts, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInUnicastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1801,8 +1801,8 @@ void SetUpInterfacesInterfaceStateCountersOutUnicastPkts(uint64 node_id,
                                                          uint32 port_id,
                                                          TreeNode* node,
                                                          YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::out_unicast_pkts);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::out_unicast_pkts, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutUnicastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1824,8 +1824,8 @@ void SetUpInterfacesInterfaceStateCountersInBroadcastPkts(uint64 node_id,
                                                           uint32 port_id,
                                                           TreeNode* node,
                                                           YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::in_broadcast_pkts);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::in_broadcast_pkts, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInBroadcastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1845,8 +1845,8 @@ void SetUpInterfacesInterfaceStateCountersInBroadcastPkts(uint64 node_id,
 // /interfaces/interface[name=<name>]/state/counters/out-broadcast-pkts
 void SetUpInterfacesInterfaceStateCountersOutBroadcastPkts(
     uint64 node_id, uint32 port_id, TreeNode* node, YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::out_broadcast_pkts);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::out_broadcast_pkts, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutBroadcastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1869,7 +1869,7 @@ void SetUpInterfacesInterfaceStateCountersInDiscards(uint64 node_id,
                                                      TreeNode* node,
                                                      YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::in_discards);
+      GetPollCounterFunctor(node_id, port_id, &PortCounters::in_discards, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInDiscards);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1891,8 +1891,8 @@ void SetUpInterfacesInterfaceStateCountersOutDiscards(uint64 node_id,
                                                       uint32 port_id,
                                                       TreeNode* node,
                                                       YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::out_discards);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id,
+                                            &PortCounters::out_discards, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutDiscards);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1914,8 +1914,8 @@ void SetUpInterfacesInterfaceStateCountersInUnknownProtos(uint64 node_id,
                                                           uint32 port_id,
                                                           TreeNode* node,
                                                           YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::in_unknown_protos);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::in_unknown_protos, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInUnknownProtos);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1937,8 +1937,8 @@ void SetUpInterfacesInterfaceStateCountersInMulticastPkts(uint64 node_id,
                                                           uint32 port_id,
                                                           TreeNode* node,
                                                           YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::in_multicast_pkts);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::in_multicast_pkts, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInMulticastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1961,7 +1961,7 @@ void SetUpInterfacesInterfaceStateCountersInErrors(uint64 node_id,
                                                    TreeNode* node,
                                                    YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::in_errors);
+      GetPollCounterFunctor(node_id, port_id, &PortCounters::in_errors, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInErrors);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1984,7 +1984,7 @@ void SetUpInterfacesInterfaceStateCountersOutErrors(uint64 node_id,
                                                     TreeNode* node,
                                                     YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::out_errors);
+      GetPollCounterFunctor(node_id, port_id, &PortCounters::out_errors, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutErrors);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -2006,8 +2006,8 @@ void SetUpInterfacesInterfaceStateCountersInFcsErrors(uint64 node_id,
                                                       uint32 port_id,
                                                       TreeNode* node,
                                                       YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::in_fcs_errors);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id,
+                                            &PortCounters::in_fcs_errors, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInFcsErrors);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -2027,8 +2027,8 @@ void SetUpInterfacesInterfaceStateCountersInFcsErrors(uint64 node_id,
 // /interfaces/interface[name=<name>]/state/counters/out-multicast-pkts
 void SetUpInterfacesInterfaceStateCountersOutMulticastPkts(
     uint64 node_id, uint32 port_id, TreeNode* node, YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
-                                            &PortCounters::out_multicast_pkts);
+  auto poll_functor = GetPollCounterFunctor(
+      node_id, port_id, &PortCounters::out_multicast_pkts, tree);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutMulticastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -1182,6 +1182,7 @@ void SetUpInterfacesInterfaceConfigEnabled(const bool state, uint64 node_id,
     }
 
     // Update the chassis config.
+    // TODO(max): use std::find to handle lookup failures.
     ChassisConfig* new_config = config->writable();
     for (auto& singleton_port : *new_config->mutable_singleton_ports()) {
       if (singleton_port.node() == node_id && singleton_port.id() == port_id) {
@@ -1351,6 +1352,7 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
     std::string mac_address_string = typed_val->string_val();
     ASSIGN_OR_RETURN(uint64 mac_address,
                      YangStringToMacAddress(mac_address_string));
+
     // Set the value.
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_mac_address,
@@ -3571,7 +3573,9 @@ void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
     port_auto_neg_enabled =
         IsPortAutonegEnabled(singleton.config_params().autoneg());
     port_enabled = IsAdminStateEnabled(singleton.config_params().admin_state());
-    mac_address = singleton.config_params().mac_address();
+    if (singleton.config_params().has_mac_address()) {
+      mac_address = singleton.config_params().mac_address().mac_address();
+    }
     loopback_enabled =
         IsLoopbackStateEnabled(singleton.config_params().loopback_mode());
   }

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -1696,9 +1696,9 @@ void SetUpInterfacesInterfaceEthernetStateAutoNegotiate(uint64 node_id,
 // "&DataResponse::PortCounters::message", where message field in
 // DataResponse::Counters.
 TreeNodeEventHandler GetPollCounterFunctor(uint64 node_id, uint32 port_id,
+                                           YangParseTree* tree,
                                            uint64 (PortCounters::*func_ptr)()
-                                               const,
-                                           YangParseTree* tree) {
+                                               const) {
   return [tree, node_id, port_id, func_ptr](const GnmiEvent& event,
                                             const ::gnmi::Path& path,
                                             GnmiSubscribeStream* stream) {
@@ -1733,7 +1733,7 @@ void SetUpInterfacesInterfaceStateCountersInOctets(uint64 node_id,
                                                    TreeNode* node,
                                                    YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, &PortCounters::in_octets, tree);
+      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::in_octets);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInOctets);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1756,7 +1756,7 @@ void SetUpInterfacesInterfaceStateCountersOutOctets(uint64 node_id,
                                                     TreeNode* node,
                                                     YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, &PortCounters::out_octets, tree);
+      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::out_octets);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutOctets);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1778,8 +1778,8 @@ void SetUpInterfacesInterfaceStateCountersInUnicastPkts(uint64 node_id,
                                                         uint32 port_id,
                                                         TreeNode* node,
                                                         YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::in_unicast_pkts, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::in_unicast_pkts);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInUnicastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1801,8 +1801,8 @@ void SetUpInterfacesInterfaceStateCountersOutUnicastPkts(uint64 node_id,
                                                          uint32 port_id,
                                                          TreeNode* node,
                                                          YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::out_unicast_pkts, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::out_unicast_pkts);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutUnicastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1824,8 +1824,8 @@ void SetUpInterfacesInterfaceStateCountersInBroadcastPkts(uint64 node_id,
                                                           uint32 port_id,
                                                           TreeNode* node,
                                                           YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::in_broadcast_pkts, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::in_broadcast_pkts);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInBroadcastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1845,8 +1845,8 @@ void SetUpInterfacesInterfaceStateCountersInBroadcastPkts(uint64 node_id,
 // /interfaces/interface[name=<name>]/state/counters/out-broadcast-pkts
 void SetUpInterfacesInterfaceStateCountersOutBroadcastPkts(
     uint64 node_id, uint32 port_id, TreeNode* node, YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::out_broadcast_pkts, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::out_broadcast_pkts);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutBroadcastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1869,7 +1869,7 @@ void SetUpInterfacesInterfaceStateCountersInDiscards(uint64 node_id,
                                                      TreeNode* node,
                                                      YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, &PortCounters::in_discards, tree);
+      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::in_discards);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInDiscards);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1891,8 +1891,8 @@ void SetUpInterfacesInterfaceStateCountersOutDiscards(uint64 node_id,
                                                       uint32 port_id,
                                                       TreeNode* node,
                                                       YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id,
-                                            &PortCounters::out_discards, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::out_discards);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutDiscards);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1914,8 +1914,8 @@ void SetUpInterfacesInterfaceStateCountersInUnknownProtos(uint64 node_id,
                                                           uint32 port_id,
                                                           TreeNode* node,
                                                           YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::in_unknown_protos, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::in_unknown_protos);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInUnknownProtos);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1937,8 +1937,8 @@ void SetUpInterfacesInterfaceStateCountersInMulticastPkts(uint64 node_id,
                                                           uint32 port_id,
                                                           TreeNode* node,
                                                           YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::in_multicast_pkts, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::in_multicast_pkts);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInMulticastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1961,7 +1961,7 @@ void SetUpInterfacesInterfaceStateCountersInErrors(uint64 node_id,
                                                    TreeNode* node,
                                                    YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, &PortCounters::in_errors, tree);
+      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::in_errors);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInErrors);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -1984,7 +1984,7 @@ void SetUpInterfacesInterfaceStateCountersOutErrors(uint64 node_id,
                                                     TreeNode* node,
                                                     YangParseTree* tree) {
   auto poll_functor =
-      GetPollCounterFunctor(node_id, port_id, &PortCounters::out_errors, tree);
+      GetPollCounterFunctor(node_id, port_id, tree, &PortCounters::out_errors);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutErrors);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -2006,8 +2006,8 @@ void SetUpInterfacesInterfaceStateCountersInFcsErrors(uint64 node_id,
                                                       uint32 port_id,
                                                       TreeNode* node,
                                                       YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(node_id, port_id,
-                                            &PortCounters::in_fcs_errors, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::in_fcs_errors);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetInFcsErrors);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();
@@ -2027,8 +2027,8 @@ void SetUpInterfacesInterfaceStateCountersInFcsErrors(uint64 node_id,
 // /interfaces/interface[name=<name>]/state/counters/out-multicast-pkts
 void SetUpInterfacesInterfaceStateCountersOutMulticastPkts(
     uint64 node_id, uint32 port_id, TreeNode* node, YangParseTree* tree) {
-  auto poll_functor = GetPollCounterFunctor(
-      node_id, port_id, &PortCounters::out_multicast_pkts, tree);
+  auto poll_functor = GetPollCounterFunctor(node_id, port_id, tree,
+                                            &PortCounters::out_multicast_pkts);
   auto on_change_functor = GetOnChangeFunctor(
       node_id, port_id, &PortCountersChangedEvent::GetOutMulticastPkts);
   auto register_functor = RegisterFunc<PortCountersChangedEvent>();

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -1211,7 +1211,7 @@ TEST_F(YangParseTreeTest,
                               /* Notification will not be called */ nullptr),
               StatusIs(_, _, ContainsRegex("not a TypedValue message")));
 
-  for (auto mac_string : kInvalidMacStrings) {
+  for (const auto& mac_string : kInvalidMacStrings) {
     // Check reaction to wrong value.
     invalid_val.set_string_val(mac_string);
     EXPECT_THAT(

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -1196,6 +1196,7 @@ TEST_F(YangParseTreeTest,
       "00112233445566",        // No colon
       "11:22:333:44:55:66",    // Too many hex digits
       "11:22:3:44:55:66",      // Too few hex digits
+      "0:0:0:0:0:0",           // Too few hex digits
       "",                      // empty mac string
       "st:ra:tu:mr:oc:ks",     // None hex digits
   };

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -1183,7 +1183,7 @@ TEST_F(YangParseTreeTest,
       "interface", "interface-1")("ethernet")("config")("mac-address")();
 
   static constexpr char kMacAddressAsString[] = "11:22:33:44:55:66";
-  static constexpr char kMacStrings[][21] = {
+  static constexpr char kInvalidMacStrings[][21] = {
       "11:22:33:44:55",        // Too short string
       "11:22:33:44:55:66:77",  // Too long string
       "11;22;33;44;55;66",     // Incorrect delimiter
@@ -1197,7 +1197,7 @@ TEST_F(YangParseTreeTest,
       "11:22:333:44:55:66",    // Too many hex digits
       "11:22:3:44:55:66",      // Too few hex digits
       "",                      // empty mac string
-      "st:ra:tu:mr:oc:ks"      // None hex digits
+      "st:ra:tu:mr:oc:ks",     // None hex digits
   };
 
   // Set new value.
@@ -1211,13 +1211,14 @@ TEST_F(YangParseTreeTest,
                               /* Notification will not be called */ nullptr),
               StatusIs(_, _, ContainsRegex("not a TypedValue message")));
 
-  for (auto mac_string : kMacStrings) {
+  for (auto mac_string : kInvalidMacStrings) {
     // Check reaction to wrong value.
     invalid_val.set_string_val(mac_string);
-    EXPECT_THAT(ExecuteOnUpdate(path, invalid_val,
-                                /* SetValue will not be called */ nullptr,
-                                /* Notification will not be called */ nullptr),
-                StatusIs(_, _, ContainsRegex("wrong value")));
+    EXPECT_THAT(
+        ExecuteOnUpdate(path, invalid_val,
+                        /* SetValue will not be called */ nullptr,
+                        /* Notification will not be called */ nullptr),
+        StatusIs(_, ERR_INVALID_PARAM, ContainsRegex("not a valid MAC")));
 
     // Check if mac_address remains unchanged.
     ASSERT_OK(ExecuteOnPoll(path, &resp));

--- a/stratum/lib/constants.h
+++ b/stratum/lib/constants.h
@@ -42,9 +42,6 @@ constexpr char kExternalStratumUrls[] = "0.0.0.0:9339,0.0.0.0:9559";
 constexpr char kProcmonServiceUrl[] = "localhost:28001";
 constexpr char kHalServiceUrl[] = "localhost:28002";
 constexpr char kPhalDbServiceUrl[] = "localhost:28003";
-
-// Rexgex pattern for mac address in openconfig-yang-types.yang
-constexpr char kMacAddressRegex[] = "^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$";
 }  // namespace stratum
 
 #endif  // STRATUM_LIB_CONSTANTS_H_


### PR DESCRIPTION
Addressed issues:

- `::google::protobuf::uint64` -> `uint64`
- `<regex>` -> RE2
- make `YangStringToMacAddress` safer
- comments
- style

This PR also fixes things introduces in commit https://github.com/stratum/stratum/commit/6e71349660bd1dbde65a9c5b765e391559e6a288.