### PR TITLE
Add `ByteStringToP4RuntimeByteString` function

### DIFF
--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -8,6 +8,8 @@
 
 #include <arpa/inet.h>
 
+#include <algorithm>
+
 #include "absl/strings/str_format.h"
 #include "absl/strings/substitute.h"
 #include "google/rpc/code.pb.h"
@@ -107,6 +109,12 @@ std::string P4RuntimeByteStringToPaddedByteString(std::string byte_string,
   DCHECK_EQ(num_bytes, byte_string.size());
 
   return byte_string;
+}
+
+std::string ByteStringToP4RuntimeByteString(std::string bytes) {
+  // Remove leading zeros.
+  bytes.erase(0, std::min(bytes.find_first_not_of('\x00'), bytes.size() - 1));
+  return bytes;
 }
 
 std::string P4RuntimeGrpcStatusToString(const ::grpc::Status& status) {

--- a/stratum/hal/lib/p4/utils.h
+++ b/stratum/hal/lib/p4/utils.h
@@ -49,6 +49,9 @@ std::string Uint32ToByteStream(uint32 val);
 std::string P4RuntimeByteStringToPaddedByteString(std::string byte_string,
                                                   size_t num_bytes);
 
+// Converts a byte string to a canonical P4Runtime byte string.
+std::string ByteStringToP4RuntimeByteString(std::string bytes);
+
 // Helper to convert a gRPC status with error details to a string. Assumes
 // ::grpc::Status includes a binary error detail which is encoding a serialized
 // version of ::google::rpc::Status proto in which the details are captured

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -77,6 +77,18 @@ TEST(ByteStringTest, P4RuntimeByteStringToPaddedByteStringCorrect) {
             P4RuntimeByteStringToPaddedByteString("\xab", 0));
 }
 
+TEST(ByteStringTest, ByteStringToP4RuntimeByteStringCorrect) {
+  EXPECT_EQ(std::string("\xab", 1),
+            ByteStringToP4RuntimeByteString(std::string("\x00\xab", 2)));
+  EXPECT_EQ(std::string("\x00", 1),
+            ByteStringToP4RuntimeByteString(std::string("\x00", 1)));
+  EXPECT_EQ(std::string("\xab", 1),
+            ByteStringToP4RuntimeByteString(std::string("\xab", 1)));
+  EXPECT_EQ("", ByteStringToP4RuntimeByteString(""));
+  EXPECT_EQ(std::string("\xab", 1), ByteStringToP4RuntimeByteString(std::string(
+                                        "\x00\x00\x00\x00\xab", 5)));
+}
+
 // This test fixture provides a common P4PipelineConfig for these tests.
 class TableMapValueTest : public testing::Test {
  protected:


### PR DESCRIPTION
It will be used in later changes to create canonical P4Runtime byte strings.