### PR TITLE
Make `TimerDaemon::Stop()` idempotent

### DIFF
--- a/stratum/lib/timer_daemon.cc
+++ b/stratum/lib/timer_daemon.cc
@@ -2,8 +2,8 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/lib/timer_daemon.h"
+
 #include "absl/synchronization/mutex.h"
 
 namespace stratum {
@@ -96,6 +96,10 @@ bool TimerDaemon::Execute() {
 ::util::Status TimerDaemon::Stop() {
   {
     absl::WriterMutexLock l(&GetInstance()->access_lock_);
+    if (GetInstance()->started_ == false) {
+      return ::util::OkStatus();
+    }
+
     GetInstance()->started_ = false;
   }
 
@@ -112,23 +116,23 @@ bool TimerDaemon::Execute() {
 }
 
 ::util::Status TimerDaemon::RequestOneShotTimer(uint64 delay_ms,
-                                                 const Action& action,
-                                                 DescriptorPtr* desc) {
+                                                const Action& action,
+                                                DescriptorPtr* desc) {
   return GetInstance()->RequestTimer(false, delay_ms,
                                      /* period_ms (ignored)= */ 0, action,
                                      desc);
 }
 
 ::util::Status TimerDaemon::RequestPeriodicTimer(uint64 delay_ms,
-                                                  uint64 period_ms,
-                                                  const Action& action,
-                                                  DescriptorPtr* desc) {
+                                                 uint64 period_ms,
+                                                 const Action& action,
+                                                 DescriptorPtr* desc) {
   return GetInstance()->RequestTimer(true, delay_ms, period_ms, action, desc);
 }
 
 ::util::Status TimerDaemon::RequestTimer(bool repeat, uint64 delay_ms,
-                                          uint64 period_ms, Action action,
-                                          DescriptorPtr* desc) {
+                                         uint64 period_ms, Action action,
+                                         DescriptorPtr* desc) {
   absl::WriterMutexLock l(&access_lock_);
 
   VLOG(1) << "Registered timer.";


### PR DESCRIPTION
This prevents errors when `Stop()` is called from multiple locations:

```
I20210503 19:32:56.548328  5679 hal.cc:252] Received signal: Interrupt
I20210503 19:32:56.553966  5624 hal.cc:175] Shutting down HAL...
I20210503 19:32:56.556783  5624 phaldb_service.cc:56] PhalDbService shutdown completed successfully.
I20210503 19:32:56.561234  5624 timer_daemon.cc:109] The timer daemon has been stopped.
E20210503 19:32:56.566639  5624 timer_daemon.cc:103] StratumErrorSpace::ERR_INTERNAL: Failed to join the timer thread.
E20210503 19:32:56.566891  5624 config_monitoring_service.cc:55] Could not stop the timer subsystem.
I20210503 19:32:56.572347  5624 main_bfrt.cc:101] See you later!
```

Current callers:

https://github.com/stratum/stratum/blob/16fa755efd629f14d585c6ce6f6f9a1ac0ecc9af/stratum/hal/lib/common/admin_service.cc#L45

https://github.com/stratum/stratum/blob/16fa755efd629f14d585c6ce6f6f9a1ac0ecc9af/stratum/hal/lib/common/config_monitoring_service.cc#L54