### PR TITLE
Replace `::google::protobuf::uintXX` with just `uintXX`

### DIFF
--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -247,8 +247,7 @@ std::string ConvertAdminStateToString(const AdminState& state) {
   }
 }
 
-std::string ConvertSpeedBpsToString(
-    const ::google::protobuf::uint64& speed_bps) {
+std::string ConvertSpeedBpsToString(const uint64& speed_bps) {
   switch (speed_bps) {
     case kTenGigBps:
       return "SPEED_10GB";
@@ -267,8 +266,7 @@ std::string ConvertSpeedBpsToString(
   }
 }
 
-::google::protobuf::uint64 ConvertStringToSpeedBps(
-    const std::string& speed_string) {
+uint64 ConvertStringToSpeedBps(const std::string& speed_string) {
   if (speed_string == "SPEED_10GB") {
     return kTenGigBps;
   } else if (speed_string == "SPEED_20GB") {
@@ -317,16 +315,14 @@ bool ConvertTrunkMemberBlockStateToBool(const TrunkMemberBlockState& state) {
   return state == TRUNK_MEMBER_BLOCK_STATE_FORWARDING;
 }
 
-std::string MacAddressToYangString(
-    const ::google::protobuf::uint64& mac_address) {
+std::string MacAddressToYangString(const uint64& mac_address) {
   return absl::StrFormat("%x:%x:%x:%x:%x:%x", (mac_address >> 40) & 0xFF,
                          (mac_address >> 32) & 0xFF, (mac_address >> 24) & 0xFF,
                          (mac_address >> 16) & 0xFF, (mac_address >> 8) & 0xFF,
                          mac_address & 0xFF);
 }
 
-::google::protobuf::uint64 YangStringToMacAddress(
-    const std::string& yang_string) {
+uint64 YangStringToMacAddress(const std::string& yang_string) {
   std::string tmp_str = yang_string;
   // Remove colons
   tmp_str.erase(std::remove(tmp_str.begin(), tmp_str.end(), ':'),

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -173,12 +173,10 @@ std::string ConvertPortStateToString(const PortState& state);
 std::string ConvertAdminStateToString(const AdminState& state);
 
 // A helper function that convert speed number to string format.
-std::string ConvertSpeedBpsToString(
-    const ::google::protobuf::uint64& speed_bps);
+std::string ConvertSpeedBpsToString(const uint64& speed_bps);
 
 // A helper function that convert OpenConfig speed string to speed number.
-::google::protobuf::uint64 ConvertStringToSpeedBps(
-    const std::string& speed_string);
+uint64 ConvertStringToSpeedBps(const std::string& speed_string);
 
 // A helper function that convert gRPC alarm severity enum to string.
 std::string ConvertAlarmSeverityToString(const Alarm::Severity& severity);
@@ -192,14 +190,12 @@ bool ConvertTrunkMemberBlockStateToBool(const TrunkMemberBlockState& state);
 // A helper function that convert data received from the HAL into a format
 // expected by the gNMI interface (MAC addresses are expected to be
 // std::strings in the following format: "XX:XX:XX:XX:XX:XX").
-std::string MacAddressToYangString(
-    const ::google::protobuf::uint64& mac_address);
+std::string MacAddressToYangString(const uint64& mac_address);
 
 // A helper function that convert data received from the gNMI interface into a
 // format expected by the HAL (MAC addresses are expected to be
-// ::google::protobuf::uint64).
-::google::protobuf::uint64 YangStringToMacAddress(
-    const std::string& yang_string);
+// uint64).
+uint64 YangStringToMacAddress(const std::string& yang_string);
 
 // A helper function that check if string of mac_address is valid.
 bool IsMacAddressValid(const std::string& mac_address);

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -1331,8 +1331,7 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
       return MAKE_ERROR(ERR_INVALID_PARAM) << "wrong value!";
     }
 
-    ::google::protobuf::uint64 mac_address =
-        YangStringToMacAddress(mac_address_string);
+    uint64 mac_address = YangStringToMacAddress(mac_address_string);
     // Set the value.
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_mac_address,
@@ -1401,8 +1400,7 @@ void SetUpInterfacesInterfaceEthernetConfigPortSpeed(uint64 node_id,
       return MAKE_ERROR(ERR_INVALID_PARAM) << "not a TypedValue message!";
     }
     std::string speed_string = typed_val->string_val();
-    ::google::protobuf::uint64 speed_bps =
-        ConvertStringToSpeedBps(speed_string);
+    uint64 speed_bps = ConvertStringToSpeedBps(speed_string);
     if (speed_bps == 0) {
       return MAKE_ERROR(ERR_INVALID_PARAM) << "wrong value!";
     }
@@ -1675,10 +1673,10 @@ void SetUpInterfacesInterfaceEthernetStateAutoNegotiate(uint64 node_id,
 // data from the DataResponse proto received from SwitchInterface, i.e.,
 // "&DataResponse::PortCounters::message", where message field in
 // DataResponse::Counters.
-TreeNodeEventHandler GetPollCounterFunctor(
-    uint64 node_id, uint32 port_id,
-    ::google::protobuf::uint64 (PortCounters::*func_ptr)() const,
-    YangParseTree* tree) {
+TreeNodeEventHandler GetPollCounterFunctor(uint64 node_id, uint32 port_id,
+                                           uint64 (PortCounters::*func_ptr)()
+                                               const,
+                                           YangParseTree* tree) {
   return [tree, node_id, port_id, func_ptr](const GnmiEvent& event,
                                             const ::gnmi::Path& path,
                                             GnmiSubscribeStream* stream) {

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -3602,7 +3602,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("interval")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_input_power,
       &OpticalTransceiverInfo::Power::set_interval, expected_value);
@@ -3621,7 +3621,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("interval")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_input_power,
       &OpticalTransceiverInfo::Power::set_interval, expected_value);
@@ -3641,7 +3641,7 @@ TEST_F(
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("interval")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   OpticalTransceiverInfo::Power input_power;
   input_power.set_interval(expected_value);
 
@@ -3726,7 +3726,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_input_power,
       &OpticalTransceiverInfo::Power::set_max_time, expected_value);
@@ -3745,7 +3745,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_input_power,
       &OpticalTransceiverInfo::Power::set_max_time, expected_value);
@@ -3764,7 +3764,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("max-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   OpticalTransceiverInfo::Power input_power;
   input_power.set_max_time(expected_value);
 
@@ -3849,7 +3849,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_input_power,
       &OpticalTransceiverInfo::Power::set_min_time, expected_value);
@@ -3868,7 +3868,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_input_power,
       &OpticalTransceiverInfo::Power::set_min_time, expected_value);
@@ -3887,7 +3887,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("input-power")("min-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   OpticalTransceiverInfo::Power input_power;
   input_power.set_min_time(expected_value);
 
@@ -4116,7 +4116,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("interval")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_output_power,
       &OpticalTransceiverInfo::Power::set_interval, expected_value);
@@ -4136,7 +4136,7 @@ TEST_F(
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("interval")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_output_power,
       &OpticalTransceiverInfo::Power::set_interval, expected_value);
@@ -4156,7 +4156,7 @@ TEST_F(
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("interval")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   OpticalTransceiverInfo::OpticalTransceiverInfo::Power output_power;
   output_power.set_interval(expected_value);
 
@@ -4241,7 +4241,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_output_power,
       &OpticalTransceiverInfo::Power::set_max_time, expected_value);
@@ -4260,7 +4260,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_output_power,
       &OpticalTransceiverInfo::Power::set_max_time, expected_value);
@@ -4280,7 +4280,7 @@ TEST_F(
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("max-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   OpticalTransceiverInfo::Power output_power;
   output_power.set_max_time(expected_value);
 
@@ -4365,7 +4365,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_output_power,
       &OpticalTransceiverInfo::Power::set_min_time, expected_value);
@@ -4384,7 +4384,7 @@ TEST_F(YangParseTreeOpticalChannelTest,
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   SubstituteOpticalChannelRetrieveValue(
       &OpticalTransceiverInfo::mutable_output_power,
       &OpticalTransceiverInfo::Power::set_min_time, expected_value);
@@ -4404,7 +4404,7 @@ TEST_F(
   auto path = GetPath("components")("component", "optical-interface-1")(
       "optical-channel")("state")("output-power")("min-time")();
 
-  const ::google::protobuf::uint64 expected_value = 100500;
+  const uint64 expected_value = 100500;
   OpticalTransceiverInfo::OpticalTransceiverInfo::Power output_power;
   output_power.set_min_time(expected_value);
 

--- a/stratum/hal/lib/p4/p4_info_manager_test.cc
+++ b/stratum/hal/lib/p4/p4_info_manager_test.cc
@@ -83,7 +83,7 @@ class P4InfoManagerTest : public testing::Test {
   }
 
   void SetUpTestP4Tables(bool need_actions = true) {
-    ::google::protobuf::int32 dummy_action_id = kFirstActionID;
+    int32 dummy_action_id = kFirstActionID;
 
     // Each table entry is assigned an ID and name in the preamble.  Each table
     // optionally gets a set of action IDs.
@@ -102,7 +102,7 @@ class P4InfoManagerTest : public testing::Test {
   void SetUpTestP4Actions() {
     const int kNumTestActions = kNumTestTables * kNumActionsPerTable;
     const int kNumParamsPerAction = 2;
-    ::google::protobuf::int32 dummy_param_id = 100000;
+    int32 dummy_param_id = 100000;
 
     for (int a = 0; a < kNumTestActions; ++a) {
       ::p4::config::v1::Action* new_action = p4_test_info_.add_actions();

--- a/stratum/p4c_backends/fpm/field_name_inspector.h
+++ b/stratum/p4c_backends/fpm/field_name_inspector.h
@@ -10,8 +10,9 @@
 #include <string>
 #include <vector>
 
-#include "google/protobuf/map.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
+#include "google/protobuf/map.h"
+#include "stratum/glue/integral_types.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -76,8 +77,7 @@ class FieldNameInspector : public Inspector {
   void AppendStackedHeaderPathNames();
 
   // Injected prefixes to ignore.
-  ::google::protobuf::Map<::std::string, ::google::protobuf::int32>
-      ignored_path_prefixes_;
+  ::google::protobuf::Map<::std::string, int32> ignored_path_prefixes_;
 
   // This member is the extracted name.
   std::string field_name_;

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -172,8 +172,8 @@ void build_gnmi_path(std::string path_str, ::gnmi::Path* path) {
   return sub_req;
 }
 
-::gnmi::SubscribeRequest build_gnmi_sub_sample_req(
-    std::string path, ::google::protobuf::uint64 interval) {
+::gnmi::SubscribeRequest build_gnmi_sub_sample_req(std::string path,
+                                                   uint64 interval) {
   ::gnmi::SubscribeRequest sub_req;
   auto* sub_list = sub_req.mutable_subscribe();
   sub_list->set_mode(::gnmi::SubscriptionList::STREAM);


### PR DESCRIPTION
Also fix all other `[u]int{32,64}` variants.
They typedef to the same underlying type anyway.