### PR TITLE
Add gNMI path to change Stratum log level

### DIFF
--- a/stratum/docs/gnmi/supported-paths.md
+++ b/stratum/docs/gnmi/supported-paths.md
@@ -368,3 +368,17 @@ Supported gNMI paths
  - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
+
+### System
+
+`/system/logging/console/config/severity`
+
+ - Subscription mode: ONCE, POLL, SAMPLE
+ - Get type: ALL, STATE
+ - Set mode: REPLACE, UPDATE
+
+`/system/logging/console/state/severity`
+
+ - Subscription mode: ONCE, POLL, SAMPLE
+ - Get type: ALL, STATE
+ - Set mode: Not valid

--- a/stratum/glue/logging.cc
+++ b/stratum/glue/logging.cc
@@ -59,6 +59,28 @@ void InitStratumLogging() {
   }
 }
 
+LoggingConfig GetCurrentLogLevel() {
+  std::string minloglevel = "UNKNOWN";
+  ::gflags::GetCommandLineOption("minloglevel", &minloglevel);
+  std::string verbosity = "UNKNOWN";
+  ::gflags::GetCommandLineOption("v", &verbosity);
+
+  return std::make_pair(minloglevel, verbosity);
+}
+
+bool SetLogLevel(const LoggingConfig& logging_config) {
+  // stderrthreshold is set in addition to minloglevel in case file logging is
+  // enabled by the user.
+  return !::gflags::SetCommandLineOption("stderrthreshold",
+                                         logging_config.first.c_str())
+              .empty() &&
+         !::gflags::SetCommandLineOption("minloglevel",
+                                         logging_config.first.c_str())
+              .empty() &&
+         !::gflags::SetCommandLineOption("v", logging_config.second.c_str())
+              .empty();
+}
+
 }  // namespace stratum
 
 // ostream overload for std::nulptr_t for C++11

--- a/stratum/glue/logging.h
+++ b/stratum/glue/logging.h
@@ -5,6 +5,9 @@
 #ifndef STRATUM_GLUE_LOGGING_H_
 #define STRATUM_GLUE_LOGGING_H_
 
+#include <string>
+#include <utility>
+
 #include "gflags/gflags.h"
 
 // P4c lib/log.h already defines the ERROR macro.
@@ -34,6 +37,15 @@ namespace stratum {
 // Initializes all Stratum specific changes to logging. This should be called
 // after InitGoogle by every Stratum binary.
 void InitStratumLogging();
+
+// An alias for the pair of (glog_severity, glog_verbosity).
+using LoggingConfig = std::pair<std::string, std::string>;
+
+// Returns the current glog logging configuration.
+LoggingConfig GetCurrentLogLevel();
+
+// Sets a new glog log level for the process. Returns true on success.
+bool SetLogLevel(const LoggingConfig& logging_config);
 }  // namespace stratum
 
 // ostream overload for std::nulptr_t for C++11

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -741,6 +741,7 @@ stratum_cc_library(
         "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
+        "//stratum/glue/status:statusor",
         "//stratum/public/lib:error",
     ],
 )
@@ -756,6 +757,7 @@ stratum_cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
         "//stratum/lib:constants",
+        "//stratum/glue/status:status_test_util",
     ],
 )
 

--- a/stratum/hal/lib/common/gnmi_events.h
+++ b/stratum/hal/lib/common/gnmi_events.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
@@ -432,6 +433,24 @@ class OpticalOutputPowerChangedEvent
 
  private:
   const OpticalTransceiverInfo::Power new_output_power_;
+};
+
+// Console log severity has been changed event.
+class ConsoleLogSeverityChangedEvent
+    : public GnmiEventProcess<ConsoleLogSeverityChangedEvent> {
+ public:
+  explicit ConsoleLogSeverityChangedEvent(const std::string& new_severity,
+                                          const std::string& new_verbosity)
+      : new_glog_severity_(new_severity), new_glog_verbosity_(new_verbosity) {}
+  ~ConsoleLogSeverityChangedEvent() override {}
+
+  const LoggingConfig GetState() const {
+    return LoggingConfig(new_glog_severity_, new_glog_verbosity_);
+  }
+
+ private:
+  const std::string new_glog_severity_;
+  const std::string new_glog_verbosity_;
 };
 
 // Configuration Has Been Pushed event.

