### PR TITLE
Expire the CircleCi Bazel cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,16 @@ version: 2.1
 restore_bazel_cache: &restore_bazel_cache
   restore_cache:
     keys:
-      - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
-      - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}
-      - v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-main
+      - v4-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
+      - v4-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}
+      - v4-bazel-cache-{{ .Environment.CIRCLE_JOB }}-main
 save_bazel_cache: &save_bazel_cache
   save_cache:
     # Always saving the cache, even in case of failures, helps with completing
     # jobs where the bazel process was killed because it took too long or OOM.
     # Restart the job if you see the bazel server being terminated abruptly.
     when: always
-    key: v3-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
+    key: v4-bazel-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - /tmp/bazel-cache
       - /tmp/bazel-disk-cache


### PR DESCRIPTION
An unintended compiler upgrade made the current cache incompatible with the rolled back compiler version, failing all builds. This PR expires the entire cache.