### PR TITLE
Update bmv2 and PI to latest revisions

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BAZELISK_VERSION=1.8.0
-ARG PI_COMMIT=0fbdac256151eb1537cd5ebf19101d5df60767fa
-ARG BMV2_COMMIT=498202d98d83a6c580aa86a3497b9b496bcd43b2
+ARG PI_COMMIT=b2760a818e0b8ade5864604d29b3008a684c6d5f
+ARG BMV2_COMMIT=6dfd5b41426310eb081fedc8fee05b675f780e31
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-11 main"
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -91,7 +91,7 @@ def stratum_deps():
         remote_workspace(
             name = "com_github_p4lang_PI",
             remote = "https://github.com/p4lang/PI.git",
-            commit = "0fbdac256151eb1537cd5ebf19101d5df60767fa",
+            commit = "b2760a818e0b8ade5864604d29b3008a684c6d5f",
         )
 
     for sde_ver in BF_SDE_PI_VER:


### PR DESCRIPTION
# PR Description

Unfortunately current bmv2 and PI versions in the `mn-stratum` docker image provided in dockerhub are a bit outdated.

Since https://github.com/p4lang/p4runtime-shell/commit/eb32e419e2bbd8a05b2032a1e6e71b932b3368e0 the p4runtime-shell defaults to the canonical representation for bytestrings instead of the legacy byte-padded format. This means that using `p4lang/p4runtime-sh` with `opennetworking/mn-stratum` won't work out of the box right now and custom options have to be provided in python's p4runtime-shell script:

```python
from p4runtime_sh.global_options import global_options
global_options["canonical_bytestrings"] = False
```

Furthermore, reading `direct_meters` and `direct_counters` also throws an error with the current version of `opennetworking/mn-stratum`: `Reading ALL direct meters in a table is not supported yet`. This functionality was only introduced in https://github.com/p4lang/PI/commit/e0d7e1f43cf1593abbd2b6e6c46285309d4f3870

# Tests

- This commit was tested by generating a new docker image for `opennetworking/mn-stratum`
- Setting up an emulated bmv2 switch via p4runtime-shell works as expected without having to define the aforementioned option
- Reading direct_meters via p4runtime-shell also works: `next(direct_meter_entry["my_table"].read())` returns the correct values
- Connection to ONOS using the `stratum-bmv2` driver also works fine. Packet-in/Packet-out was also tested using the reactive forwarding app

Thanks