--- a/stratum/hal/lib/common/gnmi_publisher_test.cc
+++ b/stratum/hal/lib/common/gnmi_publisher_test.cc
@@ -480,6 +480,15 @@ INSTANTIATE_TEST_SUITE_P(
                                      "device1.domain.net.com:ce-1/1")("output")(
             "queues")("queue", "BE1")("state")("dropped-pkts")()));
 
+// Due to Google's restriction on the size of a function frame, this automation
+// had to be split into separate calls.
+INSTANTIATE_TEST_SUITE_P(
+    SubscriptionSupportedSystemPathsTestWithPath,
+    SubscriptionSupportedPathsTest,
+    ::testing::Values(
+        GetPath("system")("logging")("console")("config")("severity")(),
+        GetPath("system")("logging")("console")("state")("severity")()));
+
 // All paths that support OnReplace only be tested by this parametrized
 // test that takes the path as a parameter.
 class ReplaceSupportedPathsTest

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -430,5 +430,53 @@ uint64 ConvertHzToMHz(const uint64& val) { return val / 1000000; }
 
 uint64 ConvertMHzToHz(const uint64& val) { return val * 1000000; }
 
+::util::Status ConvertStringToLogSeverity(const std::string& severity_string,
+                                          LoggingConfig* logging_config) {
+  if (severity_string == "CRITICAL") {
+    logging_config->first = "3";
+    logging_config->second = "0";
+  } else if (severity_string == "ERROR") {
+    logging_config->first = "2";
+    logging_config->second = "0";
+  } else if (severity_string == "WARNING") {
+    logging_config->first = "1";
+    logging_config->second = "0";
+  } else if (severity_string == "NOTICE") {
+    logging_config->first = "0";
+    logging_config->second = "0";
+  } else if (severity_string == "INFORMATIONAL") {
+    logging_config->first = "0";
+    logging_config->second = "1";
+  } else if (severity_string == "DEBUG") {
+    logging_config->first = "0";
+    logging_config->second = "2";
+  } else {
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Invalid severity string \"" << severity_string << "\".";
+  }
+
+  return ::util::OkStatus();
+}
+
+std::string ConvertLogSeverityToString(const LoggingConfig& logging_config) {
+  const std::string& glog_severity = logging_config.first;
+  const std::string& glog_verbosity = logging_config.second;
+  if (glog_severity == "0" && glog_verbosity >= "2") {
+    return "DEBUG";
+  } else if (glog_severity == "0" && glog_verbosity == "1") {
+    return "INFORMATIONAL";
+  } else if (glog_severity == "0") {
+    return "NOTICE";
+  } else if (glog_severity == "1") {
+    return "WARNING";
+  } else if (glog_severity == "2") {
+    return "ERROR";
+  } else if (glog_severity == "3") {
+    return "CRITICAL";
+  } else {
+    return "UNKNOWN";
+  }
+}
+
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -242,6 +242,13 @@ uint64 ConvertHzToMHz(const uint64& val);
 // A helper method that converts frequency from MHz to Hz.
 uint64 ConvertMHzToHz(const uint64& val);
 
