### PR TITLE
Fix move assign and move constructor of PhaldbService

### DIFF
--- a/stratum/hal/lib/phal/phaldb_service.h
+++ b/stratum/hal/lib/phal/phaldb_service.h
@@ -57,7 +57,8 @@ class PhalDbService final : public PhalDb::Service {
   // PhalDbService is neither copyable nor movable.
   PhalDbService(const PhalDbService&) = delete;
   PhalDbService& operator=(const PhalDbService&) = delete;
-  PhalDbService& operator=(PhalDbService&&) = default;
+  PhalDbService(PhalDbService&&) = delete;
+  PhalDbService& operator=(PhalDbService&&) = delete;
 
  private:
   // Actual implementations of the calls. To be moved into an impl.


### PR DESCRIPTION
Move was disallowed implicitly, this PR makes it explicit.

```
In file included from ./stratum/hal/lib/phal/attribute_database.h:24:
./stratum/hal/lib/phal/phaldb_service.h:60:18: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  PhalDbService& operator=(PhalDbService&&) = default;
                 ^
./stratum/hal/lib/phal/phaldb_service.h:79:23: note: move assignment operator of 'PhalDbService' is implicitly deleted because field 'subscriber_thread_lock_' has a deleted move assignment operator
  mutable absl::Mutex subscriber_thread_lock_;
                      ^
external/com_google_absl/absl/synchronization/mutex.h:493:10: note: 'operator=' has been explicitly marked deleted here
  Mutex& operator=(const Mutex&) = delete;
         ^
```