### PR TITLE
Add option to make Stratum-bfrt return canonical bytestrings

### DIFF
--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -472,6 +472,16 @@ To exit the BF CLI or the BF Shell, use `exit`. Note that using `Ctrl+C` will
 end the BF Shell without closing the telnet session. To exit the telnet session,
 press `Ctrl` and `]` to escape from the session and type `quit` to exit telnet.
 
+### P4Runtime canonical byte strings
+
+P4Runtime defines a [canonical byte string representation](https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html#sec-bytestrings)
+for binary data in proto messages such as TableEntries and PacketIn/Outs. In
+short, it requires that the binary strings must not contain redundant bytes,
+ i.e., `\x00\xab` vs `\xab`. For Stratum-bfrt the
+`-incompatible_enable_bfrt_legacy_bytestring_responses` flag toggles this
+behavior. **This flag will be removed in a future release and canonical byte
+strings will be the default.**
+
 -----
 
 ## Troubleshooting

--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -412,6 +412,7 @@ stratum_cc_library(
         "//stratum/hal/lib/common:common_cc_proto",
         "//stratum/hal/lib/common:constants",
         "//stratum/hal/lib/common:writer_interface",
+        "//stratum/hal/lib/p4:utils",
         "//stratum/lib:utils",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -11,6 +11,11 @@
 #include "gmock/gmock.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 
+DEFINE_bool(incompatible_enable_bfrt_legacy_bytestring_responses, true,
+            "Enables the legacy padded byte string format in P4Runtime "
+            "responses for Stratum-bfrt. The strings are left unchanged from "
+            "the underlying SDE.");
+
 namespace stratum {
 namespace hal {
 namespace barefoot {

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -44,6 +44,10 @@ int switch_pci_sysfs_str_get(char* name, size_t name_size);
 
 DEFINE_string(bfrt_sde_config_dir, "/var/run/stratum/bfrt_config",
               "The dir used by the SDE to load the device configuration.");
+DEFINE_bool(incompatible_enable_bfrt_legacy_bytestring_responses, true,
+            "Enables the legacy padded byte string format in P4Runtime "
+            "responses for Stratum-bfrt. The strings are left unchanged from "
+            "the underlying SDE.");
 
 namespace stratum {
 namespace hal {
@@ -631,6 +635,9 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
+  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+    *value = ByteStringToP4RuntimeByteString(*value);
+  }
 
   return ::util::OkStatus();
 }
@@ -648,6 +655,10 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValueandMask(
       id, value->size(), reinterpret_cast<uint8*>(gtl::string_as_array(value)),
       reinterpret_cast<uint8*>(gtl::string_as_array(mask))));
+  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+    *value = ByteStringToP4RuntimeByteString(*value);
+    *mask = ByteStringToP4RuntimeByteString(*mask);
+  }
 
   return ::util::OkStatus();
 }
@@ -663,6 +674,9 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValueLpm(
       id, prefix->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(prefix)), prefix_length));
+  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+    *prefix = ByteStringToP4RuntimeByteString(*prefix);
+  }
 
   return ::util::OkStatus();
 }
@@ -680,6 +694,10 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValueRange(
       id, low->size(), reinterpret_cast<uint8*>(gtl::string_as_array(low)),
       reinterpret_cast<uint8*>(gtl::string_as_array(high))));
+  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+    *low = ByteStringToP4RuntimeByteString(*low);
+    *high = ByteStringToP4RuntimeByteString(*high);
+  }
 
   return ::util::OkStatus();
 }
@@ -746,6 +764,9 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   RETURN_IF_BFRT_ERROR(table_data_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
+  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+    *value = ByteStringToP4RuntimeByteString(*value);
+  }
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -15,7 +15,10 @@
 #include "stratum/glue/gtl/cleanup.h"
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/hal/lib/common/constants.h"
+#include "stratum/hal/lib/p4/utils.h"
 #include "stratum/lib/utils.h"
+
+DECLARE_bool(incompatible_enable_bfrt_legacy_bytestring_responses);
 
 namespace stratum {
 namespace hal {
@@ -260,6 +263,10 @@ class BitBuffer {
     auto metadata = packet->add_metadata();
     metadata->set_metadata_id(p.first);
     metadata->set_value(bit_buf.PopField(p.second));
+    if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+      *metadata->mutable_value() =
+          ByteStringToP4RuntimeByteString(metadata->value());
+    }
     VLOG(1) << "Encoded PacketIn metadata field with id " << p.first
             << " bitwidth " << p.second << " value 0x"
             << StringToHex(metadata->value());


### PR DESCRIPTION
This PR adds a new option `incompatible_enable_bfrt_legacy_bytestring_responses` to make Stratum-bfrt return canonical P4Runtime byte strings. For now the flag defaults to `true`, which means that the current behavior remains the same, that is, padded strings. In the future we will flip and eventually remove the legacy behavior.

TODO:

- [x] some basic testing