### PR TITLE
Make HAL shutdown async-safe with atomic variable

### DIFF
--- a/stratum/hal/lib/common/hal.h
+++ b/stratum/hal/lib/common/hal.h
@@ -151,6 +151,7 @@ class Hal final {
   // in the class destructor.
   absl::flat_hash_map<int, sighandler_t> old_signal_handlers_;
 
+  // Thread id for the signal waiter thread.
   pthread_t signal_waiter_tid_;
 
   // The lock used for initialization of the singleton.

--- a/stratum/hal/lib/common/hal.h
+++ b/stratum/hal/lib/common/hal.h
@@ -151,6 +151,8 @@ class Hal final {
   // in the class destructor.
   absl::flat_hash_map<int, sighandler_t> old_signal_handlers_;
 
+  pthread_t signal_waiter_tid_;
+
   // The lock used for initialization of the singleton.
   static absl::Mutex init_lock_;
 


### PR DESCRIPTION
The current shutdown procedure is not async-safe as it takes a mutex during the signal handler. This change fixes this by using an atomic variable and a waiter thread instead. TSAN reports no issues.

I also tested this with grpc 1.32 to verify that no mutex lock cycle occurs.

Co-authored-by: Brian O'Connor <bocon@opennetworking.org>