### PR TITLE
Remove 28000 as default gRPC port

### DIFF
--- a/stratum/docs/setup_guide_barefoot_tofino_onos.md
+++ b/stratum/docs/setup_guide_barefoot_tofino_onos.md
@@ -85,7 +85,7 @@ cd stratum
 :pencil2: (Optional) You can tunnel the ports exposed by Stratum (P4Runtime, gNMI, gNOI) via SSH tunnels:
 
 ```
-for port in 9339 9559 28000; do
+for port in 9339 9559; do
     ssh \
         -o ExitOnForwardFailure=yes \
         -f \

--- a/stratum/hal/bin/barefoot/docker/Dockerfile
+++ b/stratum/hal/bin/barefoot/docker/Dockerfile
@@ -10,7 +10,6 @@ ADD ./${STRATUM_TARGET}_deb.deb /
 RUN install_packages ./${STRATUM_TARGET}_deb.deb
 RUN rm ./${STRATUM_TARGET}_deb.deb
 
-EXPOSE 28000/tcp
 EXPOSE 9339/tcp
 EXPOSE 9559/tcp
 

--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -20,8 +20,7 @@ fi
 if [[ "$PLATFORM" == 'barefoot-tofino-model' ]]; then
     DOCKER_NET_OPTS="--network host "
 else
-    DOCKER_NET_OPTS="-p 28000:28000 "
-    DOCKER_NET_OPTS+="-p 9339:9339 "
+    DOCKER_NET_OPTS="-p 9339:9339 "
     DOCKER_NET_OPTS+="-p 9559:9559 "
 fi
 

--- a/stratum/hal/bin/bcm/standalone/docker/Dockerfile
+++ b/stratum/hal/bin/bcm/standalone/docker/Dockerfile
@@ -10,7 +10,6 @@ ADD ./${STRATUM_TARGET}_deb.deb /
 RUN install_packages ./${STRATUM_TARGET}_deb.deb
 RUN rm ./${STRATUM_TARGET}_deb.deb
 
-EXPOSE 28000/tcp
 EXPOSE 9339/tcp
 EXPOSE 9559/tcp
 ENTRYPOINT ["start-stratum.sh"]

--- a/stratum/hal/bin/np4intel/docker/Dockerfile.runtime
+++ b/stratum/hal/bin/np4intel/docker/Dockerfile.runtime
@@ -139,7 +139,6 @@ RUN mkdir /stratum_configs && \
     echo "nodev /mnt/huge hugetlbfs defaults 0 0" >> /etc/fstab && \
     echo "vm.nr_hugepages=8192" >> /etc/sysctl.conf
 
-EXPOSE 28000/tcp
 EXPOSE 9339/tcp
 EXPOSE 9559/tcp
 ENTRYPOINT ["/stratum-entrypoint.sh"]

--- a/stratum/hal/bin/np4intel/docker/Dockerfile.runtime.local
+++ b/stratum/hal/bin/np4intel/docker/Dockerfile.runtime.local
@@ -133,7 +133,6 @@ RUN mkdir /stratum_configs && \
     echo "nodev /mnt/huge hugetlbfs defaults 0 0" >> /etc/fstab && \
     echo "vm.nr_hugepages=8192" >> /etc/sysctl.conf
 
-EXPOSE 28000/tcp
 EXPOSE 9339/tcp
 EXPOSE 9559/tcp
 ENTRYPOINT ["/stratum-entrypoint.sh"]

--- a/stratum/hal/bin/np4intel/docker/README.md
+++ b/stratum/hal/bin/np4intel/docker/README.md
@@ -199,7 +199,7 @@ to debug problems using gdb and the source code.
 
 5. At this point the ptf framework can be used to load tables or a real
 control plane can be started to talk to Stratum on port 9559. If it's
-on the local machine it will likely be localhost:28000 (depends on your
+on the local machine it will likely be localhost:9559 (depends on your
 docker network settings).  You will need to configure the network to
 redirect packets to this container if your trying to access stratum off
 box (i.e. using ipchains).

--- a/stratum/hal/bin/np4intel/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/np4intel/docker/start-stratum-container.sh
@@ -63,7 +63,6 @@ done
 
 docker run -it --rm --privileged \
     -v /dev:/dev -v /sys:/sys  \
-    -p 28000:28000 \
     -p 9339:9339 \
     -p 9559:9559 \
     -v $CONFIG_DIR:/stratum_configs \

--- a/stratum/lib/constants.h
+++ b/stratum/lib/constants.h
@@ -30,14 +30,12 @@ constexpr char kDefaultAuthPolicyFilePath[] =
 
 // This URL is used by a local Stratum stub binary running on the switch to
 // talk to Stratum process over an insecure connection.
-constexpr char kLocalStratumUrl[] = "localhost:28000";
+constexpr char kLocalStratumUrl[] = "localhost:9559";
 
 // This URL is used by external gNMI, gNOI and P4Runtime clients.
 // TCP port 9339 is an IANA-reserved port for gNMI and gNOI.
 // TCP port 9559 is an IANA-reserved port for P4Runtime.
-// TODO(max): Remove the deprecated port 28000 from default list.
-constexpr char kExternalStratumUrls[] =
-    "0.0.0.0:28000,0.0.0.0:9339,0.0.0.0:9559";
+constexpr char kExternalStratumUrls[] = "0.0.0.0:9339,0.0.0.0:9559";
 
 // Default URLs for the Sandcastle services Stratum service will connect to
 // over gRPC.

--- a/stratum/pipelines/ptf/ptf_exec.py
+++ b/stratum/pipelines/ptf/ptf_exec.py
@@ -70,7 +70,7 @@ def setup_and_launch_ptf_runner(device, pipeline_name, protobuf_dir, ptf_dir, sc
             " --device-id 1" +\
             " --device " + device +\
             " --port-map " + EXTERNAL_PATH_P4_FABRIC_TEST + "/port_map.veth.json" +\
-            " --grpc-addr localhost:28000" +\
+            " --grpc-addr localhost:9559" +\
             " --p4info " + PIPELINE_PATH_BINARY + pipeline_name + ".p4info" +\
             " --bmv2-json " + PIPELINE_PATH_BINARY + pipeline_name + ".json" +\
             " --cpu-port 64" +\


### PR DESCRIPTION
It has been deprecated in favor of 9559 for some time and is now removed.

Closes #499 