### PR TITLE
Make MAC address in PortConfig an embedded field

### DIFF
--- a/stratum/hal/bin/dummy/chassis_config.pb.txt
+++ b/stratum/hal/bin/dummy/chassis_config.pb.txt
@@ -25,7 +25,9 @@ singleton_ports {
   speed_bps: 100000000000  # 100Gbps
   node: 1
   config_params {
-    mac_address: 0x111111111111
+    mac_address {
+      mac_address: 0x111111111111
+    }
   }
 }
 singleton_ports {
@@ -37,7 +39,9 @@ singleton_ports {
   speed_bps: 100000000000  # 100Gbps
   node: 1
   config_params {
-    mac_address: 0x222222222222
+    mac_address {
+      mac_address: 0x222222222222
+    }
   }
 }
 optical_network_interfaces {

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -273,7 +273,7 @@ message PortConfigParams {
   // FEC operational mode
   FecMode fec_mode = 6;
   // The configured mac address for this port.
-  uint64 mac_address = 7;
+  MacAddress mac_address = 7;
   // The configured loopback state for this port.
   LoopbackState loopback_mode = 8;
 }

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -1317,7 +1317,6 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
                         stream);
   };
   auto on_change_functor = UnsupportedFunc();
-
   auto on_set_functor =
       [node_id, port_id, node, tree](
           const ::gnmi::Path& path, const ::google::protobuf::Message& val,
@@ -1327,7 +1326,6 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
     if (typed_val == nullptr) {
       return MAKE_ERROR(ERR_INVALID_PARAM) << "not a TypedValue message!";
     }
-
     std::string mac_address_string = typed_val->string_val();
     if (!IsMacAddressValid(mac_address_string)) {
       return MAKE_ERROR(ERR_INVALID_PARAM) << "wrong value!";
@@ -1347,7 +1345,9 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
     ChassisConfig* new_config = config->writable();
     for (auto& singleton_port : *new_config->mutable_singleton_ports()) {
       if (singleton_port.node() == node_id && singleton_port.id() == port_id) {
-        singleton_port.mutable_config_params()->set_mac_address(mac_address);
+        singleton_port.mutable_config_params()
+            ->mutable_mac_address()
+            ->set_mac_address(mac_address);
         break;
       }
     }
@@ -1369,7 +1369,6 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
 
     return ::util::OkStatus();
   };
-
   node->SetOnTimerHandler(poll_functor)
       ->SetOnPollHandler(poll_functor)
       ->SetOnChangeHandler(on_change_functor)
@@ -3456,7 +3455,9 @@ void YangParseTreePaths::AddSubtreeInterfaceFromSingleton(
     port_auto_neg_enabled =
         IsPortAutonegEnabled(singleton.config_params().autoneg());
     port_enabled = IsAdminStateEnabled(singleton.config_params().admin_state());
-    mac_address = singleton.config_params().mac_address();
+    if (singleton.config_params().has_mac_address()) {
+      mac_address = singleton.config_params().mac_address().mac_address();
+    }
     loopback_enabled =
         IsLoopbackStateEnabled(singleton.config_params().loopback_mode());
   }

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -118,7 +118,9 @@ class YangParseTreeTest : public ::testing::Test {
     singleton_ptr->set_node(kInterface1NodeId);
     singleton_ptr->set_id(kInterface1PortId);
     singleton_ptr->set_speed_bps(kTwentyFiveGigBps);
-    singleton_ptr->mutable_config_params()->set_mac_address(kInterfaceMac);
+    singleton_ptr->mutable_config_params()
+        ->mutable_mac_address()
+        ->set_mac_address(kInterfaceMac);
     // Add one per port per queue stat for this interface.
     NodeConfigParams node_config;
     {


### PR DESCRIPTION
This allows using `PortConfigParams` without being forced to also set a MAC address, because of the zero default value. 