### PR TITLE
Fix underscore naming of files and Bazel targets

### DIFF
--- a/.circleci/check-bazel-format.sh
+++ b/.circleci/check-bazel-format.sh
@@ -66,7 +66,7 @@ stratum/testing/protos/BUILD
 stratum/testing/scenarios/BUILD
 stratum/testing/tests/BUILD
 stratum/tools/gnmi/BUILD
-stratum/tools/stratum-replay/BUILD
+stratum/tools/stratum_replay/BUILD
 \0
 EOF
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
     docker:
       - image: stratumproject/build:build
     environment:
-      - DOCKER_SCOPE: stratum/tools/stratum-replay
+      - DOCKER_SCOPE: stratum/tools/stratum_replay
       - DOCKER_FILE: Dockerfile
       - DOCKER_IMG: stratumproject/stratum-replay
       - CC: clang
@@ -295,14 +295,14 @@ jobs:
       - *restore_bazel_cache
       - *set_bazelrc
       - run:
-          name: Build stratum-replay
+          name: Build stratum_replay
           command: |
-            bazel build --config=release //stratum/tools/stratum-replay:stratum-replay
-            cp bazel-bin/stratum/tools/stratum-replay/stratum-replay $DOCKER_SCOPE
+            bazel build --config=release //stratum/tools/stratum_replay:stratum_replay
+            cp bazel-bin/stratum/tools/stratum_replay/stratum_replay $DOCKER_SCOPE
       - *docker_login
       - *docker_build
       - run:
