### PR TITLE
Improve signal handling code

### DIFF
--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -5,7 +5,6 @@
 #include "stratum/hal/lib/common/hal.h"
 
 #include <limits.h>
-#include <unistd.h>
 
 #include <utility>
 
@@ -340,11 +339,7 @@ Hal* Hal::GetSingleton() {
     old_signal_handlers_[s] = h;
   }
   // Create the pipe to transfer signals.
-  int pipe_fds[2];
-  CHECK_RETURN_IF_FALSE(pipe(pipe_fds) == 0)
-      << "Could not create pipe for signal handling.";
-  pipe_read_fd_ = pipe_fds[0];
-  pipe_write_fd_ = pipe_fds[1];
+  RETURN_IF_ERROR(CreatePipeForSignalHandling(&pipe_read_fd_, &pipe_write_fd_));
   // Start the signal waiter thread that initiates shutdown.
   CHECK_RETURN_IF_FALSE(pthread_create(&signal_waiter_tid_, nullptr,
                                        SignalWaiterThreadFunc, nullptr) == 0)

--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -53,6 +53,8 @@ void SignalRcvCallback(int value) {
   static_assert(sizeof(value) <= PIPE_BUF,
                 "PIPE_BUF is smaller than the number of bytes that can be "
                 "written atomically to a pipe.");
+  // We must restore any changes made to errno at the end of the handler:
+  // https://www.gnu.org/software/libc/manual/html_node/POSIX-Safety-Concepts.html
   int saved_errno = errno;
   // No reasonable error handling possible.
   write(Hal::pipe_write_fd_, &value, sizeof(value));

--- a/stratum/hal/lib/common/hal.cc
+++ b/stratum/hal/lib/common/hal.cc
@@ -54,8 +54,10 @@ void SignalRcvCallback(int value) {
   static_assert(sizeof(value) <= PIPE_BUF,
                 "PIPE_BUF is smaller than the number of bytes that can be "
                 "written atomically to a pipe.");
+  int saved_errno = errno;
   // No reasonable error handling possible.
   write(Hal::pipe_write_fd_, &value, sizeof(value));
+  errno = saved_errno;
 }
 
 // Set the channel arguments to match the defualt keep-alive parameters set by

--- a/stratum/lib/utils.cc
+++ b/stratum/lib/utils.cc
@@ -256,12 +256,14 @@ std::string Demangle(const char* mangled) {
                 "PIPE_BUF is smaller than the number of bytes that can be "
                 "written atomically to a pipe.");
   int pipe_fds[2];  // [0] is read side, [1] is write side.
-  CHECK_RETURN_IF_FALSE(pipe(pipe_fds) == 0) << "Could not create pipe.";
+  CHECK_RETURN_IF_FALSE(pipe(pipe_fds) == 0)
+      << "Could not create pipe: " << strerror(errno) << ".";
   // Set write side to non-blocking mode.
   int flags = fcntl(pipe_fds[1], F_GETFL);
-  CHECK_RETURN_IF_FALSE(flags != -1) << "Could not read file descriptor flags.";
+  CHECK_RETURN_IF_FALSE(flags != -1)
+      << "Could not read file descriptor flags: " << strerror(errno) << ".";
   CHECK_RETURN_IF_FALSE(fcntl(pipe_fds[1], F_SETFL, flags | O_NONBLOCK) != -1)
-      << "Could not set file descriptor flags.";
+      << "Could not set file descriptor flags: " << strerror(errno) << ".";
   *read_fd = pipe_fds[0];
   *write_fd = pipe_fds[1];
 

--- a/stratum/lib/utils.h
+++ b/stratum/lib/utils.h
@@ -252,6 +252,14 @@ inline U ByteStreamToUint(const std::string& bytes) {
 // Not async-safe, do not use this function inside a signal handler!
 std::string Demangle(const char* mangled);
 
+// Creates a POSIX pipe suitable for use in a signal handler. The write side is
+// in non-blocking mode.
+// Rationale: handling signals safely is complicated as the number of async-safe
+// functions that can be called withing a signal handler is limited (cf. `man
+// signal-safety`). We use a pipe to transfer the signal value out of the
+// handler and into, e.g., a waiter thread where it can be properly processed.
+::util::Status CreatePipeForSignalHandling(int* read_fd, int* write_fd);
+
 }  // namespace stratum
 
 #endif  // STRATUM_LIB_UTILS_H_

--- a/stratum/lib/utils_test.cc
+++ b/stratum/lib/utils_test.cc
@@ -2,18 +2,18 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-
 #include "stratum/lib/utils.h"
 
+#include <algorithm>
+
 #include "gflags/gflags.h"
-#include "stratum/glue/status/status_test_util.h"
-#include "stratum/public/lib/error.h"
-#include "stratum/hal/lib/common/common.pb.h"
-#include "stratum/lib/test_utils/matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/lib/test_utils/matchers.h"
+#include "stratum/public/lib/error.h"
 
 DECLARE_string(test_tmpdir);
 
@@ -146,7 +146,7 @@ TEST(CommonUtilsTest, CreateDirWhichAlreadyExistsAndNotADir) {
   ASSERT_OK(WriteStringToFile(some_string, filename));
 
   EXPECT_THAT(RecursivelyCreateDir(filename),
-    StatusIs(_, ERR_INVALID_PARAM, HasSubstr("is not a dir")));
+              StatusIs(_, ERR_INVALID_PARAM, HasSubstr("is not a dir")));
 }
 
 TEST(CommonUtilsTest, ProtoSerialize) {
@@ -206,7 +206,6 @@ TEST(CommonUtilsTest, ProtoSerialize) {
             });
   EXPECT_EQ(ProtoSerialize(e1), ProtoSerialize(e2));
 }
