### PR TITLE
Implement `/state/last-change` node by referencing `/oper-status`

### DIFF
--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -233,6 +233,18 @@ std::string ConvertPortStateToString(const PortState& state) {
   }
 }
 
+PortState ConvertStringToPortState(const std::string& state_string) {
+  if (state_string == "UP") {
+    return PORT_STATE_UP;
+  } else if (state_string == "DOWN") {
+    return PORT_STATE_DOWN;
+  } else if (state_string == "LOWER_LAYER_DOWN") {
+    return PORT_STATE_FAILED;
+  } else {
+    return PORT_STATE_UNKNOWN;
+  }
+}
+
 std::string ConvertAdminStateToString(const AdminState& state) {
   switch (state) {
     case ADMIN_STATE_ENABLED:

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -169,6 +169,9 @@ std::string ConvertHwStateToString(const HwState& state);
 // A helper function that convert Stratum port state enum to string.
 std::string ConvertPortStateToString(const PortState& state);
 
+// A helper function that convert OpenConfig port state string to PortState.
+PortState ConvertStringToPortState(const std::string& state_string);
+
 // A helper function that convert Stratum admin state enum to string.
 std::string ConvertAdminStateToString(const AdminState& state);
 


### PR DESCRIPTION
This PR implements the OpenConfig `/interfaces/interface[name=<name>]/state/last-change` path by monitoring the `/oper-status` node of the same interface and watching for port changes.

Alternatives:
- Add `uint64 last_change` field to the common `OperStatus` message and have the ChassisManagers handle it, possibly with help from the SDK

We should keep in mind that `counters/last-clear` will require a similar solution.