### PR TITLE
Remove unused RegisterClearThreadData struct

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -42,15 +42,6 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
     OperationMode mode, BfSdeInterface* bf_sde_interface, int device) {
   return absl::WrapUnique(new BfrtTableManager(mode, bf_sde_interface, device));
 }
-namespace {
-struct RegisterClearThreadData {
-  std::vector<p4::config::v1::Register> registers;
-  BfrtTableManager* mgr;
-
-  explicit RegisterClearThreadData(BfrtTableManager* _mgr)
-      : registers(), mgr(_mgr) {}
-};
-}  // namespace
 
 ::util::Status BfrtTableManager::PushForwardingPipelineConfig(
     const BfrtDeviceConfig& config) {


### PR DESCRIPTION
It's a leftover from the automatic register clearing feature we had for some time.