-
 
 TEST(CommonUtilsTest, ProtoEqual) {
   ::p4::v1::TableEntry e1, e2;
@@ -315,6 +314,20 @@ TEST(CommonUtilsTest, ByteStreamTruncate) {
   bytes_too_long = {0xf, 1, 2, 3, 4, 5, 6, 7, 8};
   uint64 value64 = ByteStreamToUint<uint64>(bytes_too_long);
   EXPECT_EQ(0x0f01020304050607ULL, value64);
+}
+
+TEST(CommonUtilsTest, Demangle) {
+  EXPECT_EQ("foo(int)", Demangle("_Z3fooi"));
+  EXPECT_EQ("invalid", Demangle("invalid"));
+}
+
+TEST(CommonUtilsTest, CreatePipeForSignalHandling) {
+  int read_fd, write_fd = -1;
+  EXPECT_OK(CreatePipeForSignalHandling(&read_fd, &write_fd));
+  EXPECT_NE(-1, read_fd);
+  EXPECT_NE(-1, write_fd);
+  close(read_fd);
+  close(write_fd);
 }
 
 }  // namespace stratum

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -98,6 +98,8 @@ void HandleSignal(int signal) {
   static_assert(sizeof(signal) <= PIPE_BUF,
                 "PIPE_BUF is smaller than the number of bytes that can be "
                 "written atomically to a pipe.");
+  // We must restore any changes made to errno at the end of the handler:
+  // https://www.gnu.org/software/libc/manual/html_node/POSIX-Safety-Concepts.html
   int saved_errno = errno;
   // No reasonable error handling possible.
   write(pipe_write_fd_, &signal, sizeof(signal));

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -231,11 +231,8 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   ctx_ = &ctx;
   // Create the pipe to transfer signals.
   {
-    int pipe_fds[2];
-    CHECK_RETURN_IF_FALSE(pipe(pipe_fds) == 0)
-        << "Could not create pipe for signal handling.";
-    pipe_read_fd_ = pipe_fds[0];
-    pipe_write_fd_ = pipe_fds[1];
+    RETURN_IF_ERROR(
+        CreatePipeForSignalHandling(&pipe_read_fd_, &pipe_write_fd_));
   }
   CHECK_RETURN_IF_FALSE(std::signal(SIGINT, HandleSignal) != SIG_ERR);
   pthread_t context_cancel_tid;

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -98,8 +98,10 @@ void HandleSignal(int signal) {
   static_assert(sizeof(signal) <= PIPE_BUF,
                 "PIPE_BUF is smaller than the number of bytes that can be "
                 "written atomically to a pipe.");
+  int saved_errno = errno;
   // No reasonable error handling possible.
   write(pipe_write_fd_, &signal, sizeof(signal));
+  errno = saved_errno;
 }
 
 void* ContextCancelThreadFunc(void*) {


### PR DESCRIPTION
This PR improves the signal handing code by properly saving and restoring `errno` during the handler and creating a helper functions for the pipe creation.

See: https://www.gnu.org/software/libc/manual/html_node/POSIX-Safety-Concepts.html