### PR TITLE
Enforce common Bazel style with buildifier

### DIFF
--- a/.circleci/check-bazel-format.sh
+++ b/.circleci/check-bazel-format.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright 2021-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+set -ex
+
+# Files in this branch that are different from main.
+CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/main -- 'BUILD' '*.BUILD' '*.bzl')
+
+# List of files that are already formatted.
+read -r -d '\0' KNOWN_FILES << EOF
+bazel/BUILD
+bazel/defs.bzl
+bazel/external/bfsde.BUILD
+bazel/google/BUILD
+bazel/patches/BUILD
+bazel/rules/BUILD
+bazel/rules/build_tools.bzl
+bazel/rules/proto_gen.bzl
+bazel/rules/test_rule.bzl
+bazel/rules/yang_to_proto_rule.bzl
+stratum/BUILD
+stratum/glue/BUILD
+stratum/glue/gtl/BUILD
+stratum/glue/gtl/BUILD
+stratum/glue/net_util/BUILD
+stratum/glue/net_util/BUILD
+stratum/glue/status/BUILD
+stratum/glue/status/BUILD
+stratum/hal/bin/barefoot/BUILD
+stratum/hal/bin/barefoot/BUILD
+stratum/hal/bin/bcm/sim/BUILD
+stratum/hal/bin/bcm/sim/BUILD
+stratum/hal/bin/bcm/standalone/BUILD
+stratum/hal/bin/bcm/standalone/BUILD
+stratum/hal/bin/bmv2/bmv2.bzl
+stratum/hal/bin/np4intel/BUILD
+stratum/hal/bin/np4intel/np4intel.bzl
+stratum/hal/config/platform_config_test.bzl
+stratum/hal/lib/dummy/BUILD
+stratum/hal/lib/np4intel/BUILD
+stratum/hal/lib/phal/BUILD
+stratum/hal/lib/phal/onlp/onlp.bzl
+stratum/hal/lib/phal/tai/BUILD
+stratum/hal/lib/phal/test/BUILD
+stratum/hal/lib/pi/BUILD
+stratum/hal/stub/embedded/BUILD
+stratum/p4c_backends/common/build_defs.bzl
+stratum/p4c_backends/fpm/bcm/BUILD
+stratum/p4c_backends/ir/BUILD
+stratum/p4c_backends/test/build_defs.bzl
+stratum/pipelines/loopback/BUILD
+stratum/pipelines/main/BUILD
+stratum/pipelines/ptf/BUILD
+stratum/pipelines/ptf/ptf_exec.bzl
+stratum/pipelines/ptf/scapy_exec.bzl
+stratum/portage/BUILD
+stratum/portage/build_defs.bzl
+stratum/public/lib/BUILD
+stratum/public/model/BUILD
+stratum/public/proto/BUILD
+stratum/public/proto/proto2/BUILD
+stratum/testing/cdlang/BUILD
+stratum/testing/protos/BUILD
+stratum/testing/scenarios/BUILD
+stratum/testing/tests/BUILD
+stratum/tools/gnmi/BUILD
+stratum/tools/stratum-replay/BUILD
+\0
+EOF
+
+echo -e "$KNOWN_FILES\n$CHANGED_FILES" | sort -u | xargs -t buildifier -lint=fix -mode=fix
+
+# Report which files need to be fixed.
+git update-index --refresh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,14 +364,15 @@ jobs:
       - run:
           name: Run reuse
           command: reuse lint
+
   bazel-style-check:
     docker:
       - image: stratumproject/build:build
     steps:
       - checkout
       - run:
-          name: Run buildifier
-          command: buildifier --lint=warn -r ./ || true
+          name: Run buildifier script
+          command: .circleci/check-bazel-format.sh
 
 workflows:
   version: 2

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -43,6 +43,7 @@ STRATUM_DISABLED_COMPILER_WARNINGS_LLVM = [
     "-Wno-unused-lambda-capture",
     "-Wno-unused-template",
 ]