+// A helper method that converts glog log level to Openconfig severity string.
+std::string ConvertLogSeverityToString(const LoggingConfig& logging_config);
+
+// A helper method that converts Openconfig severity to glog log level.
+::util::Status ConvertStringToLogSeverity(const std::string& severity_string,
+                                          LoggingConfig* logging_config);
+
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/hal/lib/common/utils_test.cc
+++ b/stratum/hal/lib/common/utils_test.cc
@@ -12,6 +12,7 @@
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 #include "stratum/glue/status/canonical_errors.h"
+#include "stratum/glue/status/status_test_util.h"
 #include "stratum/lib/constants.h"
 
 namespace stratum {
@@ -462,6 +463,43 @@ TEST(DecimalUtilTest, TestFromDecimal64ToDouble) {
 
   DecimalToDoubleTest(0ll, 0, 0);
   DecimalToDoubleTest(-0ll, -0, 0);
+}
+
+TEST(LogSeverityUtilTest, TestFromLogSeverityToString) {
+  EXPECT_EQ("DEBUG", ConvertLogSeverityToString(LoggingConfig("0", "2")));
+  EXPECT_EQ("INFORMATIONAL",
+            ConvertLogSeverityToString(LoggingConfig("0", "1")));
+  EXPECT_EQ("NOTICE", ConvertLogSeverityToString(LoggingConfig("0", "0")));
+  EXPECT_EQ("WARNING", ConvertLogSeverityToString(LoggingConfig("1", "0")));
+  EXPECT_EQ("ERROR", ConvertLogSeverityToString(LoggingConfig("2", "0")));
+  EXPECT_EQ("CRITICAL", ConvertLogSeverityToString(LoggingConfig("3", "0")));
+}
+
+TEST(LogSeverityUtilTest, TestFromStringToLogSeverity) {
+  LoggingConfig logging_config;
+  ASSERT_OK(ConvertStringToLogSeverity("DEBUG", &logging_config));
+  EXPECT_EQ("0", logging_config.first);
+  EXPECT_EQ("2", logging_config.second);
+
+  ASSERT_OK(ConvertStringToLogSeverity("INFORMATIONAL", &logging_config));
+  EXPECT_EQ("0", logging_config.first);
+  EXPECT_EQ("1", logging_config.second);
+
+  ASSERT_OK(ConvertStringToLogSeverity("NOTICE", &logging_config));
+  EXPECT_EQ("0", logging_config.first);
+  EXPECT_EQ("0", logging_config.second);
+
+  ASSERT_OK(ConvertStringToLogSeverity("WARNING", &logging_config));
+  EXPECT_EQ("1", logging_config.first);
+  EXPECT_EQ("0", logging_config.second);
+
+  ASSERT_OK(ConvertStringToLogSeverity("ERROR", &logging_config));
+  EXPECT_EQ("2", logging_config.first);
+  EXPECT_EQ("0", logging_config.second);
+
+  ASSERT_OK(ConvertStringToLogSeverity("CRITICAL", &logging_config));
+  EXPECT_EQ("3", logging_config.first);
+  EXPECT_EQ("0", logging_config.second);
 }
 
 }  // namespace hal

--- a/stratum/hal/lib/common/yang_parse_tree.cc
+++ b/stratum/hal/lib/common/yang_parse_tree.cc
@@ -174,6 +174,8 @@ void YangParseTree::ProcessPushedConfig(
   }
   // Add all chassis-related gNMI paths.
   AddSubtreeChassis(change.new_config_.chassis());