-          name: Test stratum-replay Docker image
+          name: Test stratum_replay Docker image
           command: |
             docker run $DOCKER_IMG -version
       - *docker_push

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Also see the chapter about
 - [gNMI CLI Tool](/stratum/tools/gnmi/README.md)
 - [Tofino Pipeline Builder](/stratum/hal/bin/barefoot/README.pipeline.md#stratum-bfpipelineconfig-format-and-the-bfpipelinebuilder)
 - [Stratum-Enabled Mininet](/tools/mininet/README.md)
-- [P4Runtime write request replay tool](/stratum/tools/stratum-replay/README.md)
+- [P4Runtime write request replay tool](/stratum/tools/stratum_replay/README.md)
 - [ChassisConfig Migrator](/stratum/hal/config/chassis_config_migrator.cc)
 - [PHAL CLI Tool](/stratum/hal/lib/phal/phal_cli.cc)
 - [ONLP CLI Tool](/stratum/hal/lib/phal/onlp/onlp_cli.cc)

--- a/stratum/tools/gnmi/BUILD
+++ b/stratum/tools/gnmi/BUILD
@@ -15,7 +15,7 @@ package(
 )
 
 stratum_cc_binary(
-    name = "gnmi-cli",
+    name = "gnmi_cli",
     srcs = ["gnmi_cli.cc"],
     arches = HOST_ARCHES,
     deps = [

--- a/stratum/tools/gnmi/README.md
+++ b/stratum/tools/gnmi/README.md
@@ -10,7 +10,7 @@ gNMI tool
 ### Usage
 
 ```
-usage: gnmi-cli [--help] [Options] {get,set,cap,del,sub-onchange,sub-sample} path
+usage: gnmi_cli [--help] [Options] {get,set,cap,del,sub-onchange,sub-sample} path
 
 Basic gNMI CLI
 
@@ -38,14 +38,14 @@ optional arguments:
 
 ```
 # To get port index (which is used when referring to a port in P4Runtime)
-bazel run //stratum/tools/gnmi:gnmi-cli -- get /interfaces/interface[name=1/1/1]/state/ifindex
+bazel run //stratum/tools/gnmi:gnmi_cli -- get /interfaces/interface[name=1/1/1]/state/ifindex
 
 # To set port health indicator
-bazel run //stratum/tools/gnmi:gnmi-cli -- set /interfaces/interface[name=1/1/1]/config/health-indicator --string-val GOOD
+bazel run //stratum/tools/gnmi:gnmi_cli -- set /interfaces/interface[name=1/1/1]/config/health-indicator --string-val GOOD
 
 # To subscribe one sample of port operation status per second
-bazel run //stratum/tools/gnmi:gnmi-cli -- sub-sample /interfaces/interface[name=1/1/1]/state/oper-status --interval 1000
+bazel run //stratum/tools/gnmi:gnmi_cli -- sub-sample /interfaces/interface[name=1/1/1]/state/oper-status --interval 1000
 
 # To push chassis config
-bazel run //stratum/tools/gnmi:gnmi-cli -- --replace --bytes_val_file [chassis config file] set /
+bazel run //stratum/tools/gnmi:gnmi_cli -- --replace --bytes_val_file [chassis config file] set /
 ```

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -21,7 +21,7 @@
 #include "stratum/lib/utils.h"
 
 const char kUsage[] =
-    R"USAGE(usage: gnmi-cli [--help] [Options] {get,set,cap,del,sub-onchange,sub-sample} path
+    R"USAGE(usage: gnmi_cli [--help] [Options] {get,set,cap,del,sub-onchange,sub-sample} path
 
 Basic gNMI CLI
 

--- a/stratum/tools/stratum_replay/BUILD
+++ b/stratum/tools/stratum_replay/BUILD
@@ -15,7 +15,7 @@ package(
 )
 
 stratum_cc_binary(
-    name = "stratum-replay",
+    name = "stratum_replay",
     srcs = ["stratum_replay.cc"],
     arches = HOST_ARCHES,
     deps = [

--- a/stratum/tools/stratum_replay/Dockerfile
+++ b/stratum/tools/stratum_replay/Dockerfile
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM bitnami/minideb:stretch
-ADD ./stratum-replay /
+ADD ./stratum_replay /
 
 LABEL maintainer="Stratum dev <stratum-dev@lists.stratumproject.org>"
-LABEL description="Docker-based distribution of the stratum-replay tool"
+LABEL description="Docker-based distribution of the stratum_replay tool"
 
-ENTRYPOINT [ "/stratum-replay" ]
+ENTRYPOINT [ "/stratum_replay" ]

--- a/stratum/tools/stratum_replay/README.md
+++ b/stratum/tools/stratum_replay/README.md
@@ -59,11 +59,11 @@ $ ls
 p4_writes.pb.txt  pipeline_cfg.pb.txt
 ```
 
-Copy those files to your laptop or the place you are going to run stratum-replay tool.
+Copy those files to your laptop or the place you are going to run stratum_replay tool.
 
 ## Step 2 - Replay the pipeline, and P4Runtime writes
 
-We provide a container image that includes a prebuilt stratum-replay binary.
+We provide a container image that includes a prebuilt stratum_replay binary.
 
 To use it, you can run the following commands:
 
@@ -71,7 +71,7 @@ To use it, you can run the following commands:
 docker run \
   -v $PWD:$PWD \
   -w $PWD \
-  stratumproject/stratum-replay \
+  stratumproject/stratum_replay \
   -grpc-addr="ip-of-switch-to-replay-on:9339" \
   -pipeline-cfg pipeline_cfg.pb.txt \
   p4_writes.pb.txt
@@ -122,7 +122,7 @@ for a given pipeline config file.
 
 # Usage and available options:
 
-`stratum-replay [options] [p4runtime write log file]`
+`stratum_replay [options] [p4runtime write log file]`
 
 ```
 -device_id: The device ID (default: 1)

--- a/stratum/tools/stratum_replay/stratum_replay.cc
+++ b/stratum/tools/stratum_replay/stratum_replay.cc
@@ -38,7 +38,7 @@ namespace tools {
 namespace p4rt_replay {
 
 const char kUsage[] = R"USAGE(
-Usage: stratum-replay [options] [p4runtime write log file]
+Usage: stratum_replay [options] [p4runtime write log file]
   This tool replays P4Runtime write requests to a Stratum device from a given
   Stratum P4Runtime write request log.
 


### PR DESCRIPTION
Some files and Bazel targets have `-` in their names. The prevalent naming scheme is mandating `_`. This PR fixes most instances of this. Exceptions are made for the `hal/config/<platform_name>` folders and `p4c-fpm`.