### PR TITLE
Fix BfrtInfoManager bf_rt includes

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_id_mapper.cc
+++ b/stratum/hal/lib/barefoot/bfrt_id_mapper.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "absl/strings/match.h"
+#include "bf_rt/bf_rt_table.hpp"
 #include "nlohmann/json.hpp"
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/hal/lib/barefoot/bfrt_constants.h"

--- a/stratum/hal/lib/barefoot/bfrt_id_mapper.h
+++ b/stratum/hal/lib/barefoot/bfrt_id_mapper.h
@@ -9,6 +9,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
+#include "bf_rt/bf_rt_info.hpp"
 #include "bf_rt/bf_rt_init.hpp"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/integral_types.h"


### PR DESCRIPTION
Include all needed headers explicitly. Future SDEs might rearrange code.