### PR TITLE
Replace `TableData::GetCounterData` with byte and packet specific versions

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -120,9 +120,11 @@ class BfSdeInterface {
     // This hides the IDs for the $COUNTER_SPEC_BYTES fields.
     virtual ::util::Status SetCounterData(uint64 bytes, uint64 packets) = 0;
 
-    // Get the counter values.
-    virtual ::util::Status GetCounterData(uint64* bytes,
-                                          uint64* packets) const = 0;
+    // Get the byte counter value.
+    virtual ::util::Status GetByteCounter(uint64* bytes) const = 0;
+
+    // Get the packet counter value.
+    virtual ::util::Status GetPacketCounter(uint64* packets) const = 0;
 
     // Get the action ID.
     virtual ::util::Status GetActionId(int* action_id) const = 0;

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -57,8 +57,8 @@ class TableDataMock : public BfSdeInterface::TableDataInterface {
   MOCK_CONST_METHOD1(GetSelectorGroupId,
                      ::util::Status(uint64* selector_group_id));
   MOCK_METHOD2(SetCounterData, ::util::Status(uint64 bytes, uint64 packets));
-  MOCK_CONST_METHOD2(GetCounterData,
-                     ::util::Status(uint64* bytes, uint64* packets));
+  MOCK_CONST_METHOD1(GetByteCounter, ::util::Status(uint64* bytes));
+  MOCK_CONST_METHOD1(GetPacketCounter, ::util::Status(uint64* packets));
   MOCK_CONST_METHOD1(GetActionId, ::util::Status(int* action_id));
   MOCK_METHOD1(Reset, ::util::Status(int action_id));
 };

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -874,44 +874,48 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   return ::util::OkStatus();
 }
 
-::util::Status TableData::GetCounterData(uint64* bytes, uint64* packets) const {
+::util::Status TableData::GetByteCounter(uint64* bytes) const {
   CHECK_RETURN_IF_FALSE(bytes);
-  CHECK_RETURN_IF_FALSE(packets);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(table_data_->getParent(&table));
-
   bf_rt_id_t action_id = 0;
   if (table->actionIdApplicable()) {
     RETURN_IF_BFRT_ERROR(table_data_->actionIdGet(&action_id));
   }
-
   bf_rt_id_t field_id;
-  // Try to read byte counter.
-  bf_status_t bf_status;
   if (action_id) {
-    bf_status =
-        table->dataFieldIdGet("$COUNTER_SPEC_BYTES", action_id, &field_id);
+    RETURN_IF_BFRT_ERROR(
+        table->dataFieldIdGet("$COUNTER_SPEC_BYTES", action_id, &field_id));
   } else {
-    bf_status = table->dataFieldIdGet("$COUNTER_SPEC_BYTES", &field_id);
+    RETURN_IF_BFRT_ERROR(
+        table->dataFieldIdGet("$COUNTER_SPEC_BYTES", &field_id));
   }
-  if (bf_status == BF_SUCCESS) {
-    uint64 counter_val;
-    RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, &counter_val));
-    *bytes = counter_val;
-  }
+  uint64 counter_val;
+  RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, &counter_val));
+  *bytes = counter_val;
 
-  // Try to read packet counter.
+  return ::util::OkStatus();
+}
+
+::util::Status TableData::GetPacketCounter(uint64* packets) const {
+  CHECK_RETURN_IF_FALSE(packets);
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_data_->getParent(&table));
+  bf_rt_id_t action_id = 0;
+  if (table->actionIdApplicable()) {
+    RETURN_IF_BFRT_ERROR(table_data_->actionIdGet(&action_id));
+  }
+  bf_rt_id_t field_id;
   if (action_id) {
-    bf_status =
-        table->dataFieldIdGet("$COUNTER_SPEC_PKTS", action_id, &field_id);
+    RETURN_IF_BFRT_ERROR(
+        table->dataFieldIdGet("$COUNTER_SPEC_PKTS", action_id, &field_id));
   } else {
-    bf_status = table->dataFieldIdGet("$COUNTER_SPEC_PKTS", &field_id);
+    RETURN_IF_BFRT_ERROR(
+        table->dataFieldIdGet("$COUNTER_SPEC_PKTS", &field_id));
   }
-  if (bf_status == BF_SUCCESS) {
-    uint64 counter_val;
-    RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, &counter_val));
-    *packets = counter_val;
-  }
+  uint64 counter_val;
+  RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, &counter_val));
+  *packets = counter_val;
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -76,7 +76,8 @@ class TableData : public BfSdeInterface::TableDataInterface {
   ::util::Status SetSelectorGroupId(uint64 selector_group_id) override;
   ::util::Status GetSelectorGroupId(uint64* selector_group_id) const override;
   ::util::Status SetCounterData(uint64 bytes, uint64 packets) override;
-  ::util::Status GetCounterData(uint64* bytes, uint64* packets) const override;
+  ::util::Status GetByteCounter(uint64* bytes) const override;
+  ::util::Status GetPacketCounter(uint64* packets) const override;
   ::util::Status GetActionId(int* action_id) const override;
   ::util::Status Reset(int action_id) override;
 


### PR DESCRIPTION
This prevents doing the field name lookup for table data which has none or only one of the fields.

Fixes #668 