+  // Add all system-related gNMI paths.
+  AddSubtreeSystem();
   // Add all node-related gNMI paths.
   for (const auto& node : change.new_config_.nodes()) {
     AddSubtreeNode(node);
@@ -315,6 +317,10 @@ void YangParseTree::AddSubtreeNode(const Node& node) {
 
 void YangParseTree::AddSubtreeChassis(const Chassis& chassis) {
   YangParseTreePaths::AddSubtreeChassis(chassis, this);
+}
+
+void YangParseTree::AddSubtreeSystem() {
+  YangParseTreePaths::AddSubtreeSystem(this);
 }
 
 void YangParseTree::AddSubtreeAllInterfaces() {

--- a/stratum/hal/lib/common/yang_parse_tree.h
+++ b/stratum/hal/lib/common/yang_parse_tree.h
@@ -424,6 +424,9 @@ class YangParseTree {
   void AddSubtreeChassis(const Chassis& chassis)
       EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
 
+  // Add supported leaf handles for the system.
+  void AddSubtreeSystem() EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
+
   // Configure the root element.
   void AddRoot() EXCLUSIVE_LOCKS_REQUIRED(root_access_lock_);
 

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -3236,6 +3236,86 @@ void SetUpComponentsComponentIntegratedCircuitStateNodeId(uint64 node_id,
       ->SetOnChangeHandler(on_change_functor);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// /system/logging/console/config/severity
+void SetUpSystemLoggingConsoleConfigSeverity(LoggingConfig logging_config,
+                                             TreeNode* node,
+                                             YangParseTree* tree) {
+  auto poll_functor = [logging_config](const GnmiEvent& event,
+                                       const ::gnmi::Path& path,
+                                       GnmiSubscribeStream* stream) {
+    // This leaf represents configuration data. Return what was known when it
+    // was configured!
+    return SendResponse(
+        GetResponse(path, ConvertLogSeverityToString(logging_config)), stream);
+  };
+
+  auto on_set_functor =
+      [node, tree](const ::gnmi::Path& path,
+                   const ::google::protobuf::Message& val,
+                   CopyOnWriteChassisConfig* config) -> ::util::Status {
+    const gnmi::TypedValue* typed_val =
+        dynamic_cast<const gnmi::TypedValue*>(&val);
+    if (typed_val == nullptr) {
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "not a TypedValue message!";
+    }
+    LoggingConfig logging_config;
+    RETURN_IF_ERROR(
+        ConvertStringToLogSeverity(typed_val->string_val(), &logging_config));
+
+    // Set the value.
+    CHECK_RETURN_IF_FALSE(SetLogLevel(logging_config))
+        << "Could not set new log level (" << logging_config.first << ", "
+        << logging_config.second << ").";
+
+    // Update the YANG parse tree.
+    auto poll_functor = [logging_config](const GnmiEvent& event,
+                                         const ::gnmi::Path& path,
+                                         GnmiSubscribeStream* stream) {
+      // This leaf represents configuration data. Return what was known when it
+      // was configured!
+      return SendResponse(
+          GetResponse(path, ConvertLogSeverityToString(logging_config)),
+          stream);
+    };
+    node->SetOnTimerHandler(poll_functor)->SetOnPollHandler(poll_functor);
+
+    // Trigger change notification.
+    tree->SendNotification(GnmiEventPtr(new ConsoleLogSeverityChangedEvent(
+        logging_config.first, logging_config.second)));
+
+    return ::util::OkStatus();
+  };
+  auto register_functor = RegisterFunc<ConsoleLogSeverityChangedEvent>();
+  auto on_change_functor = GetOnChangeFunctor(
+      &ConsoleLogSeverityChangedEvent::GetState, ConvertLogSeverityToString);
+  node->SetOnPollHandler(poll_functor)
+      ->SetOnTimerHandler(poll_functor)
+      ->SetOnChangeHandler(on_change_functor)
+      ->SetOnChangeRegistration(register_functor)
+      ->SetOnUpdateHandler(on_set_functor)
+      ->SetOnReplaceHandler(on_set_functor);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// /system/logging/console/state/severity
+void SetUpSystemLoggingConsoleStateSeverity(TreeNode* node,
+                                            YangParseTree* tree) {
+  auto poll_functor = [](const GnmiEvent& event, const ::gnmi::Path& path,
+                         GnmiSubscribeStream* stream) -> ::util::Status {
+    return SendResponse(
+        GetResponse(path, ConvertLogSeverityToString(GetCurrentLogLevel())),
+        stream);
+  };
+  auto register_functor = RegisterFunc<ConsoleLogSeverityChangedEvent>();
+  auto on_change_functor = GetOnChangeFunctor(
+      &ConsoleLogSeverityChangedEvent::GetState, ConvertLogSeverityToString);
+  node->SetOnPollHandler(poll_functor)
+      ->SetOnTimerHandler(poll_functor)
+      ->SetOnChangeRegistration(register_functor)
+      ->SetOnChangeHandler(on_change_functor);
+}
+
 }  // namespace
 
 // Path of leafs created by this method are defined 'manualy' by analysing
@@ -3744,6 +3824,16 @@ void YangParseTreePaths::AddSubtreeChassis(const Chassis& chassis,
   node = tree->AddNode(GetPath("components")(
       "component", name)("chassis")("state")("description")());
   SetUpComponentsComponentStateDescription(chassis.name(), node);
+}
+
+void YangParseTreePaths::AddSubtreeSystem(YangParseTree* tree) {
+  LoggingConfig log_level = GetCurrentLogLevel();
+  TreeNode* node = tree->AddNode(
+      GetPath("system")("logging")("console")("config")("severity")());
+  SetUpSystemLoggingConsoleConfigSeverity(log_level, node, tree);
+  node = tree->AddNode(
+      GetPath("system")("logging")("console")("state")("severity")());
+  SetUpSystemLoggingConsoleStateSeverity(node, tree);
 }
 
 void YangParseTreePaths::AddSubtreeAllInterfaces(YangParseTree* tree) {

--- a/stratum/hal/lib/common/yang_parse_tree_paths.h
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.h
@@ -48,6 +48,10 @@ class YangParseTreePaths {
   static void AddSubtreeChassis(const Chassis& chassis, YangParseTree* tree)
       EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
 
+  // Adds all supported paths for the specified system.
+  static void AddSubtreeSystem(YangParseTree* tree)
+      EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);
+
   // Adds all supported wildcard interface-related paths.
   static void AddSubtreeAllInterfaces(YangParseTree* tree)
       EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_);


### PR DESCRIPTION
`/system/logging/console/config/severity` can be used to set the glog level.

Example:

```bash
bazel run --config=asan //stratum/tools/gnmi:gnmi_cli -- --grpc_addr=10.128.13.27:9339 set --string_val="DEBUG" '/system/logging/console/config/severity'
```


TODO:

- [x] Add comment/docs about this new feature
- [x] Unit tests