### PR TITLE
Implement LACP MAC in all switch interfaces and unify dummy MAC

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -647,7 +647,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       // - node_id: req.mac_address().node_id()
       // - port_id: req.mac_address().port_id()
       // and then write it into the response.
-      resp.mutable_mac_address()->set_mac_address(0ull);
+      resp.mutable_mac_address()->set_mac_address(kDummyMacAddress);
       break;
     }
     case Request::kPortSpeed: {
@@ -669,6 +669,14 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
                                     request.negotiated_port_speed().port_id()));
       if (port_state != PORT_STATE_UP) break;
       resp.mutable_negotiated_port_speed()->set_speed_bps(*config->speed_bps);
+      break;
+    }
+    case DataRequest::Request::kLacpRouterMac: {
+      // Find LACP System ID MAC address of port located at:
+      // - node_id: req.lacp_router_mac().node_id()
+      // - port_id: req.lacp_router_mac().port_id()
+      // and then write it into the response.
+      resp.mutable_lacp_router_mac()->set_mac_address(kDummyMacAddress);
       break;
     }
     case Request::kPortCounters: {

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -501,6 +501,13 @@ TEST_F(BFChassisManagerTest, GetPortData) {
                   &DataResponse::port_speed, &DataResponse::has_port_speed,
                   &PortSpeed::speed_bps, kHundredGigBps);
 
+  // LACP router MAC
+  GetPortDataTest(bf_chassis_manager_.get(), kNodeId, portId,
+                  &DataRequest::Request::mutable_lacp_router_mac,
+                  &DataResponse::lacp_router_mac,
+                  &DataResponse::has_lacp_router_mac, &MacAddress::mac_address,
+                  0x112233445566ul);
+
   // Negotiated port speed
   GetPortDataTest(bf_chassis_manager_.get(), kNodeId, portId,
                   &DataRequest::Request::mutable_negotiated_port_speed,
@@ -561,15 +568,6 @@ TEST_F(BFChassisManagerTest, GetPortData) {
                   &DataResponse::health_indicator,
                   &DataResponse::has_health_indicator, &HealthIndicator::state,
                   HEALTH_STATE_UNKNOWN);
-
-  // Unsupported
-  DataRequest::Request req;
-  req.mutable_lacp_router_mac()->set_node_id(kNodeId);
-  req.mutable_lacp_router_mac()->set_port_id(portId);
-  auto status = bf_chassis_manager_->GetPortData(req);
-  EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.status().error_code(), ERR_INTERNAL);
-  EXPECT_THAT(status.status().error_message(), HasSubstr("Not supported yet"));
 
   ASSERT_OK(ShutdownAndTestCleanState());
 }

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -257,6 +257,7 @@ namespace {
       case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
+      case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kHealthIndicator:

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -203,6 +203,7 @@ BfrtSwitch::~BfrtSwitch() {}
       case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
+      case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kHealthIndicator:

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -306,7 +306,7 @@ BcmSwitch::~BcmSwitch() {}
         // - node_id: req.lacp_router_mac().node_id()
         // - port_id: req.lacp_router_mac().port_id()
         // and then write it into the response.
-        resp.mutable_lacp_router_mac()->set_mac_address(0x112233445566ull);
+        resp.mutable_lacp_router_mac()->set_mac_address(kDummyMacAddress);
         break;
       case DataRequest::Request::kLacpSystemPriority:
         // Find LACP System priority of port located at:
@@ -328,7 +328,7 @@ BcmSwitch::~BcmSwitch() {}
         // - node_id: req.mac_address().node_id()
         // - port_id: req.mac_address().port_id()
         // and then write it into the response.
-        resp.mutable_mac_address()->set_mac_address(0ull);
+        resp.mutable_mac_address()->set_mac_address(kDummyMacAddress);
         break;
       case DataRequest::Request::kPortCounters: {
         // Find current port counters for port located at:

--- a/stratum/hal/lib/bcm/bcm_switch_test.cc
+++ b/stratum/hal/lib/bcm/bcm_switch_test.cc
@@ -494,38 +494,22 @@ TEST_F(BcmSwitchTest, GetPortAdminStatus) {
   EXPECT_EQ(error.ToString(), details.at(0).ToString());
 }
 
-TEST_F(BcmSwitchTest, GetPortLoopbackStatus) {
-  PushChassisConfigSuccess();
-
+TEST_F(BcmSwitchTest, GetMacAddressPass) {
   WriterMock<DataResponse> writer;
   DataResponse resp;
-
-  // Expect successful retrieval followed by failure.
-  ::util::Status error = ::util::UnknownErrorBuilder(GTL_LOC) << "error";
-  EXPECT_CALL(*bcm_chassis_manager_mock_,
-              GetPortLoopbackState(kNodeId, kPortId))
-      .WillOnce(Return(LOOPBACK_STATE_NONE))
-      .WillOnce(Return(error));
+  // Expect Write() call and store data in resp.
   ExpectMockWriteDataResponse(&writer, &resp);
 
   DataRequest req;
-  auto* req_info = req.add_requests()->mutable_loopback_status();
-  req_info->set_node_id(kNodeId);
-  req_info->set_port_id(kPortId);
-  std::vector<::util::Status> details;
+  auto* request = req.add_requests()->mutable_mac_address();
+  request->set_node_id(1);
+  request->set_port_id(2);
 
+  std::vector<::util::Status> details;
   EXPECT_OK(bcm_switch_->RetrieveValue(kNodeId, req, &writer, &details));
-  EXPECT_TRUE(resp.has_loopback_status());
-  EXPECT_EQ(LOOPBACK_STATE_NONE, resp.loopback_status().state());
+  EXPECT_TRUE(resp.has_mac_address());
   ASSERT_EQ(details.size(), 1);
   EXPECT_THAT(details.at(0), ::util::OkStatus());
-
-  details.clear();
-  resp.Clear();
-  EXPECT_OK(bcm_switch_->RetrieveValue(kNodeId, req, &writer, &details));
-  EXPECT_FALSE(resp.has_loopback_status());
-  ASSERT_EQ(details.size(), 1);
-  EXPECT_EQ(error.ToString(), details.at(0).ToString());
 }
 
 TEST_F(BcmSwitchTest, GetPortSpeed) {
@@ -664,6 +648,61 @@ TEST_F(BcmSwitchTest, GetNodePacketIoDebugInfoPass) {
   std::vector<::util::Status> details;
   EXPECT_OK(bcm_switch_->RetrieveValue(kNodeId, req, &writer, &details));
   EXPECT_TRUE(resp.has_node_packetio_debug_info());
+  ASSERT_EQ(details.size(), 1);
+  EXPECT_THAT(details.at(0), ::util::OkStatus());
+}
+
+TEST_F(BcmSwitchTest, GetPortLoopbackStatus) {
+  PushChassisConfigSuccess();
+
+  WriterMock<DataResponse> writer;
+  DataResponse resp;
+
+  // Expect successful retrieval followed by failure.
+  ::util::Status error = ::util::UnknownErrorBuilder(GTL_LOC) << "error";
+  EXPECT_CALL(*bcm_chassis_manager_mock_,
+              GetPortLoopbackState(kNodeId, kPortId))
+      .WillOnce(Return(LOOPBACK_STATE_NONE))
+      .WillOnce(Return(error));
+  ExpectMockWriteDataResponse(&writer, &resp);
+
+  DataRequest req;
+  auto* req_info = req.add_requests()->mutable_loopback_status();
+  req_info->set_node_id(kNodeId);
+  req_info->set_port_id(kPortId);
+  std::vector<::util::Status> details;
+
+  EXPECT_OK(bcm_switch_->RetrieveValue(kNodeId, req, &writer, &details));
+  EXPECT_TRUE(resp.has_loopback_status());
+  EXPECT_EQ(LOOPBACK_STATE_NONE, resp.loopback_status().state());
+  ASSERT_EQ(details.size(), 1);
+  EXPECT_THAT(details.at(0), ::util::OkStatus());
+
+  details.clear();
+  resp.Clear();
+  EXPECT_OK(bcm_switch_->RetrieveValue(kNodeId, req, &writer, &details));
+  EXPECT_FALSE(resp.has_loopback_status());
+  ASSERT_EQ(details.size(), 1);
+  EXPECT_EQ(error.ToString(), details.at(0).ToString());
+}
+
+TEST_F(BcmSwitchTest, GetSdnPortId) {
+  PushChassisConfigSuccess();
+
+  WriterMock<DataResponse> writer;
+  DataResponse resp;
+  // Expect Write() call and store data in resp.
+  ExpectMockWriteDataResponse(&writer, &resp);
+
+  DataRequest req;
+  auto* req_info = req.add_requests()->mutable_sdn_port_id();
+  req_info->set_node_id(kNodeId);
+  req_info->set_port_id(kPortId);
+  std::vector<::util::Status> details;
+
+  EXPECT_OK(bcm_switch_->RetrieveValue(kNodeId, req, &writer, &details));
+  EXPECT_TRUE(resp.has_sdn_port_id());
+  EXPECT_EQ(kPortId, resp.sdn_port_id().port_id());
   ASSERT_EQ(details.size(), 1);
   EXPECT_THAT(details.at(0), ::util::OkStatus());
 }

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -249,7 +249,7 @@ namespace {
       // - node_id: req.mac_address().node_id()
       // - port_id: req.mac_address().port_id()
       // and then write it into the response.
-      resp.mutable_mac_address()->set_mac_address(0ull);
+      resp.mutable_mac_address()->set_mac_address(kDummyMacAddress);
       break;
     }
     case Request::kPortSpeed: {
@@ -266,6 +266,14 @@ namespace {
                            request.negotiated_port_speed().port_id()));
       resp.mutable_negotiated_port_speed()->set_speed_bps(
           singleton->speed_bps());
+      break;
+    }
+    case DataRequest::Request::kLacpRouterMac: {
+      // Find LACP System ID MAC address of port located at:
+      // - node_id: req.lacp_router_mac().node_id()
+      // - port_id: req.lacp_router_mac().port_id()
+      // and then write it into the response.
+      resp.mutable_lacp_router_mac()->set_mac_address(kDummyMacAddress);
       break;
     }
     case Request::kPortCounters: {

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -178,6 +178,7 @@ Bmv2Switch::~Bmv2Switch() {}
       case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
+      case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kHealthIndicator:
       case DataRequest::Request::kForwardingViability:

--- a/stratum/hal/lib/common/constants.h
+++ b/stratum/hal/lib/common/constants.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_CONSTANTS_H_
 #define STRATUM_HAL_LIB_COMMON_CONSTANTS_H_
 

--- a/stratum/hal/lib/common/constants.h
+++ b/stratum/hal/lib/common/constants.h
@@ -68,6 +68,9 @@ constexpr uint8 kIpProtoGre = 47;
 // Precision for converting floating point to ::gnmi::Decimal64
 constexpr uint32 kDefaultPrecision = 2;
 
+// Dummy MAC address used for unsupported DataRequests.
+constexpr uint64 kDummyMacAddress = 0x112233445566ull;
+
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/hal/lib/dummy/dummy_node.cc
+++ b/stratum/hal/lib/dummy/dummy_node.cc
@@ -116,57 +116,57 @@ bool DummyNode::DummyNodeEventWriter::Write(const DummyNodeEventPtr& msg) {
   auto& port_state = dummy_node_->ports_state_[port_id];
   GnmiEvent* event = nullptr;
   switch (state_update.response_case()) {
-    case ::stratum::hal::DataResponse::kOperStatus:
+    case DataResponse::kOperStatus:
       event = new PortOperStateChangedEvent(node_id, port_id,
                                             state_update.oper_status().state());
       port_state.oper_status = state_update.oper_status();
       break;
-    case ::stratum::hal::DataResponse::kAdminStatus:
+    case DataResponse::kAdminStatus:
       event = new PortAdminStateChangedEvent(
           node_id, port_id, state_update.admin_status().state());
       port_state.admin_status = state_update.admin_status();
       break;
-    case ::stratum::hal::DataResponse::kMacAddress:
+    case DataResponse::kMacAddress:
       event = new PortMacAddressChangedEvent(
           node_id, port_id, state_update.mac_address().mac_address());
       port_state.mac_address = state_update.mac_address();
       break;
-    case ::stratum::hal::DataResponse::kPortSpeed:
+    case DataResponse::kPortSpeed:
       event = new PortSpeedBpsChangedEvent(
           node_id, port_id, state_update.port_speed().speed_bps());
       port_state.port_speed = state_update.port_speed();
       break;
-    case ::stratum::hal::DataResponse::kNegotiatedPortSpeed:
+    case DataResponse::kNegotiatedPortSpeed:
       event = new PortNegotiatedSpeedBpsChangedEvent(
           node_id, port_id, state_update.negotiated_port_speed().speed_bps());
       port_state.negotiated_port_speed = state_update.negotiated_port_speed();
       break;
-    case ::stratum::hal::DataResponse::kLacpRouterMac:
+    case DataResponse::kLacpRouterMac:
       event = new PortLacpRouterMacChangedEvent(
           node_id, port_id, state_update.lacp_router_mac().mac_address());
       port_state.lacp_router_mac = state_update.lacp_router_mac();
       break;
-    case ::stratum::hal::DataResponse::kLacpSystemPriority:
+    case DataResponse::kLacpSystemPriority:
       event = new PortLacpSystemPriorityChangedEvent(
           node_id, port_id, state_update.lacp_system_priority().priority());
       port_state.lacp_system_priority = state_update.lacp_system_priority();
       break;
-    case ::stratum::hal::DataResponse::kPortCounters:
+    case DataResponse::kPortCounters:
       event = new PortCountersChangedEvent(node_id, port_id,
                                            state_update.port_counters());
       port_state.port_counters = state_update.port_counters();
       break;
-    case ::stratum::hal::DataResponse::kForwardingViability:
+    case DataResponse::kForwardingViability:
       event = new PortForwardingViabilityChangedEvent(
           node_id, port_id, state_update.forwarding_viability().state());
       port_state.forwarding_viability = state_update.forwarding_viability();
       break;
-    case ::stratum::hal::DataResponse::kHealthIndicator:
+    case DataResponse::kHealthIndicator:
       event = new PortHealthIndicatorChangedEvent(
           node_id, port_id, state_update.health_indicator().state());
       port_state.health_indicator = state_update.health_indicator();
       break;
-    case ::stratum::hal::DataResponse::RESPONSE_NOT_SET:
+    case DataResponse::RESPONSE_NOT_SET:
       LOG(ERROR) << "State update type does not set.";
       return false;
     default:

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -207,7 +207,7 @@ namespace {
       // - node_id: req.mac_address().node_id()
       // - port_id: req.mac_address().port_id()
       // and then write it into the response.
-      resp.mutable_mac_address()->set_mac_address(0ull);
+      resp.mutable_mac_address()->set_mac_address(kDummyMacAddress);
       break;
     }
     case Request::kPortSpeed: {
@@ -224,6 +224,14 @@ namespace {
                            request.negotiated_port_speed().port_id()));
       resp.mutable_negotiated_port_speed()->set_speed_bps(
           singleton->speed_bps());
+      break;
+    }
+    case DataRequest::Request::kLacpRouterMac: {
+      // Find LACP System ID MAC address of port located at:
+      // - node_id: req.lacp_router_mac().node_id()
+      // - port_id: req.lacp_router_mac().port_id()
+      // and then write it into the response.
+      resp.mutable_lacp_router_mac()->set_mac_address(kDummyMacAddress);
       break;
     }
     case Request::kPortCounters: {

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -186,6 +186,7 @@ NP4Switch::~NP4Switch() {}
       case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kPortSpeed:
       case DataRequest::Request::kNegotiatedPortSpeed:
+      case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
       case DataRequest::Request::kForwardingViability:
       case DataRequest::Request::kHealthIndicator:


### PR DESCRIPTION
This PR unifies the returned MAC address for the `/lacp/interfaces/interface[name=<name>]/state/system-id-mac` and `/interfaces/interface[name=<name>]/ethernet/config/mac-address` paths and across the switch implementations.