### PR TITLE
Update gnmi cli

### DIFF
--- a/stratum/tools/gnmi/BUILD
+++ b/stratum/tools/gnmi/BUILD
@@ -19,6 +19,7 @@ stratum_cc_binary(
     srcs = ["gnmi_cli.cc"],
     arches = HOST_ARCHES,
     deps = [
+        "//stratum/glue/gtl:cleanup",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/lib:macros",
@@ -28,5 +29,6 @@ stratum_cc_binary(
         "@com_github_openconfig_gnmi_proto//:gnmi_cc_grpc",
         "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "@com_google_protobuf//:protobuf",
+        "@com_googlesource_code_re2//:re2",
     ],
 )

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <thread>
+#include <thread>  // NOLINT
 #include <vector>
 
 #define STRIP_FLAG_HELP 1  // remove additional flag help text from gflag

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -91,8 +91,11 @@ optional arguments:
   --client-key             gRPC Client key
 )USAGE";
 
-// Flag to indicate that SIGINT has been received and we should shutdown.
+// Atomic flag to indicate that SIGINT has been received and we should shutdown.
 std::atomic_bool shutdown(false);
+// Since we set the shutdown flag from a signal handler, it must be implemented
+// in lock-free manner.
+static_assert(ATOMIC_BOOL_LOCK_FREE == 2, "std::atomic_bool is not lock-free");
 
 // Pointer to the client context to cancel the blocking calls.
 grpc::ClientContext* ctx_ = nullptr;


### PR DESCRIPTION
This PR makes it thread, memory and signal-safe. It also replaces `<regex>` with RE2.

Feel free to do a before-after comparison with `bazel run --config=tsan //stratum/tools/gnmi:gnmi-cli`!