+
 # TODO(max): Bazel currently does not detect GCC, therefore we have to match on
 # the default conditions. See: https://github.com/bazelbuild/bazel/issues/12707
 STRATUM_DISABLED_COMPILER_WARNINGS = STRATUM_DISABLED_COMPILER_WARNINGS_COMMON + select({

--- a/bazel/rules/build_tools.bzl
+++ b/bazel/rules/build_tools.bzl
@@ -1,7 +1,6 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:workspace_rule.bzl", "remote_workspace")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def build_tools_deps():

--- a/bazel/rules/proto_gen.bzl
+++ b/bazel/rules/proto_gen.bzl
@@ -23,7 +23,7 @@ def proto_gen_deps():
             remote = "https://github.com/openconfig/goyang",
             commit = "e8b0ed2cbb0c40683bc0785ea2c796b2c12df80f",
             importpath = "github.com/openconfig/goyang",
-            vcs = "git"
+            vcs = "git",
         )
     if "com_github_golang_glog" not in native.existing_rules():
         go_repository(
@@ -31,7 +31,7 @@ def proto_gen_deps():
             remote = "https://github.com/golang/glog",
             commit = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
             importpath = "github.com/golang/glog",
-            vcs = "git"
+            vcs = "git",
         )
     if "com_github_kylelemons_godebug" not in native.existing_rules():
         go_repository(
@@ -39,7 +39,7 @@ def proto_gen_deps():
             remote = "https://github.com/kylelemons/godebug",
             commit = "9ff306d4fbead574800b66369df5b6144732d58e",
             importpath = "github.com/kylelemons/godebug",
-            vcs = "git"
+            vcs = "git",
         )
 
     if "com_github_openconfig_ygot" not in native.existing_rules():
@@ -50,9 +50,9 @@ def proto_gen_deps():
             importpath = "github.com/openconfig/ygot",
             vcs = "git",
             patches = [
-                "//bazel/patches:ygot.patch"
+                "//bazel/patches:ygot.patch",
             ],
-            patch_args = ["-p1"]
+            patch_args = ["-p1"],
         )
     if "com_github_openconfig_ygot_proto" not in native.existing_rules():
         remote_workspace(

--- a/bazel/rules/test_rule.bzl
+++ b/bazel/rules/test_rule.bzl
@@ -1,17 +1,26 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-def stratum_cc_test(name, deps = None, srcs = None, data = None, copts = None,
-                    defines = None, linkopts = None, size = "small",
-                    visibility = None):
-  native.cc_test(
-    name = name,
-    deps = deps,
-    srcs = srcs,
-    data = data,
-    copts = copts,
-    defines = defines,
-    linkopts = linkopts,
-    size = size,
-    visibility = visibility,
-  )
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+def stratum_cc_test(
+        name,
+        deps = None,
+        srcs = None,
+        data = None,
+        copts = None,
+        defines = None,
+        linkopts = None,
+        size = "small",
+        visibility = None):
+    cc_test(
+        name = name,
+        deps = deps,
+        srcs = srcs,
+        data = data,
+        copts = copts,
+        defines = defines,
+        linkopts = linkopts,
+        size = size,
+        visibility = visibility,
+    )

--- a/bazel/rules/yang_to_proto_rule.bzl
+++ b/bazel/rules/yang_to_proto_rule.bzl
@@ -14,7 +14,6 @@ def yang_to_proto(
         pkg_name = "",
         exclude_modules = [],
         base_import_path = ""):
-
     if pkg_name == "":
         pkg_name = name
 
@@ -41,6 +40,6 @@ def yang_to_proto(
         outs = outs,
         cmd = cmd,
         tools = [
-            "@com_github_openconfig_ygot//proto_generator:proto_generator"
-        ]
+            "@com_github_openconfig_ygot//proto_generator:proto_generator",
+        ],
     )

--- a/stratum/BUILD
+++ b/stratum/BUILD
@@ -2,14 +2,13 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_package",
-    "stratum_platform_select",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",

--- a/stratum/glue/BUILD
+++ b/stratum/glue/BUILD
@@ -2,13 +2,13 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",

