### PR TITLE
Pin LLVM / clang version to TDB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
   # Build targets and run unit tests.
   unit_tests:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - CC: clang
       - CXX: clang++
@@ -99,7 +99,7 @@ jobs:
   # CDLang
   cdlang_tests:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - CC: clang
       - CXX: clang++
@@ -121,7 +121,7 @@ jobs:
   # Generate coverage report and upload to codecov.io.
   coverage:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - CC: clang
       - CXX: clang++
@@ -146,7 +146,7 @@ jobs:
     environment:
       - DOCKER_SCOPE: .
       - DOCKER_FILE: Dockerfile.build
-      - DOCKER_IMG: stratumproject/build:build
+      - DOCKER_IMG: stratumproject/build:build-test
     steps:
       - checkout
       - *docker_login
@@ -175,7 +175,7 @@ jobs:
 
   publish-docker-p4c-fpm:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - DOCKER_SCOPE: stratum/p4c_backends/fpm
       - DOCKER_FILE: Dockerfile
@@ -204,7 +204,7 @@ jobs:
 
   publish-docker-stratum-bcm-sdklt:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/bcm/standalone/docker
       - DOCKER_FILE: Dockerfile
@@ -229,7 +229,7 @@ jobs:
 
   publish-docker-stratum-bcm-opennsa:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/bcm/standalone/docker
       - DOCKER_FILE: Dockerfile
@@ -253,7 +253,7 @@ jobs:
 
   publish-docker-bf-pipeline-builder:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/barefoot/docker
       - DOCKER_FILE: Dockerfile.bf_pipeline_builder
@@ -282,7 +282,7 @@ jobs:
 
   publish-docker-stratum-replay:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - DOCKER_SCOPE: stratum/tools/stratum-replay
       - DOCKER_FILE: Dockerfile
@@ -311,7 +311,7 @@ jobs:
 
   publish-docker-chassis-config-migrator:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     environment:
       - DOCKER_SCOPE: stratum/hal/config
       - DOCKER_FILE: Dockerfile
@@ -340,7 +340,7 @@ jobs:
 
   cpp-format-check:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     steps:
       - checkout
       - run:
@@ -349,7 +349,7 @@ jobs:
 
   cpp-lint-check:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     steps:
       - checkout
       - run:
@@ -366,7 +366,7 @@ jobs:
           command: reuse lint
   bazel-style-check:
     docker:
-      - image: stratumproject/build:build
+      - image: stratumproject/build:build-test
     steps:
       - checkout
       - run:
@@ -377,13 +377,28 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - unit_tests
-      - cdlang_tests
-      - coverage
-      - cpp-format-check
-      - cpp-lint-check
-      - license-check
-      - bazel-style-check
+      - publish-docker-build
+      - unit_tests:
+          requires:
+            - publish-docker-build
+      - cdlang_tests:
+          requires:
+            - publish-docker-build
+      - coverage:
+          requires:
+            - publish-docker-build
+      - cpp-format-check:
+          requires:
+            - publish-docker-build
+      - cpp-lint-check:
+          requires:
+            - publish-docker-build
+      - license-check:
+          requires:
+            - publish-docker-build
+      - bazel-style-check:
+          requires:
+            - publish-docker-build
   docker-publish:
     jobs:
       - publish-docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
   # Build targets and run unit tests.
   unit_tests:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - CC: clang
       - CXX: clang++
@@ -99,7 +99,7 @@ jobs:
   # CDLang
   cdlang_tests:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - CC: clang
       - CXX: clang++
@@ -121,7 +121,7 @@ jobs:
   # Generate coverage report and upload to codecov.io.
   coverage:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - CC: clang
       - CXX: clang++
@@ -146,7 +146,7 @@ jobs:
     environment:
       - DOCKER_SCOPE: .
       - DOCKER_FILE: Dockerfile.build
-      - DOCKER_IMG: stratumproject/build:build-test
+      - DOCKER_IMG: stratumproject/build:build
     steps:
       - checkout
       - *docker_login
@@ -175,7 +175,7 @@ jobs:
 
   publish-docker-p4c-fpm:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - DOCKER_SCOPE: stratum/p4c_backends/fpm
       - DOCKER_FILE: Dockerfile
