### PR TITLE
Fix P4RT details error vector size on PI node read path

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -243,6 +243,11 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   if (FLAGS_read_req_log_file.empty()) {
     return;
   }
+  if (results.size() != req.entities_size()) {
+    LOG(ERROR) << "Size mismatch: " << results.size()
+               << " != " << req.entities_size() << ". Did not log anything!";
+    return;
+  }
   std::string msg = "";
   std::string ts =
       absl::FormatTime("%Y-%m-%d %H:%M:%E6S", timestamp, absl::LocalTimeZone());

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -171,7 +171,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
 
   ::p4::v1::ReadResponse response;
   auto status = device_mgr_->read(req, &response);
-  RETURN_IF_ERROR(toUtilStatus(status, details, response.entities_size()));
+  RETURN_IF_ERROR(toUtilStatus(status, details, req.entities_size()));
   if (!writer->Write(response))
     return MAKE_ERROR(ERR_INTERNAL) << "Write to stream channel failed.";
   return ::util::OkStatus();


### PR DESCRIPTION
The number of statuses must match the number of request entities, not response entities. This change also adds a check for this issue in P4Service.

Fixes this libprotobuf error message:
```
[libprotobuf FATAL external/com_google_protobuf/src/google/protobuf/repeated_field.h:1694] CHECK failed: (index) < (current_size_):
```