### PR TITLE
add SetSfpFrequency function to onlp_wrapper

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -120,6 +120,12 @@ BFChassisManager::~BFChassisManager() = default;
     config->admin_state = ADMIN_STATE_ENABLED;
   }
 
+  if (config_params.frequency() != 0) {
+    RETURN_IF_ERROR(
+        onlp_interface_->SetSfpFrequency(unit, sdk_port_id, config_params.frequency()));
+  }
+  config->frequency = config_params.frequency();
+
   RETURN_IF_ERROR(
       bf_sde_interface_->EnablePortShaping(unit, sdk_port_id, TRI_STATE_FALSE));
 

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -276,6 +276,8 @@ message PortConfigParams {
   MacAddress mac_address = 7;
   // The configured loopback state for this port.
   LoopbackState loopback_mode = 8;
+  // Tunable SFP+'s frequency in Hz
+  int64 frequency = 9;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.cc
@@ -7,6 +7,7 @@
 #include <dlfcn.h>
 
 #include <string>
+#include <stdint.h>
 
 #include "absl/memory/memory.h"
 #include "absl/strings/strip.h"
@@ -127,6 +128,9 @@ template <typename T>
   LOAD_SYMBOL(onlp_led_mode_set);
   LOAD_SYMBOL(onlp_led_char_set);
   LOAD_SYMBOL(onlp_psu_info_get);
+  LOAD_SYMBOL(onlp_i2c_mux_select);
+  LOAD_SYMBOL(onlp_i2c_write);
+  LOAD_SYMBOL(onlp_i2c_readb);
 #undef LOAD_SYMBOL
 
   CHECK_RETURN_IF_FALSE(ONLP_SUCCESS(onlp_functions_.onlp_sw_init(nullptr)))
@@ -154,6 +158,227 @@ template <typename T>
         << "Failed to get SFP info for OID " << oid << ".";
   }
   return SfpInfo(sfp_info);
