### PR TITLE
Use `stratum_cc_*` rules in more places

### DIFF
--- a/stratum/glue/gtl/BUILD
+++ b/stratum/glue/gtl/BUILD
@@ -1,10 +1,11 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
+    "stratum_cc_library",
+    "stratum_cc_test",
 )
 
 licenses(["notice"])  # Apache v2
@@ -14,17 +15,17 @@ package(
     default_visibility = STRATUM_INTERNAL,
 )
 
-cc_library(
+stratum_cc_library(
     name = "stl_util",
     hdrs = ["stl_util.h"],
 )
 
-cc_library(
+stratum_cc_library(
     name = "map_util",
     hdrs = ["map_util.h"],
 )
 
-cc_test(
+stratum_cc_test(
     name = "map_util_test",
     size = "small",
     srcs = ["map_util_test.cc"],
@@ -40,12 +41,12 @@ cc_test(
     ],
 )
 
-cc_library(
+stratum_cc_library(
     name = "source_location",
     hdrs = ["source_location.h"],
 )
 
-cc_library(
+stratum_cc_library(
     name = "cleanup",
     hdrs = ["cleanup.h"],
     deps = [
@@ -53,7 +54,7 @@ cc_library(
     ],
 )
 
-cc_test(
+stratum_cc_test(
     name = "cleanup_test",
     srcs = ["cleanup_test.cc"],
     deps = [

--- a/stratum/glue/net_util/BUILD
+++ b/stratum/glue/net_util/BUILD
@@ -2,7 +2,6 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
@@ -97,7 +96,7 @@ stratum_cc_library(
     ],
 )
 
-cc_test(
+stratum_cc_test(
     name = "absl_test",
     srcs = ["absl_test.cc"],
     deps = [

--- a/stratum/glue/status/BUILD
+++ b/stratum/glue/status/BUILD
@@ -2,7 +2,6 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
@@ -70,7 +69,7 @@ stratum_cc_library(
     ],
 )
 
-cc_library(
+stratum_cc_library(
     name = "status_test_util",
     testonly = 1,
     srcs = [

--- a/stratum/lib/BUILD
+++ b/stratum/lib/BUILD
@@ -46,7 +46,7 @@ stratum_cc_test(
     ],
 )
 
-cc_library(
+stratum_cc_library(
     name = "test_main",
     testonly = 1,
     srcs = ["test_main.cc"],

--- a/stratum/lib/channel/BUILD
+++ b/stratum/lib/channel/BUILD
@@ -52,7 +52,7 @@ stratum_cc_library(
     ],
 )
 
-cc_library(
+stratum_cc_library(
     name = "test_main",
     testonly = 1,
     srcs = ["test_main.cc"],

--- a/stratum/lib/libcproxy/BUILD
+++ b/stratum/lib/libcproxy/BUILD
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
@@ -44,7 +43,7 @@ stratum_cc_library(
 #     ],
 # )
 
-cc_library(
+stratum_cc_library(
     name = "libcwrapper",
     srcs = [
         "libcwrapper.cc",

--- a/stratum/lib/security/BUILD
+++ b/stratum/lib/security/BUILD
@@ -2,7 +2,6 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//bazel:rules.bzl",
     "HOST_ARCHES",
@@ -147,7 +146,7 @@ stratum_cc_library(
     ],
 )
 
-cc_library(
+stratum_cc_library(
     name = "test_main",
     testonly = 1,
     srcs = ["test_main.cc"],

--- a/stratum/public/lib/BUILD
+++ b/stratum/public/lib/BUILD
@@ -2,11 +2,11 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
+    "stratum_cc_test",
 )
 
 licenses(["notice"])  # Apache v2
@@ -31,7 +31,7 @@ stratum_cc_library(
     ],
 )
 
-cc_library(
+stratum_cc_library(
     name = "test_main",
     testonly = 1,
     srcs = ["test_main.cc"],
@@ -41,7 +41,7 @@ cc_library(
     ],
 )
 
-cc_test(
+stratum_cc_test(
     name = "error_test",
     srcs = ["error_test.cc"],
     deps = [


### PR DESCRIPTION
This ensures that all targets use our desired configuration, like stricter compiler flags.