### PR TITLE
Prevent DirectCounterEntry modifies from changing the action data

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -120,10 +120,6 @@ class BfSdeInterface {
     // This hides the IDs for the $COUNTER_SPEC_BYTES fields.
     virtual ::util::Status SetCounterData(uint64 bytes, uint64 packets) = 0;
 
-    // Like SetCounterData, but deactivates all other fields. Useful when
-    // modifying counter values without touching the action.
-    virtual ::util::Status SetOnlyCounterData(uint64 bytes, uint64 packets) = 0;
-
     // Get the counter values.
     virtual ::util::Status GetCounterData(uint64* bytes,
                                           uint64* packets) const = 0;

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -57,8 +57,6 @@ class TableDataMock : public BfSdeInterface::TableDataInterface {
   MOCK_CONST_METHOD1(GetSelectorGroupId,
                      ::util::Status(uint64* selector_group_id));
   MOCK_METHOD2(SetCounterData, ::util::Status(uint64 bytes, uint64 packets));
-  MOCK_METHOD2(SetOnlyCounterData,
-               ::util::Status(uint64 bytes, uint64 packets));
   MOCK_CONST_METHOD2(GetCounterData,
                      ::util::Status(uint64* bytes, uint64* packets));
   MOCK_CONST_METHOD1(GetActionId, ::util::Status(int* action_id));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -76,7 +76,6 @@ class TableData : public BfSdeInterface::TableDataInterface {
   ::util::Status SetSelectorGroupId(uint64 selector_group_id) override;
   ::util::Status GetSelectorGroupId(uint64* selector_group_id) const override;
   ::util::Status SetCounterData(uint64 bytes, uint64 packets) override;
-  ::util::Status SetOnlyCounterData(uint64 bytes, uint64 packets) override;
   ::util::Status GetCounterData(uint64* bytes, uint64* packets) const override;
   ::util::Status GetActionId(int* action_id) const override;
   ::util::Status Reset(int action_id) override;

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -685,8 +685,9 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
   RETURN_IF_ERROR(BuildTableKey(table_entry, table_key.get()));
 
   // Fetch existing entry with action data. This is needed since the P4RT
-  // request does not provide the action (id), but the SDE requires it in the
-  // later modify call.
+  // request does not provide the action ID and data, but we have to provide the
+  // current values in the later modify call to the SDE, else we would modify
+  // the table entry.
   RETURN_IF_ERROR(bf_sde_interface_->GetTableEntry(
       device_, session, table_id, table_key.get(), table_data.get()));
 
@@ -697,9 +698,9 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
     return ::util::OkStatus();
   }
 
-  RETURN_IF_ERROR(table_data->SetOnlyCounterData(
-      direct_counter_entry.data().byte_count(),
-      direct_counter_entry.data().packet_count()));
+  RETURN_IF_ERROR(
+      table_data->SetCounterData(direct_counter_entry.data().byte_count(),
+                                 direct_counter_entry.data().packet_count()));
 
   RETURN_IF_ERROR(bf_sde_interface_->ModifyTableEntry(
       device_, session, table_id, table_key.get(), table_data.get()));

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -144,7 +144,7 @@ TEST_F(BfrtTableManagerTest, WriteDirectCounterEntryTest) {
 
   EXPECT_CALL(*table_key_mock, SetPriority(kBfrtPriority))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*table_data_mock, SetOnlyCounterData(200, 100))
+  EXPECT_CALL(*table_data_mock, SetCounterData(200, 100))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4TableId))
       .WillOnce(Return(kBfRtTableId));


### PR DESCRIPTION
This change removes `SetOnlyCounterData` which erroneously *did* modify the action data and replaces it with the existing `SetCounterData` function. We improve the later by only setting BfRt table data fields that exists, e.g., in byte-only counters.

Fixes #685