### PR TITLE
Statically link SDE libraries

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -10,15 +10,47 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+# We import the static libraries explicitly to make sure they are linked with
+# -Wl,-whole-archive later.
+cc_import(
+    name = "libavago",
+    static_library = "barefoot-bin/lib/libavago.a",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "libbf_switchd_lib",
+    static_library = "barefoot-bin/lib/libbf_switchd_lib.a",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "libbfsys",
+    static_library = "barefoot-bin/lib/libbfsys.a",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "libbfutils",
+    static_library = "barefoot-bin/lib/libbfutils.a",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "libdriver",
+    static_library = "barefoot-bin/lib/libdriver.a",
+    alwayslink = 1,
+)
+
+cc_import(
+    name = "libdru_sim",
+    static_library = "barefoot-bin/lib/libdru_sim.a",
+    alwayslink = 1,
+)
+
 cc_library(
     name = "bfsde",
-    srcs = glob([
-        "barefoot-bin/lib/libavago.so*",
-        "barefoot-bin/lib/libbfsys.so*",
-        "barefoot-bin/lib/libbfutils.so*",
-        "barefoot-bin/lib/libdriver.so*",
-        "barefoot-bin/lib/libpython3.4m.so*",
-    ]) + ["barefoot-bin/lib/libbf_switchd_lib.a"],
+    srcs = [],
     hdrs = glob([
         "barefoot-bin/include/bf_rt/*.h",
         "barefoot-bin/include/bf_rt/*.hpp",
@@ -42,6 +74,12 @@ cc_library(
     ],
     strip_include_prefix = "barefoot-bin/include",
     deps = [
+        ":libavago",
+        ":libbf_switchd_lib",
+        ":libbfsys",
+        ":libbfutils",
+        ":libdriver",
+        ":libdru_sim",
         # TODO(bocon): PI needed when linking libdriver.so if/when pi is
         # enabled when building bf-drivers. This shouldn't hurt, but can
         # be excluded if/when PI is removed from the SDE build options.
@@ -53,12 +91,6 @@ pkg_tar_with_symlinks(
     name = "bf_library_files",
     srcs = glob([
         "barefoot-bin/lib/bfshell_plugin_*.so*",
-        "barefoot-bin/lib/libavago.so*",
-        "barefoot-bin/lib/libbfsys.so*",
-        "barefoot-bin/lib/libbfutils.so*",
-        "barefoot-bin/lib/libdriver.so*",
-        "barefoot-bin/lib/libdru_sim.so*",
-        "barefoot-bin/lib/libpython3.4m.so*",
     ]),
     mode = "0644",
     package_dir = "/usr",


### PR DESCRIPTION
With the introduction of version specific code `(#define SDE_5_0_0)` it is absolutely critical that same SDE libraries are used at build and runtime. Static linking removes any chance for errors. It also reduces the file size of the packages and docker images by 90%!