### PR TITLE
Move SDE init code to SdeWrapper

### DIFF
--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -54,7 +54,6 @@ stratum_cc_binary(
         "//stratum/hal/lib/barefoot:bf_sde_wrapper",
         "//stratum/hal/lib/barefoot:bf_switch",
         "//stratum/hal/lib/pi:pi_node_bf",
-        "@local_barefoot_bin//:bfsde",
     ] + stratum_bf_common_deps,
 )
 
@@ -77,7 +76,6 @@ stratum_cc_binary(
         "//stratum/hal/lib/barefoot:bfrt_pre_manager",
         "//stratum/hal/lib/barefoot:bfrt_table_manager",
         "//stratum/hal/lib/barefoot:bfrt_counter_manager",
-        "@local_barefoot_bin//:bfsde",
     ] + stratum_bf_common_deps,
 )
 

--- a/stratum/hal/bin/barefoot/main_bfrt.cc
+++ b/stratum/hal/bin/barefoot/main_bfrt.cc
@@ -2,13 +2,6 @@
 // Copyright 2020-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-extern "C" {
-
-#include "bf_switchd/bf_switchd.h"
-
-int switch_pci_sysfs_str_get(char* name, size_t name_size);
-}
-
 #include "gflags/gflags.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/logging.h"
@@ -42,47 +35,13 @@ namespace barefoot {
   InitGoogle(argv[0], &argc, &argv, true);
   InitStratumLogging();
 
-  char bf_sysfs_fname[128];
-  FILE* fd;
-
-  auto switchd_main_ctx = absl::make_unique<bf_switchd_context_t>();
-
-  /* Parse bf_switchd arguments */
-  CHECK_RETURN_IF_FALSE(FLAGS_bf_sde_install != "")
-      << "Flag --bf_sde_install is required";
-  switchd_main_ctx->install_dir = strdup(FLAGS_bf_sde_install.c_str());
-  switchd_main_ctx->conf_file = strdup(FLAGS_bf_switchd_cfg.c_str());
-  switchd_main_ctx->skip_p4 = true;
-  if (FLAGS_bf_switchd_background)
-    switchd_main_ctx->running_in_background = true;
-  else
-    switchd_main_ctx->shell_set_ucli = true;
-
-  /* determine if kernel mode packet driver is loaded */
-  switch_pci_sysfs_str_get(bf_sysfs_fname,
-                           sizeof(bf_sysfs_fname) - sizeof("/dev_add"));
-  strncat(bf_sysfs_fname, "/dev_add", sizeof("/dev_add"));
-  printf("bf_sysfs_fname %s\n", bf_sysfs_fname);
-  fd = fopen(bf_sysfs_fname, "r");
-  if (fd != NULL) {
-    /* override previous parsing if bf_kpkt KLM was loaded */
-    printf("kernel mode packet driver present, forcing kernel_pkt option!\n");
-    switchd_main_ctx->kernel_pkt = true;
-    fclose(fd);
-  }
-
-  {
-    int status = bf_switchd_lib_init(switchd_main_ctx.get());
-    CHECK_RETURN_IF_FALSE(status == 0)
-        << "Error when starting switchd, status: " << status;
-    LOG(INFO) << "switchd started successfully";
-  }
-
   // TODO(antonin): The SDE expects 0-based device ids, so we instantiate
   // components with "device_id" instead of "node_id".
   int device_id = 0;
 
   auto bf_sde_wrapper = BfSdeWrapper::CreateSingleton();
+  RETURN_IF_ERROR(bf_sde_wrapper->InitializeSde(
+      FLAGS_bf_sde_install, FLAGS_bf_switchd_cfg, FLAGS_bf_switchd_background));
   ASSIGN_OR_RETURN(bool is_sw_model,
                    bf_sde_wrapper->IsSoftwareModel(device_id));
   const OperationMode mode =

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -137,6 +137,11 @@ class BfSdeInterface {
 
   virtual ~BfSdeInterface() {}
 
+  // Initializes the SDE. Must be called before any other methods.
+  virtual ::util::Status InitializeSde(const std::string& sde_install_path,
+                                       const std::string& sde_config_file,
+                                       bool run_in_background) = 0;
+
   // Add and initialize a device. The device config (pipeline) will be loaded
   // into the ASIC. Can be used to re-initialize an existing device.
   virtual ::util::Status AddDevice(int device,

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -62,6 +62,10 @@ class TableDataMock : public BfSdeInterface::TableDataInterface {
 
 class BfSdeMock : public BfSdeInterface {
  public:
+  MOCK_METHOD3(InitializeSde,
+               ::util::Status(const std::string& sde_install_path,
+                              const std::string& sde_config_file,
+                              bool run_in_background));
   MOCK_METHOD2(AddDevice,
                ::util::Status(int device,
                               const BfrtDeviceConfig& device_config));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -1351,8 +1351,7 @@ std::string BfSdeWrapper::GetSdeVersion() const {
   std::string bf_sysfs_fname;
   {
     char buf[128] = {};
-    CHECK_RETURN_IF_FALSE(
-        switch_pci_sysfs_str_get(buf, sizeof(buf) - sizeof("/dev_add")) == 0);
+    RETURN_IF_BFRT_ERROR(switch_pci_sysfs_str_get(buf, sizeof(buf)));
     bf_sysfs_fname = buf;
   }
   absl::StrAppend(&bf_sysfs_fname, "/dev_add");
@@ -1364,12 +1363,9 @@ std::string BfSdeWrapper::GetSdeVersion() const {
     switchd_main_ctx->kernel_pkt = true;
   }
 
-  {
-    int status = bf_switchd_lib_init(switchd_main_ctx.get());
-    CHECK_RETURN_IF_FALSE(status == 0)
-        << "Error when starting switchd, status: " << status;
-    LOG(INFO) << "switchd started successfully";
-  }
+  RETURN_IF_BFRT_ERROR(bf_switchd_lib_init(switchd_main_ctx.get()))
+      << "Error when starting switchd.";
+  LOG(INFO) << "switchd started successfully";
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -136,6 +136,9 @@ class BfSdeWrapper : public BfSdeInterface {
   };
 
   // BfSdeInterface public methods.
+  ::util::Status InitializeSde(const std::string& sde_install_path,
+                               const std::string& sde_config_file,
+                               bool run_in_background) override;
   ::util::Status AddDevice(int device,
                            const BfrtDeviceConfig& device_config) override;
   ::util::StatusOr<std::shared_ptr<BfSdeInterface::SessionInterface>>


### PR DESCRIPTION
This change extracts the SDE init code from both `main.cc` files and consolidates it into the `SdeWrapper` class.

Co-authored-by: Brian O'Connor <bocon@opennetworking.org>