### PR TITLE
stratum-bmv2: temporarily revert default canonical bytestrings

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BAZELISK_VERSION=1.8.0
-ARG PI_COMMIT=b2760a818e0b8ade5864604d29b3008a684c6d5f
+ARG PI_COMMIT=35ac4fc80d5a3560d171dc8aa60d104bfa31d37a
 ARG BMV2_COMMIT=6dfd5b41426310eb081fedc8fee05b675f780e31
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-11 main"

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -91,7 +91,7 @@ def stratum_deps():
         remote_workspace(
             name = "com_github_p4lang_PI",
             remote = "https://github.com/p4lang/PI.git",
-            commit = "b2760a818e0b8ade5864604d29b3008a684c6d5f",
+            commit = "35ac4fc80d5a3560d171dc8aa60d104bfa31d37a",
         )
 
     for sde_ver in BF_SDE_PI_VER:

--- a/stratum/hal/bin/bmv2/README.md
+++ b/stratum/hal/bin/bmv2/README.md
@@ -71,3 +71,26 @@ cp stratum/hal/bin/bmv2/update_config.py /tmp/ && \
 
 You can use the loopback program under `stratum/pipelines/loopback/p4c-out/bmv2`
 if you do not have your own P4 program.
+
+## Notes
+
+### P4Runtime canonical byte strings
+
+P4Runtime defines a [canonical byte string representation](https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html#sec-bytestrings)
+for binary data in proto messages such as TableEntries and PacketIn/Outs. In
+short, it requires that the binary strings must not contain redundant bytes,
+ i.e., `\x00\xab` vs `\xab`.
+ Stratum-bmv2 does not yet support canonical byte strings although support is planned for the near future. If using a p4runtime client that defaults to canonical bytestrings usage (e.g. `p4lang/p4runtime-sh`) make sure the legacy byte-padded format is used instead. For `p4lang/p4runtime-sh` this is:
+
+ ```python
+ P4Runtime sh >>> global_options["canonical_bytestrings"] = False
+ ```
+
+ if using the shell or:
+
+ ```python
+from p4runtime_sh.global_options import global_options
+global_options["canonical_bytestrings"] = False
+ ```
+
+if using python directly.


### PR DESCRIPTION
Hey @pudelkoM

Unfortunately https://github.com/stratum/stratum/pull/660 introduced a few regressions on the use of ONOS with stratum-bmv2. Although packet-in/packet-out and some flow rules work well, simple rules such as `match IN_PORT=1, OUTPUT=2` fail to install and are kept on the pending add state forever (removed and inserted again at each cycle). This happens because, due to the default use of canonical bytestrings in PI, the received bytes for the port field are different than the ones of the inserted rule. Since ONOS compares both buffers, the flow rule is flagged as being different than the one installed. For a better understanding of the problem please check: https://gerrit.onosproject.org/c/onos/+/24608
Support for canonical bytestrings in ONOS is WIP and available in https://gerrit.onosproject.org/c/onos/+/24609.

Hence, while ONOS doesn't support canonical bytestrings in some stable version it is better to partially revert the above PR. This PR moves the PI commit a bit early in history, to the first commit before canonical bytestrings were enforced as default. Also adds a bit of documentation (similar to one of your recent PRs) to advise disabling canonical bytestrings on the client for now. There aren't pretty much any changes in PI since this point in history that are not related to canonical bytestrings anyway.
So, we can still benefit from the fixes for direct resources (meter) reading introduced in my latest PR and use ONOS as the control plane without any unexpected behaviour.

Sorry for the inconvenience/regression and thanks a lot for your time. 