### PR TITLE
Use `minloglevel` instead of `stderrthreshold`

### DIFF
--- a/stratum/glue/init_google.h
+++ b/stratum/glue/init_google.h
@@ -22,13 +22,18 @@ using gflags::ParseCommandLineFlags;
 inline void InitGoogle(const char* usage, int* argc, char*** argv,
                        bool remove_flags) {
   // Here we can set Stratum-wide defaults or overrides for library flags.
+  // No logging to files, stderr only.
   CHECK(!::gflags::SetCommandLineOptionWithMode("logtostderr", "true",
                                                 ::gflags::SET_FLAGS_DEFAULT)
              .empty());
   CHECK(!::gflags::SetCommandLineOptionWithMode("colorlogtostderr", "true",
                                                 ::gflags::SET_FLAGS_DEFAULT)
              .empty());
+  // Note: stderrthreshold is only meaningful if logtostderr == false!
   CHECK(!::gflags::SetCommandLineOptionWithMode("stderrthreshold", "0",
+                                                ::gflags::SET_FLAGS_DEFAULT)
+             .empty());
+  CHECK(!::gflags::SetCommandLineOptionWithMode("minloglevel", "0",
                                                 ::gflags::SET_FLAGS_DEFAULT)
              .empty());
   ParseCommandLineFlags(argc, argv, remove_flags);

--- a/stratum/glue/net_util/bits_test.cc
+++ b/stratum/glue/net_util/bits_test.cc
@@ -1210,8 +1210,8 @@ BENCHMARK(BM_CountLeadingZeros32);
 BENCHMARK(BM_CountLeadingZeros64);
 
 int main(int argc, char **argv) {
-  LogToStderr();
   InitGoogle("", &argc, &argv, true);
+  InitStratumLogging();
   RunSpecifiedBenchmarks();
 
   CHECK_LE(max_bytes, kMaxBytes);

--- a/stratum/hal/stub/embedded/main.cc
+++ b/stratum/hal/stub/embedded/main.cc
@@ -700,7 +700,7 @@ class HalServiceClient {
 
 ABSL_CONST_INIT absl::Mutex HalServiceClient::lock_(absl::kConstInit);
 
-int Main(int argc, char** argv) {
+::util::Status Main(int argc, char** argv) {
   InitGoogle(argv[0], &argc, &argv, true);
   InitStratumLogging();
   HalServiceClient client(FLAGS_url);
@@ -724,10 +724,10 @@ int Main(int argc, char** argv) {
   } else if (FLAGS_start_gnmi_subscription_session) {
     client.StartGnmiSubscriptionSession();
   } else {
-    LOG(ERROR) << "Invalid command.";
+    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid command.";
   }
 
-  return 0;
+  return ::util::OkStatus();
 }
 
 }  // namespace stub
@@ -735,6 +735,5 @@ int Main(int argc, char** argv) {
 }  // namespace stratum
 
 int main(int argc, char** argv) {
-  FLAGS_logtostderr = true;
-  return stratum::hal::stub::Main(argc, argv);
+  return stratum::hal::stub::Main(argc, argv).error_code();
 }

--- a/stratum/p4c_backends/common/build_defs.bzl
+++ b/stratum/p4c_backends/common/build_defs.bzl
@@ -72,10 +72,6 @@ def _generate_p4c_stratum_config(ctx):
             "--p4c_annotation_map_files=" + annotation_map_files,
             "--slice_map_file=" + ctx.file.slice_map.path,
             "--target_parser_map_file=" + ctx.file.parser_map.path,
-            "--colorlogtostderr",
-            "--stderrthreshold=1",
-            "--logtostderr",
-            "--v=0",
         ],
         inputs = ([p4_preprocessed_file] + [ctx.file.parser_map] +
                   [ctx.file.slice_map] + ctx.files.annotation_maps),

--- a/stratum/p4c_backends/fpm/p4c_switch_main.cc
+++ b/stratum/p4c_backends/fpm/p4c_switch_main.cc
@@ -34,10 +34,7 @@ using stratum::p4c_backends::SwitchP4cBackend;
 using stratum::p4c_backends::TableMapGenerator;
 using stratum::p4c_backends::TargetInfo;
 
-DECLARE_int32(stderrthreshold);
-
 int main(int argc, char** argv) {
-  FLAGS_stderrthreshold = 1;
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();
   std::unique_ptr<BcmTargetInfo> bcm_target_info(new BcmTargetInfo);
@@ -46,14 +43,14 @@ int main(int argc, char** argv) {
       new BcmTunnelOptimizer);
   std::unique_ptr<AnnotationMapper> annotation_mapper(new AnnotationMapper);
   auto midend_callback = std::function<std::unique_ptr<MidEndInterface>(
-      CompilerOptions* p4c_options)>(&MidEnd::CreateInstance);
+      CompilerOptions * p4c_options)>(&MidEnd::CreateInstance);
   std::unique_ptr<P4cFrontMidReal> p4c_real_fe_me(
       new P4cFrontMidReal(midend_callback));
   std::unique_ptr<TableMapGenerator> table_mapper(new TableMapGenerator);
   std::unique_ptr<BackendExtensionInterface> extension(new SwitchP4cBackend(
       table_mapper.get(), p4c_real_fe_me.get(), annotation_mapper.get(),
       bcm_tunnel_optimizer.get()));
-  std::vector<BackendExtensionInterface*> extensions {extension.get()};
+  std::vector<BackendExtensionInterface*> extensions{extension.get()};
   std::unique_ptr<BackendPassManager> backend(
       new BackendPassManager(p4c_real_fe_me.get(), extensions));
   backend->Compile();

--- a/tools/mininet/stratum.py
+++ b/tools/mininet/stratum.py
@@ -213,7 +213,6 @@ nodes {{
             '-local_stratum_url=localhost:%d' % pickUnusedPort(),
             '-max_num_controllers_per_node=%d' % MAX_CONTROLLERS_PER_NODE,
             '-write_req_log_file=%s/write-reqs.txt' % self.tmpDir,
-            '-logtostderr=true',
             '-bmv2_log_level=%s' % self.loglevel,
         ]
 

--- a/tools/mininet/tofino-model.py
+++ b/tools/mininet/tofino-model.py
@@ -54,8 +54,8 @@ class StratumTofinoModel(Switch):
     mininet_exception = multiprocessing.Value('i', 0)
     nextNodeId = 0
 
-    def __init__(self, name, inNamespace = True, 
-                 sdeInstall="/root/sde/install", 
+    def __init__(self, name, inNamespace = True,
+                 sdeInstall="/root/sde/install",
                  bfSwitchdConfig="/etc/stratum/tofino_skip_p4.conf", **kwargs):
         Switch.__init__(self, name, inNamespace = True, **kwargs)
         self.sdeInstall = sdeInstall
@@ -116,8 +116,7 @@ class StratumTofinoModel(Switch):
                 '-bf_sim',
                 '-enable_onlp=false',
                 '-bf_switchd_background=false',
-                '-v=6',
-                '-alsologtostderr=true',
+                '-v=2',
                 f'-bf_sde_install={self.sdeInstall}',
                 f'-bf_switchd_cfg={self.bfSwitchdConfig}',
             ]


### PR DESCRIPTION
`stderrthreshold` only works when logging to files is enabled (`logtostderr == false`). We disable logging to files by default. This change fixes this throughout the code base.