@@ -204,7 +204,7 @@ jobs:
 
   publish-docker-stratum-bcm-sdklt:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/bcm/standalone/docker
       - DOCKER_FILE: Dockerfile
@@ -229,7 +229,7 @@ jobs:
 
   publish-docker-stratum-bcm-opennsa:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/bcm/standalone/docker
       - DOCKER_FILE: Dockerfile
@@ -253,7 +253,7 @@ jobs:
 
   publish-docker-bf-pipeline-builder:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/barefoot/docker
       - DOCKER_FILE: Dockerfile.bf_pipeline_builder
@@ -282,7 +282,7 @@ jobs:
 
   publish-docker-stratum-replay:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - DOCKER_SCOPE: stratum/tools/stratum-replay
       - DOCKER_FILE: Dockerfile
@@ -311,7 +311,7 @@ jobs:
 
   publish-docker-chassis-config-migrator:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     environment:
       - DOCKER_SCOPE: stratum/hal/config
       - DOCKER_FILE: Dockerfile
@@ -340,7 +340,7 @@ jobs:
 
   cpp-format-check:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     steps:
       - checkout
       - run:
@@ -349,7 +349,7 @@ jobs:
 
   cpp-lint-check:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     steps:
       - checkout
       - run:
@@ -366,7 +366,7 @@ jobs:
           command: reuse lint
   bazel-style-check:
     docker:
-      - image: stratumproject/build:build-test
+      - image: stratumproject/build:build
     steps:
       - checkout
       - run:
@@ -377,28 +377,13 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - publish-docker-build
-      - unit_tests:
-          requires:
-            - publish-docker-build
-      - cdlang_tests:
-          requires:
-            - publish-docker-build
-      - coverage:
-          requires:
-            - publish-docker-build
-      - cpp-format-check:
-          requires:
-            - publish-docker-build
-      - cpp-lint-check:
-          requires:
-            - publish-docker-build
-      - license-check:
-          requires:
-            - publish-docker-build
-      - bazel-style-check:
-          requires:
-            - publish-docker-build
+      - unit_tests
+      - cdlang_tests
+      - coverage
+      - cpp-format-check
+      - cpp-lint-check
+      - license-check
+      - bazel-style-check
   docker-publish:
     jobs:
       - publish-docker-build:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,7 +5,7 @@ ARG BAZELISK_VERSION=1.7.5
 ARG PI_COMMIT=0fbdac256151eb1537cd5ebf19101d5df60767fa
 ARG BMV2_COMMIT=498202d98d83a6c580aa86a3497b9b496bcd43b2
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
-ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-12 main"
+ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-11 main"
 
 # Reasonable for CI
 ARG JOBS=2
@@ -43,12 +43,12 @@ ARG LLVM_REPO_NAME
 RUN wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "$LLVM_REPO_NAME"
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends clang-format-12 clang-12
+    apt-get install -y --no-install-recommends clang-format-11 clang-11
 # Versioned LLVM releases don't come with the meta packages for the
 # clang -> clang-12 symlinks. We create them manually here.
-RUN ln -s /usr/bin/clang-12 /usr/bin/clang
-RUN ln -s /usr/bin/clang++-12 /usr/bin/clang++
-RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+RUN ln -s /usr/bin/clang-11 /usr/bin/clang
+RUN ln -s /usr/bin/clang++-11 /usr/bin/clang++
+RUN ln -s /usr/bin/clang-format-11 /usr/bin/clang-format
 
 # Install java and lcov for Bazel coverage
 ARG JDK_URL

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -46,9 +46,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends clang-format-11 clang-11
 # Versioned LLVM releases don't come with the meta packages for the
 # clang -> clang-12 symlinks. We create them manually here.