--- a/stratum/hal/bin/bmv2/BUILD
+++ b/stratum/hal/bin/bmv2/BUILD
@@ -2,13 +2,14 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary")
+load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+
 licenses(["notice"])  # Apache v2
 
 package(
     default_visibility = ["//visibility:public"],
 )
-
-load("//bazel:rules.bzl", "stratum_cc_binary", "HOST_ARCHES")
 
 stratum_cc_binary(
     name = "stratum_bmv2",
@@ -16,8 +17,8 @@ stratum_cc_binary(
         "main.cc",
     ],
     arches = HOST_ARCHES,
+    data = ["dummy.json"],
     deps = [
-        "@com_github_google_glog//:glog",
         "//stratum/glue:init_google",
         "//stratum/glue:logging",
         "//stratum/hal/lib/bmv2:bmv2_switch",
@@ -26,14 +27,12 @@ stratum_cc_binary(
         "//stratum/hal/lib/pi:pi_node",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/lib/security:credentials_manager",
+        "@com_github_google_glog//:glog",
         "@local_bmv2_bin//:bmv2_headers",
-        "@local_bmv2_bin//:bmv2_simple_switch",
         "@local_bmv2_bin//:bmv2_pi",
+        "@local_bmv2_bin//:bmv2_simple_switch",
     ],
-    data = ["dummy.json"],
 )
-
-load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
 pkg_tar(
     name = "stratum_bmv2_bin",

--- a/stratum/hal/bin/bmv2/bmv2.bzl
+++ b/stratum/hal/bin/bmv2/bmv2.bzl
@@ -1,7 +1,7 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-# This Skylark rule imports the bmv2 shared libraries and headers since there is
+# This Starlark rule imports the bmv2 shared libraries and headers since there is
 # not yet any native support for Bazel in bmv2. The BMV2_INSTALL environment
 # variable needs to be set, otherwise the Stratum rules which depend on bmv2
 # cannot be built.

--- a/stratum/hal/bin/np4intel/BUILD
+++ b/stratum/hal/bin/np4intel/BUILD
@@ -3,13 +3,16 @@
 # Copyright 2019-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb", "pkg_tar")
+
 licenses(["notice"])  # Apache v2
 
 package(
     default_visibility = ["//visibility:public"],
 )
-
-load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary")
 
 stratum_cc_binary(
     name = "stratum_np4intel",
@@ -36,8 +39,6 @@ stratum_cc_binary(
         ":dpdk_cc_proto",
     ],
 )
-
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb", "pkg_tar")
 
 pkg_tar(
     name = "stratum_np4intel_bin",

--- a/stratum/hal/bin/np4intel/np4intel.bzl
+++ b/stratum/hal/bin/np4intel/np4intel.bzl
@@ -3,7 +3,7 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-# This Skylark rule imports the netcope shared libraries and headers since
+# This Starlark rule imports the netcope shared libraries and headers since
 # there is not yet any native support for Bazel in netcope. The NP4_INSTALL
 # environment variable needs to be set, otherwise the Stratum rules which
 # depend on netcope cannot be built.

--- a/stratum/hal/config/platform_config_test.bzl
+++ b/stratum/hal/config/platform_config_test.bzl
@@ -8,7 +8,7 @@ load(
     "stratum_cc_test",
 )
 
-def platform_config_test(platform, bcm_target=False, sim_target=False):
+def platform_config_test(platform, bcm_target = False, sim_target = False):
     defines = ["PLATFORM=" + platform]
     if bcm_target:
         defines.append("BCM_TARGET")
@@ -19,7 +19,7 @@ def platform_config_test(platform, bcm_target=False, sim_target=False):
     stratum_cc_test(
         name = "validate_configs_" + platform,
         srcs = [
-            "config_validator_main.cc"
+            "config_validator_main.cc",
         ],
         deps = [
             "//stratum/glue/status:status_test_util",
@@ -35,5 +35,5 @@ def platform_config_test(platform, bcm_target=False, sim_target=False):
             "@com_github_grpc_grpc//:grpc++",
         ],
         data = native.glob([platform + "/*.pb.txt"]),
-        defines = defines
+        defines = defines,
     )

--- a/stratum/hal/lib/phal/onlp/onlp.bzl
+++ b/stratum/hal/lib/phal/onlp/onlp.bzl
@@ -1,7 +1,7 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-# This Skylark rule imports the onlp shared libraries and headers
+# This Starlark rule imports the onlp shared libraries and headers
 # The ONLP_INSTALL environment variable needs to be set
 # otherwise will download the prebuit libraries
 

--- a/stratum/hal/lib/phal/tai/BUILD
+++ b/stratum/hal/lib/phal/tai/BUILD
@@ -146,15 +146,15 @@ stratum_cc_test(
     name = "tai_phal_test",
     srcs = ["tai_phal_test.cc"],
     deps = [
-        ":tai_phal",
         ":tai_interface",
         ":tai_interface_mock",
-        "//stratum/hal/lib/common:common_cc_proto",
+        ":tai_phal",
         "//stratum/glue/status",
         "//stratum/glue/status:status_test_util",
         "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/common:common_cc_proto",
         "//stratum/lib:macros",
         "@com_google_absl//absl/memory",
         "@com_google_googletest//:gtest_main",
-    ]
+    ],
 )

--- a/stratum/hal/lib/phal/test/BUILD
+++ b/stratum/hal/lib/phal/test/BUILD
@@ -2,12 +2,14 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -21,5 +23,5 @@ proto_library(
 
 cc_proto_library(
     name = "test_cc_proto",
-    deps = [":test_proto"]
+    deps = [":test_proto"],
 )

--- a/stratum/lib/libcproxy/BUILD
+++ b/stratum/lib/libcproxy/BUILD
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-licenses(["notice"])  # Apache v2
-
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//bazel:rules.bzl",
-    "stratum_cc_library",
-    "stratum_cc_test",
     "STRATUM_INTERNAL",
+    "stratum_cc_library",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     # default_hdrs_check = "strict",

--- a/stratum/lib/security/BUILD
+++ b/stratum/lib/security/BUILD
@@ -2,15 +2,15 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//bazel:rules.bzl",
+    "HOST_ARCHES",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
-    "stratum_cc_test",
-    "HOST_ARCHES",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -125,14 +125,14 @@ stratum_cc_library(
     srcs = ["credentials_manager.cc"],
     hdrs = ["credentials_manager.h"],
     deps = [
+        "//stratum/glue:logging",
+        "//stratum/glue/status:statusor",
+        "//stratum/lib:macros",
+        "//stratum/lib:utils",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/synchronization",
-        "//stratum/glue:logging",
-        "//stratum/glue/status:statusor",
-        "//stratum/lib:utils",
-        "//stratum/lib:macros",
     ],
 )
 
@@ -152,9 +152,9 @@ cc_library(
     testonly = 1,
     srcs = ["test_main.cc"],
     deps = [
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest",
         "//stratum/glue:init_google",
         "//stratum/glue:logging",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/stratum/lib/statemachine/BUILD
+++ b/stratum/lib/statemachine/BUILD
@@ -2,14 +2,14 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
     "stratum_cc_test",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -22,11 +22,11 @@ stratum_cc_library(
         "state_machine.h",
     ],
     deps = [
+        "//stratum/glue/status",
+        "//stratum/glue/status:statusor",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/synchronization",
-        "//stratum/glue/status:status",
-        "//stratum/glue/status:statusor",
     ],
 )
 
@@ -41,11 +41,11 @@ stratum_cc_library(
     ],
     deps = [
         ":state_machine",
-        "@com_google_googletest//:gtest",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "//stratum/glue/status:status",
-        "//stratum/glue/status:status_test_util",
+        "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
+        "//stratum/glue/status:status_test_util",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -57,9 +57,9 @@ stratum_cc_test(
     deps = [
         ":example_state_machine",
         ":state_machine",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "//stratum/glue/status:status",
-        "//stratum/glue/status:status_macros",
     ],
 )

--- a/stratum/p4c_backends/common/build_defs.bzl
+++ b/stratum/p4c_backends/common/build_defs.bzl
@@ -2,7 +2,6 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-
 """P4c configuration generation rules."""
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")

--- a/stratum/p4c_backends/fpm/bcm/BUILD
+++ b/stratum/p4c_backends/fpm/bcm/BUILD
@@ -2,12 +2,13 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     # default_copts = [
@@ -49,8 +50,8 @@ cc_test(
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
         ":bcm_target_info",
-        "@com_google_googletest//:gtest_main",
         "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -67,12 +68,12 @@ cc_library(
     ],
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
-        "@com_github_google_glog//:glog",
-        "@com_google_protobuf//:protobuf",
+        "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/p4c_backends/fpm:p4c_switch_utils",
         "//stratum/p4c_backends/fpm:tunnel_optimizer_interface",
-        "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -91,10 +92,10 @@ cc_test(
     ],
     deps = [
         ":bcm_tunnel_optimizer",
-        "@com_google_googletest//:gtest_main",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/stratum/p4c_backends/test/build_defs.bzl
+++ b/stratum/p4c_backends/test/build_defs.bzl
@@ -78,19 +78,19 @@ p4c_save_ir = rule(
         "_model": attr.label(
             allow_single_file = True,
             mandatory = False,
-            default = Label("@com_github_p4lang_p4c//:p4include/v1model.p4"), # FIXME
+            default = Label("@com_github_p4lang_p4c//:p4include/v1model.p4"),  # FIXME
         ),
         "_core": attr.label(
             allow_single_file = True,
             mandatory = False,
-            default = Label("@com_github_p4lang_p4c//:p4include/core.p4"), # FIXME
+            default = Label("@com_github_p4lang_p4c//:p4include/core.p4"),  # FIXME
         ),
         "_p4c_ir_json_saver": attr.label(
             cfg = "host",
             executable = True,
             default = Label("//stratum/p4c_backends/test:p4c_ir_json_saver"),
         ),
-        "cpp": attr.label_list(default = [Label("@bazel_tools//tools/cpp:current_cc_toolchain")]), # FIXME
+        "cpp": attr.label_list(default = [Label("@bazel_tools//tools/cpp:current_cc_toolchain")]),  # FIXME
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),

--- a/stratum/pipelines/loopback/BUILD
+++ b/stratum/pipelines/loopback/BUILD
@@ -1,48 +1,54 @@
 # Copyright 2019 NoviFlow Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//bazel/rules:p4c_build_defs.bzl", "p4_bmv2_compile")
+load("//stratum/pipelines/ptf:ptf_exec.bzl", "ptf_exec")
+
 licenses(["notice"])  # Apache v2
 
 package(
     default_visibility = ["//visibility:public"],
 )
 
-load("//bazel/rules:p4c_build_defs.bzl", "p4_bmv2_compile")
-load("//stratum/pipelines/ptf:ptf_exec.bzl", "ptf_exec")
-
 p4_bmv2_compile(
     name = "p4_loopback",
     src = "loopback.p4",
-    hdrs = ["@com_github_p4lang_p4c//:p4include/core.p4",
-            "@com_github_p4lang_p4c//:p4include/v1model.p4"],
+    hdrs = [
+        "@com_github_p4lang_p4c//:p4include/core.p4",
+        "@com_github_p4lang_p4c//:p4include/v1model.p4",
+    ],
     out_p4_info = "p4c-out/bmv2/loopback.p4info",
     out_p4_pipeline_json = "p4c-out/bmv2/loopback.json",
 )
 
 filegroup(
     name = "p4_loopback_test_files",
-    srcs = ["ptf/loopback.py",
-            "p4c-out/bmv2/loopback.p4info",
-            "p4c-out/bmv2/loopback.json"]
+    srcs = [
+        "p4c-out/bmv2/loopback.json",
+        "p4c-out/bmv2/loopback.p4info",
+        "ptf/loopback.py",
+    ],
 )
 
 ptf_exec(
     name = "p4_loopback_test",
+    data = [
+        "p4_loopback",
+        "p4_loopback_test_files",
+        "//stratum/hal/bin/bmv2:stratum_bmv2",
+    ],
     device = "stratum-bmv2",
     pipeline_name = "loopback",
-    data = ["p4_loopback_test_files",
-            "p4_loopback",
-            "//stratum/hal/bin/bmv2:stratum_bmv2"]
 )
 
 ptf_exec(
     name = "p4_loopback_pipeline",
+    data = [
+        "p4_loopback",
+        "p4_loopback_test_files",
+    ],
     device = "stratum-bmv2",
     pipeline_name = "loopback",
-    data = ["p4_loopback_test_files",
-            "p4_loopback"],
-    skip_test = True,
     skip_bmv2_start = True,
+    skip_test = True,
 )
-
-

--- a/stratum/pipelines/main/BUILD
+++ b/stratum/pipelines/main/BUILD
@@ -1,15 +1,13 @@
 # Copyright 2019-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("//stratum/p4c_backends/common:build_defs.bzl", "p4_fpm_compile")
+load("//bazel/rules:p4c_build_defs.bzl", "p4_bmv2_compile")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
 licenses(["notice"])  # Apache v2
 
 # Build the main P4 pipeline for Broadcom switches.
-
-load("//stratum/p4c_backends/common:build_defs.bzl", "p4_fpm_compile")
-
-load("//bazel/rules:p4c_build_defs.bzl", "p4_bmv2_compile")
-
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "annotation_map_files",
@@ -39,14 +37,14 @@ p4_bmv2_compile(
 
 pkg_tar(
     name = "main_pipelines",
-    extension = "tar.gz",
-    strip_prefix = ".",
     srcs = [
+        "bmv2/main.json",
+        "bmv2/main.p4info",
         "fpm/main.p4info",
         "fpm/main.pb.bin",
         "fpm/main.pb.txt",
-        "bmv2/main.p4info",
-        "bmv2/main.json",
     ],
+    extension = "tar.gz",
     mode = "0644",
+    strip_prefix = ".",
 )

--- a/stratum/pipelines/ptf/BUILD
+++ b/stratum/pipelines/ptf/BUILD
@@ -2,10 +2,10 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
 load(":scapy_exec.bzl", "scapy_exec")
+
+licenses(["notice"])  # Apache v2
 
 exports_files(["LICENSE"])
 
@@ -17,12 +17,12 @@ package(
 
 filegroup(
     name = "ptf_exec_files",
-    srcs = ["ptf_exec.py"]
+    srcs = ["ptf_exec.py"],
 )
 
 filegroup(
     name = "scapy_exec_files",
-    srcs = ["scapy_exec.py"]
+    srcs = ["scapy_exec.py"],
 )
 
 python_grpc_library(
@@ -31,5 +31,5 @@ python_grpc_library(
 )
 
 scapy_exec(
-    name = "scapy"
-    )
+    name = "scapy",
+)

--- a/stratum/pipelines/ptf/ptf_exec.bzl
+++ b/stratum/pipelines/ptf/ptf_exec.bzl
@@ -2,11 +2,11 @@
 # Copyright 2019-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@grpc_py_deps//:requirements.bzl", grpc_all_requirements = "all_requirements", grpc_requirement = "requirement")
 load("@ptf_deps//:requirements.bzl", ptf_all_requirements = "all_requirements", ptf_requirement = "requirement")
 
-def ptf_exec( name, device, pipeline_name, data=None, skip_test=False, skip_bmv2_start=False ):
-
+def ptf_exec(name, device, pipeline_name, data = None, skip_test = False, skip_bmv2_start = False):
     py_data = []
     for x in data:
         py_data.append(x)
@@ -29,15 +29,16 @@ def ptf_exec( name, device, pipeline_name, data=None, skip_test=False, skip_bmv2
     py_args.append(ptf_requirement("ptf")[1:-6])
     py_args.append(" --scapy-dir")
     py_args.append(ptf_requirement("scapy")[1:-6])
-
-    native.py_binary(
+    py_binary(
         name = name,
         srcs = ["//stratum/pipelines/ptf:ptf_exec_files"],
         main = "//stratum/pipelines/ptf:ptf_exec.py",
         args = py_args,
-        deps = ["@com_github_p4lang_p4runtime//:p4runtime_py_grpc",
-                "//stratum/pipelines/ptf:ptf_py_lib"] +
-                depset(grpc_all_requirements).to_list() +
-                depset(ptf_all_requirements).to_list(),
-        data = py_data
+        deps = [
+                   "@com_github_p4lang_p4runtime//:p4runtime_py_grpc",
+                   "//stratum/pipelines/ptf:ptf_py_lib",
+               ] +
+               depset(grpc_all_requirements).to_list() +
+               depset(ptf_all_requirements).to_list(),
+        data = py_data,
     )

--- a/stratum/pipelines/ptf/scapy_exec.bzl
+++ b/stratum/pipelines/ptf/scapy_exec.bzl
@@ -2,15 +2,14 @@
 # Copyright 2019-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@ptf_deps//:requirements.bzl", ptf_requirement = "requirement")
 
-def scapy_exec( name ):
-
+def scapy_exec(name):
     py_args = []
     py_args.append("--scapy-dir")
     py_args.append(ptf_requirement("scapy")[1:-6])
-
-    native.py_binary(
+    py_binary(
         name = name,
         srcs = ["//stratum/pipelines/ptf:scapy_exec_files"],
         main = "//stratum/pipelines/ptf:scapy_exec.py",

--- a/stratum/portage/BUILD
+++ b/stratum/portage/BUILD
@@ -2,6 +2,8 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 licenses(["notice"])  # Apache v2
 
 package(

--- a/stratum/portage/build_defs.bzl
+++ b/stratum/portage/build_defs.bzl
@@ -45,6 +45,8 @@ load(
     "//devtools/build_cleaner/skylark:build_defs.bzl",
     "register_extension_info",
 )
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 # Generic path & label helpers. ============================================
 
@@ -80,7 +82,7 @@ def _normpath(path):
                 continue
         else:
             level += 1
-        result += [d]
+        result.append(d)
     return sep.join(result)
 
 # Adds a suffix to a label, expanding implicit targets if needed.
@@ -294,7 +296,7 @@ def sc_cc_test(
       linkopts: Analogous to cc_test linkopts argument.
       visibility: Analogous to cc_test visibility argument.
     """
-    native.cc_test(
+    cc_test(
         name = name,
         size = size or "small",
         srcs = sc_platform_select(host = srcs or [], default = []),
@@ -366,7 +368,7 @@ def sc_cc_lib(
         arches = ALL_ARCHES
     defs_plus = (defines or []) + _ARCH_DEFINES
     textual_plus = textual_hdrs | depset(deps.to_list())
-    native.cc_library(
+    cc_library(
         name = name,
         deps = sc_platform_filter(deps, [], arches),
         srcs = sc_platform_filter(srcs, [], arches),
@@ -420,7 +422,7 @@ def sc_cc_bin(
     if not arches:
         arches = ALL_ARCHES
     defs_plus = (defines or []) + _ARCH_DEFINES
-    native.cc_binary(
+    cc_binary(
         name = name,
         deps = sc_platform_filter(
             deps,
@@ -798,7 +800,7 @@ def _gen_py_proto_lib(name, srcs, deps, visibility, testonly):
     """
     regular_proto_name = decorate(name, "default_pb")
     py_name = decorate(name, "py")
-    native.proto_library(
+    proto_library(
         name = regular_proto_name,
         srcs = srcs,
         deps = [decorate(dep, "default_pb") for dep in deps],


### PR DESCRIPTION
Initially we only check a set of known files and files that get modified. This PR also applies a list of low churn style fixes to boost the initial good set.