+}
+
+::util::Status OnlpWrapper::SetSfpFrequency(OnlpOid oid, int port_number, int frequency) const {
+  // Default value of the SFP info
+  onlp_sfp_info_t sfp_info = {{oid}};
+  // Retreive spf_info to check the type
+  CHECK_RETURN_IF_FALSE(
+      ONLP_SUCCESS(onlp_functions_.onlp_sfp_info_get(oid, &sfp_info)))
+      << "Failed to get SFP info for OID " << oid << ".";
+  // Check the transceiver's type. This code only allows you to set the frequency of an SFP/SFP+.
+  if (sfp_info.type != ONLP_SFP_TYPE_SFP) {
+      fprintf(stderr, "Error: This is not an SFP\n");
+      exit(0);
+  }
+  // Set the port where the SFP is plugged in
+  int channel_cpu; // cpu channel number from hardware specification
+  int channel_mb; // mb channel number from hardware specification
+  uint8_t res;
+  onlp_i2c_mux_device_t cpu_mux;
+  onlp_i2c_mux_device_t mb_mux;
+  cpu_mux.name = "CPU MUX";
+  cpu_mux.bus = 0;
+  cpu_mux.devaddr = 0x70; //CPU MUX address from hardware specification
+  cpu_mux.driver = onlp_i2c_mux_driver_pca9548; //Driver for BF6064X switch
+  mb_mux.name = "MB MUX";
+  mb_mux.bus = 0;
+
+  mb_mux.driver = onlp_i2c_mux_driver_pca9548; //For BF6064X switch
+  if (port_number > 0 && port_number <= 32) {
+      channel_cpu = 2;
+  } else if (port_number >= 33 && port_number <= 64) {
+      channel_cpu = 6;
+  } else {
+      fprintf(stderr, "Error: Ports limit exceeded\n"); //Port number has to be between 1 and 64 for BF6064X switch
+      exit(0);
+  }
+  CHECK_RETURN_IF_FALSE(
+      ONLP_SUCCESS(onlp_functions_.onlp_i2c_mux_select(cpu_mux, channel_cpu)))
+      << "Failed to set CPU MUX.";
+
+  switch (port_number) {
+  case 1 || 33:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 0;
+      break;
+  case 2 || 34:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 1;
+      break;
+  case 3 || 35:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 2;
+      break;
+  case 4 || 36:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 3;
+      break;
+  case 5 || 37:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 4;
+      break;
+  case 6 || 38:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 5;
+      break;
+  case 7 || 39:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 6;
+      break;
+  case 8 || 40:
+      mb_mux.devaddr = 0x74;
+      channel_mb = 7;
+      break;
+  case 14 || 47:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 0;
+      break;
+  case 13 || 48:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 1;
+      break;
+  case 16 || 41:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 2;
+      break;
+  case 15 || 42:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 3;
+      break;
+  case 10 || 43:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 4;
+      break;
+  case 9 || 44:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 5;
+      break;
+  case 12 || 45:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 6;
+      break;
+  case 11 || 46:
+      mb_mux.devaddr = 0x75;
+      channel_mb = 7;
+      break;
+  case 17 || 55:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 0;
+      break;
+  case 18 || 56:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 1;
+      break;
+  case 26 || 53:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 2;
+      break;
+  case 25 || 54:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 3;
+      break;
+  case 22 || 58:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 4;
+      break;
+  case 21 || 57:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 5;
+      break;
+  case 24 || 49:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 6;
+      break;
+  case 23 || 50:
+      mb_mux.devaddr = 0x76;
+      channel_mb = 7;
+      break;
+  case 29 || 59:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 0;
+      break;
+  case 30 || 60:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 1;
+      break;
+  case 27 || 61:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 2;
+      break;
+  case 28 || 62:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 3;
+      break;
+  case 32 || 63:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 4;
+      break;
+  case 31 || 64:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 5;
+      break;
+  case 19 || 52:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 6;
+      break;
+  default: //or case 20 || 51:
+      mb_mux.devaddr = 0x77;
+      channel_mb = 7;
+      break;
+  }
+  CHECK_RETURN_IF_FALSE(
+       ONLP_SUCCESS(onlp_functions_.onlp_i2c_mux_select(mb_mux, channel_mb)))
+       << "Failed to set MB MUX.";
+  // Change the page on slave 0x51 to access page 2
+  CHECK_RETURN_IF_FALSE(
+       ONLP_SUCCESS(onlp_functions_.onlp_i2c_write(0,0x51,0x7f,1,0x2,0)))
+       << "Failed to write the page.";
+  // Check if page has been changed. If not, then the SFP is not tunable
+  res = onlp_functions_.onlp_i2c_readb(0, 0x51, 0x7f);
+  if (res != 2) {
+      fprintf(stderr, "Error: Can not change the page, the SFP+ is not tunable.\n");
+      exit(0);
+  }
+  // Retrieve Grid spacing value
+  uint16_t grid_spacing_hexa; // Need 2 bytes.
+  int grid_spacing;
+  grid_spacing_hexa = ((onlp_functions_.onlp_i2c_readb(0,0x51,0x8C) << 8) | onlp_functions_.onlp_i2c_readb(0,0x51,0x8D));
+  grid_spacing = grid_spacing_hexa * 0.1 * 1000000000; //value in Hz
+
+  // Retrieve First frequency
+  uint16_t first_frequency_THz;
+  uint16_t first_frequency_GHz;
+  int first_frequency;
+  first_frequency_THz = ((onlp_functions_.onlp_i2c_readb(0,0x51,0x84) << 8) | onlp_functions_.onlp_i2c_readb(0,0x51,0x85));
+  first_frequency_GHz = ((onlp_functions_.onlp_i2c_readb(0,0x51,0x86) << 8) | onlp_functions_.onlp_i2c_readb(0,0x51,0x87));
+  first_frequency = (first_frequency_THz * 1000000000000) + (first_frequency_GHz * 0.1 * 1000000000); //value in Hz
+
+  // Desired channel number
+  uint8_t channel_number;
+  channel_number = 1 + ((frequency - first_frequency)/grid_spacing); // Formula from SFF-8690 document
+
+  // Change the channel number of the SFP
+  CHECK_RETURN_IF_FALSE(
+       ONLP_SUCCESS(onlp_functions_.onlp_i2c_write(0,0x51,0x91,1,channel_number,0)))
+       << "Failed to set CPU MUX.";
+
+  // Check if it has been done correctly
+  if (onlp_functions_.onlp_i2c_readb(0,0x51,0x91) != channel_number) {
+      fprintf(stderr, "Error: Can not write the desired frequency.\n");
+      exit(0);
+  }
+
+  // Put the page register back to 1
+  CHECK_RETURN_IF_FALSE(
+       ONLP_SUCCESS(onlp_functions_.onlp_i2c_write(0,0x51,0x7f,1,0x01,0)))
+       << "Failed to set CPU MUX.";
+  // Remove port selection from MUXs
+  CHECK_RETURN_IF_FALSE(
+       ONLP_SUCCESS(onlp_functions_.onlp_i2c_mux_select(mb_mux.devaddr, -1))) //put 0x00 in mb_mux.devaddr i.e channel number = 0
+       << "Failed to set CPU MUX.";
+  return ::util::OkStatus();
 }
 
 ::util::StatusOr<FanInfo> OnlpWrapper::GetFanInfo(OnlpOid oid) const {

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.h
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.h
@@ -13,6 +13,7 @@ extern "C" {
 #include <onlp/psu.h>
 #include <onlp/sfp.h>
 #include <onlp/thermal.h>
+#include <onlp/i2c.h>
 }
 
 #include <bitset>
@@ -147,6 +148,8 @@ class OnlpInterface {
 
   // Given a OID object id, returns SFP info or failure.
   virtual ::util::StatusOr<SfpInfo> GetSfpInfo(OnlpOid oid) const = 0;
+  // Given a OID object id, sets SFP frequency.
+  virtual ::util::Status SetSfpFrequency(OnlpOid oid, int port_number, int frequency) const = 0;
 
   // Given a OID object id, returns FAN info or failure.
   virtual ::util::StatusOr<FanInfo> GetFanInfo(OnlpOid oid) const = 0;
@@ -211,6 +214,7 @@ class OnlpWrapper : public OnlpInterface {
   ::util::StatusOr<OidInfo> GetOidInfo(OnlpOid oid) const override;
   ::util::StatusOr<PsuInfo> GetPsuInfo(OnlpOid oid) const override;
   ::util::StatusOr<SfpInfo> GetSfpInfo(OnlpOid oid) const override;
+  ::util::Status SetSfpFrequency(OnlpOid oid, int port_number, int frequency) const override;
   ::util::StatusOr<FanInfo> GetFanInfo(OnlpOid oid) const override;
   ::util::Status SetFanPercent(OnlpOid oid, int value) const override;
   ::util::Status SetFanRpm(OnlpOid oid, int val) const override;
@@ -249,6 +253,9 @@ class OnlpWrapper : public OnlpInterface {
     int (*onlp_led_mode_set)(onlp_oid_t oid, onlp_led_mode_t mode);
     int (*onlp_led_char_set)(onlp_oid_t oid, char c);
     int (*onlp_psu_info_get)(onlp_oid_t oid, onlp_psu_info_t* rv);
+    int (*onlp_i2c_mux_select)((onlp_i2c_mux_device_t* dev, int channel);
+    int (*onlp_i2c_write)(int bus, uint8_t addr, uint8_t offset, int size, uint8_t* data, uint32_t flags);
+    int (*onlp_i2c_readb)(int bus, uint8_t addr, uint8_t offset, uint32_t flags);
     OnlpFunctions()
         : onlp_sw_init(nullptr),
           onlp_sw_denit(nullptr),
@@ -268,7 +275,10 @@ class OnlpWrapper : public OnlpInterface {
           onlp_led_info_get(nullptr),
           onlp_led_mode_set(nullptr),
           onlp_led_char_set(nullptr),
-          onlp_psu_info_get(nullptr) {}
+          onlp_psu_info_get(nullptr),
+          onlp_i2c_mux_select(nullptr),
+          onlp_i2c_write(nullptr),
+          onlp_i2c_readb(nullptr) {}
   };
   // Private constructor. Use CreateInstance instead.
   OnlpWrapper();

--- a/stratum/hal/lib/phal/onlp/onlp_wrapper_mock.h
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper_mock.h
@@ -22,6 +22,7 @@ class OnlpWrapperMock : public OnlpInterface {
  public:
   MOCK_CONST_METHOD1(GetOidInfo, ::util::StatusOr<OidInfo>(OnlpOid oid));
   MOCK_CONST_METHOD1(GetSfpInfo, ::util::StatusOr<SfpInfo>(OnlpOid oid));
+  MOCK_CONST_METHOD3(SetSfpFrequency, ::util::Status(OnlpOid oid, int port_number, int frequency));
   MOCK_CONST_METHOD1(GetFanInfo, ::util::StatusOr<FanInfo>(OnlpOid oid));
   MOCK_CONST_METHOD2(SetLedMode, ::util::Status(OnlpOid oid, LedMode mode));
   MOCK_CONST_METHOD2(SetLedCharacter, ::util::Status(OnlpOid oid, char val));


### PR DESCRIPTION
Some comments on the files:

Overall, I've never learnt to write in C++ so it might be some syntax issues.

**onlp_warrper.cc:**
- <stdint.h> is for the uint8_t type
- I'm using GetSfpInfo function because I want to check if the SFP is tunable, and this information is located in sfp_info. However I don't know how to use that function direclty inside SetSfpFrequency so I just copied and pasted the code.
- I check the TYPE, and exit if it's not an SFP/SFP+. This should work but in case it doesn't, I know which register is responsible for the TYPE so I can access it using onlp_i2c_readb as well.
- Then a lot of lines of code for the ports allocation. All those functions are defined in the [APSN-ONL2 repository](https://github.com/NetworkGradeLinux/APSN-ONL2/blob/main/packages/base/any/onlp/src/onlplib/module/src/i2c.c), including the driver definition. The MUX selection is mandatory if we want to access the register with onlp_i2c_* functions. Therefore, I added an input int port_number which is the port number on the Tofino switch.
- I guess the switch (port-number) function can be located somewhere else.
- onlp_i2c_write function does not always give an error message, even if you can't write the value, that's why I put some check just after them to see if it has been written correclty.
- Grid spacing, first frequency Thz and first frequency Ghz are written on 2 registers (bytes) so I retreive the uint16_t value and convert it into Hz int value.
- The value "0.1" in first_frequency is the unit given by SFF-8690 document.
- in onlp_i2c_write, the desired value can be in hex or int format. Both are working.
- At the end, I go back to initial values so that GetSfpInfo will still be the correct values from page 1 and so that we can access other SFPs without issue.

**onlp_wrapper.h**
- not sure at all of what I added.

**onlp_wrapper.mock.h**
- Do I need to add something here? I put METHOD3 because I have 3 variables but I have not idea if it is correct.

In order to expose the phal API to the switch:
Which file should I modify? I did modify bf_chassis_manager.cc as the code is for Barefoot tofino switches but I also remember that you were taking about onlp_phal.cc or something.

**bf_chassis_manager.cc**
- I put onlp_interface_->, knowing that this might not work on this function. I wanted first to put it in onlp_phal.cc but nothing is defined there so I don't know where to call SetSfpFrequency and I don't know the difference between onlp_phal and bf_chassis_manager