-RUN ln -s /usr/bin/clang-11 /usr/bin/clang
-RUN ln -s /usr/bin/clang++-11 /usr/bin/clang++
-RUN ln -s /usr/bin/clang-format-11 /usr/bin/clang-format
+RUN ln -s ../lib/llvm-11/bin/clang /usr/bin/clang
+RUN ln -s ../lib/llvm-11/bin/clang++ /usr/bin/clang++
+RUN ln -s ../lib/llvm-11/bin/clang-format /usr/bin/clang-format
 
 # Install java and lcov for Bazel coverage
 ARG JDK_URL

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -48,7 +48,7 @@ RUN apt-get update && \
 # Install java and lcov for Bazel coverage
 ARG JDK_URL
 ENV JAVA_HOME /usr/local/lib/jvm
-RUN wget $JDK_URL -O $HOME/jdk_11.0.2.tar.gz && \
+RUN wget --quiet $JDK_URL -O $HOME/jdk_11.0.2.tar.gz && \
     mkdir -p $JAVA_HOME && \
     tar xf $HOME/jdk_11.0.2.tar.gz -C $JAVA_HOME --strip-components=1 && \
     rm $HOME/jdk_11.0.2.tar.gz
@@ -80,7 +80,7 @@ RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
 # Bazelisk and Bazel
 ADD .bazelversion .
 ARG BAZELISK_VERSION
-RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64 && \
+RUN wget --quiet https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64 && \
     mv bazelisk-linux-amd64 /usr/local/bin/bazel && \
     chmod +x /usr/local/bin/bazel && \
     bazel version
@@ -88,7 +88,7 @@ RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VE
 # Tools for style and license checking
 RUN pip install setuptools wheel && \
     pip install 'cpplint==1.*'
-RUN wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/4.0.0/buildifier
+RUN wget --quiet -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/4.0.0/buildifier
 RUN chmod +x /usr/local/bin/buildifier
 
 # Docker CLI for CI builds

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,7 +5,7 @@ ARG BAZELISK_VERSION=1.7.5
 ARG PI_COMMIT=0fbdac256151eb1537cd5ebf19101d5df60767fa
 ARG BMV2_COMMIT=498202d98d83a6c580aa86a3497b9b496bcd43b2
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
-ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch main"
+ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-12 main"
 
 # Reasonable for CI
 ARG JOBS=2
@@ -43,7 +43,12 @@ ARG LLVM_REPO_NAME
 RUN wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "$LLVM_REPO_NAME"
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends clang-format clang
+    apt-get install -y --no-install-recommends clang-format-12 clang-12
+# Versioned LLVM releases don't come with the meta packages for the
+# clang -> clang-12 symlinks. We create them manually here.
+RUN ln -s /usr/bin/clang-12 /usr/bin/clang
+RUN ln -s /usr/bin/clang++-12 /usr/bin/clang++
+RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
 
 # Install java and lcov for Bazel coverage
 ARG JDK_URL

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -104,6 +104,7 @@ RUN add-apt-repository \
    stable"
 RUN apt-get update && apt-get install -y --no-install-recommends docker-ce-cli
 
+# TODO(max): not needed anymore, remove
 # Install git-lfs for OpenNSA
 # TODO the curl line can be dropped in Debian 10
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash


### PR DESCRIPTION
The current LLVM / clang install procedure always fetches the latest LLVM release when the `build` Docker container is built. 
This means we will get random upgrades of the toolchain which will introduce incompatible changes (e.g. clang-format rules change) and will fail our CI builds spontaneously and without clear indication.

This PR pins the LLVM version to a known working value (TBD), so we can do planed upgrades at our pace.

#### Details:

 - Upstream apt repository: https://apt.llvm.org/
 - Version selection is done by picking the appropriate repo:
```
deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main
deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main
# 11 
deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-11 main
deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch-11 main
# 12 
deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-12 main
deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch-12 main
```
- Versioned repos **do not provide** the convenience meta packages (`clang`) that set up all the generic symlinks, e.g. `/usr/bin/clang -> ../lib/llvm-13/bin/clang`
  - Only `/usr/bin/clang-12 -> ../lib/llvm-12/bin/clang` will exist
  - We can create the missing ones as part of the docker image (`clang`, `clang++` and `clang-format`)
  - We do not want to `export CXX=/usr/bin/clang++-12`, because this will break SDE builds and some dependencies that are also built inside the container. During CI we override this for Bazel targets we know that compile.