### PR TITLE
Fix naming of various `BF*` classes

### DIFF
--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -560,7 +560,7 @@ will crash the switch:
     @           0x9f8403 pi::fe::proto::DeviceMgrImp::pipeline_config_set()
     @           0x9f7e31 pi::fe::proto::DeviceMgr::pipeline_config_set()
     @           0x7220d6 stratum::hal::pi::PINode::PushForwardingPipelineConfig()
-    @           0x41fb99 stratum::hal::barefoot::BFSwitch::PushForwardingPipelineConfig()
+    @           0x41fb99 stratum::hal::barefoot::BfSwitch::PushForwardingPipelineConfig()
     @           0x65db56 stratum::hal::P4Service::SetForwardingPipelineConfig()
 ```
 

--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -110,7 +110,7 @@ void registerDeviceMgrLogger() {
   VLOG(1) << "Detected is_sw_model: " << is_sw_model;
   VLOG(1) << "SDE version: " << bf_sde_wrapper->GetSdeVersion();
   auto bf_chassis_manager =
-      BFChassisManager::CreateInstance(mode, phal_impl, bf_sde_wrapper);
+      BfChassisManager::CreateInstance(mode, phal_impl, bf_sde_wrapper);
   auto bf_switch =
       BFSwitch::CreateInstance(phal_impl, bf_chassis_manager.get(),
                                bf_sde_wrapper, device_id_to_pi_node);

--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -112,7 +112,7 @@ void registerDeviceMgrLogger() {
   auto bf_chassis_manager =
       BfChassisManager::CreateInstance(mode, phal_impl, bf_sde_wrapper);
   auto bf_switch =
-      BFSwitch::CreateInstance(phal_impl, bf_chassis_manager.get(),
+      BfSwitch::CreateInstance(phal_impl, bf_chassis_manager.get(),
                                bf_sde_wrapper, device_id_to_pi_node);
 
   // Create the 'Hal' class instance.

--- a/stratum/hal/bin/barefoot/main_bfrt.cc
+++ b/stratum/hal/bin/barefoot/main_bfrt.cc
@@ -74,7 +74,7 @@ namespace barefoot {
       {device_id, bfrt_node.get()},
   };
   auto bf_chassis_manager =
-      BFChassisManager::CreateInstance(mode, phal_impl, bf_sde_wrapper);
+      BfChassisManager::CreateInstance(mode, phal_impl, bf_sde_wrapper);
   auto bf_switch =
       BfrtSwitch::CreateInstance(phal_impl, bf_chassis_manager.get(),
                                  bf_sde_wrapper, device_id_to_bfrt_node);

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -34,11 +34,11 @@ using TransceiverEvent = PhalInterface::TransceiverEvent;
 ABSL_CONST_INIT absl::Mutex chassis_lock(absl::kConstInit);
 
 /* static */
-constexpr int BFChassisManager::kMaxPortStatusEventDepth;
+constexpr int BfChassisManager::kMaxPortStatusEventDepth;
 /* static */
-constexpr int BFChassisManager::kMaxXcvrEventDepth;
+constexpr int BfChassisManager::kMaxXcvrEventDepth;
 
-BFChassisManager::BFChassisManager(OperationMode mode,
+BfChassisManager::BfChassisManager(OperationMode mode,
                                    PhalInterface* phal_interface,
                                    BfSdeInterface* bf_sde_interface)
     : mode_(mode),
@@ -63,9 +63,9 @@ BFChassisManager::BFChassisManager(OperationMode mode,
       phal_interface_(ABSL_DIE_IF_NULL(phal_interface)),
       bf_sde_interface_(ABSL_DIE_IF_NULL(bf_sde_interface)) {}
 
-BFChassisManager::~BFChassisManager() = default;
+BfChassisManager::~BfChassisManager() = default;
 
-::util::Status BFChassisManager::AddPortHelper(
+::util::Status BfChassisManager::AddPortHelper(
     uint64 node_id, int unit, uint32 sdk_port_id,
     const SingletonPort& singleton_port /* desired config */,
     /* out */ PortConfig* config /* new config */) {
@@ -126,7 +126,7 @@ BFChassisManager::~BFChassisManager() = default;
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::UpdatePortHelper(
+::util::Status BfChassisManager::UpdatePortHelper(
     uint64 node_id, int unit, uint32 sdk_port_id,
     const SingletonPort& singleton_port /* desired config */,
     const PortConfig& config_old /* current config */,
@@ -261,7 +261,7 @@ BFChassisManager::~BFChassisManager() = default;
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::PushChassisConfig(
+::util::Status BfChassisManager::PushChassisConfig(
     const ChassisConfig& config) {
   if (!initialized_) RETURN_IF_ERROR(RegisterEventWriters());
 
@@ -359,7 +359,7 @@ BFChassisManager::~BFChassisManager() = default;
       // was added and the speed_bps was set.
       if (!config_old->speed_bps) {
         RETURN_ERROR(ERR_INTERNAL)
-            << "Invalid internal state in BFChassisManager, "
+            << "Invalid internal state in BfChassisManager, "
             << "speed_bps field should contain a value";
       }
 
@@ -472,7 +472,7 @@ BFChassisManager::~BFChassisManager() = default;
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::ApplyPortShapingConfig(
+::util::Status BfChassisManager::ApplyPortShapingConfig(
     uint64 node_id, int unit, uint32 sdk_port_id,
     const TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig&
         shaping_config) {
@@ -505,7 +505,7 @@ BFChassisManager::~BFChassisManager() = default;
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::VerifyChassisConfig(
+::util::Status BfChassisManager::VerifyChassisConfig(
     const ChassisConfig& config) {
   CHECK_RETURN_IF_FALSE(config.trunk_ports_size() == 0)
       << "Trunk ports are not supported on Tofino.";
@@ -637,21 +637,21 @@ BFChassisManager::~BFChassisManager() = default;
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::RegisterEventNotifyWriter(
+::util::Status BfChassisManager::RegisterEventNotifyWriter(
     const std::shared_ptr<WriterInterface<GnmiEventPtr>>& writer) {
   absl::WriterMutexLock l(&gnmi_event_lock_);
   gnmi_event_writer_ = writer;
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::UnregisterEventNotifyWriter() {
+::util::Status BfChassisManager::UnregisterEventNotifyWriter() {
   absl::WriterMutexLock l(&gnmi_event_lock_);
   gnmi_event_writer_ = nullptr;
   return ::util::OkStatus();
 }
 
-::util::StatusOr<const BFChassisManager::PortConfig*>
-BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
+::util::StatusOr<const BfChassisManager::PortConfig*>
+BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   auto* port_id_to_config =
       gtl::FindOrNull(node_id_to_port_id_to_port_config_, node_id);
   CHECK_RETURN_IF_FALSE(port_id_to_config != nullptr)
@@ -663,7 +663,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return config;
 }
 
-::util::StatusOr<DataResponse> BFChassisManager::GetPortData(
+::util::StatusOr<DataResponse> BfChassisManager::GetPortData(
     const DataRequest::Request& request) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -790,7 +790,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return resp;
 }
 
-::util::StatusOr<PortState> BFChassisManager::GetPortState(uint64 node_id,
+::util::StatusOr<PortState> BfChassisManager::GetPortState(uint64 node_id,
                                                            uint32 port_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -821,7 +821,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return port_state;
 }
 
-::util::Status BFChassisManager::GetPortCounters(uint64 node_id, uint32 port_id,
+::util::Status BfChassisManager::GetPortCounters(uint64 node_id, uint32 port_id,
                                                  PortCounters* counters) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -831,7 +831,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return bf_sde_interface_->GetPortCounters(unit, sdk_port_id, counters);
 }
 
-::util::StatusOr<std::map<uint64, int>> BFChassisManager::GetNodeIdToUnitMap()
+::util::StatusOr<std::map<uint64, int>> BfChassisManager::GetNodeIdToUnitMap()
     const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -839,7 +839,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return node_id_to_unit_;
 }
 
-::util::Status BFChassisManager::ReplayPortsConfig(uint64 node_id) {
+::util::Status BfChassisManager::ReplayPortsConfig(uint64 node_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
@@ -863,12 +863,12 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
     if (!config.speed_bps) {
       RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in BFChassisManager, "
+          << "Invalid internal state in BfChassisManager, "
           << "speed_bps field should contain a value";
     }
     if (!config.fec_mode) {
       RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in BFChassisManager, "
+          << "Invalid internal state in BfChassisManager, "
           << "fec_mode field should contain a value";
     }
 
@@ -949,7 +949,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return status;
 }
 
-::util::Status BFChassisManager::ResetPortsConfig(uint64 node_id) {
+::util::Status BfChassisManager::ResetPortsConfig(uint64 node_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
@@ -967,7 +967,7 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::GetFrontPanelPortInfo(
+::util::Status BfChassisManager::GetFrontPanelPortInfo(
     uint64 node_id, uint32 port_id, FrontPanelPortInfo* fp_port_info) {
   auto* port_id_to_port_key =
       gtl::FindOrNull(node_id_to_port_id_to_singleton_port_key_, node_id);
@@ -981,14 +981,14 @@ BFChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
                                                 fp_port_info);
 }
 
-std::unique_ptr<BFChassisManager> BFChassisManager::CreateInstance(
+std::unique_ptr<BfChassisManager> BfChassisManager::CreateInstance(
     OperationMode mode, PhalInterface* phal_interface,
     BfSdeInterface* bf_sde_interface) {
   return absl::WrapUnique(
-      new BFChassisManager(mode, phal_interface, bf_sde_interface));
+      new BfChassisManager(mode, phal_interface, bf_sde_interface));
 }
 
-void BFChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
+void BfChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
                                                   uint32 port_id,
                                                   PortState new_state) {
   absl::ReaderMutexLock l(&gnmi_event_lock_);
@@ -1005,7 +1005,7 @@ void BFChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
   }
 }
 
-void BFChassisManager::ReadPortStatusEvents() {
+void BfChassisManager::ReadPortStatusEvents() {
   PortStatusEvent event;
   while (true) {
     // port_status_event_reader_ does not need to be protected by a mutex
@@ -1055,7 +1055,7 @@ void BFChassisManager::ReadPortStatusEvents() {
   }
 }
 
-void BFChassisManager::ReadTransceiverEvents() {
+void BfChassisManager::ReadTransceiverEvents() {
   TransceiverEvent event;
   while (true) {
     // xcvr_event_reader_ does not need to be protected by a mutex because this
@@ -1077,7 +1077,7 @@ void BFChassisManager::ReadTransceiverEvents() {
   }
 }
 
-void BFChassisManager::TransceiverEventHandler(int slot, int port,
+void BfChassisManager::TransceiverEventHandler(int slot, int port,
                                                HwState new_state) {
   absl::WriterMutexLock l(&chassis_lock);
 
@@ -1136,7 +1136,7 @@ void BFChassisManager::TransceiverEventHandler(int slot, int port,
   }
 }
 
-::util::Status BFChassisManager::RegisterEventWriters() {
+::util::Status BfChassisManager::RegisterEventWriters() {
   if (initialized_) {
     return MAKE_ERROR(ERR_INTERNAL)
            << "RegisterEventWriters() can be called only before the class is "
@@ -1179,7 +1179,7 @@ void BFChassisManager::TransceiverEventHandler(int slot, int port,
   return ::util::OkStatus();
 }
 
-::util::Status BFChassisManager::UnregisterEventWriters() {
+::util::Status BfChassisManager::UnregisterEventWriters() {
   absl::WriterMutexLock l(&chassis_lock);
   ::util::Status status = ::util::OkStatus();
   APPEND_STATUS_IF_ERROR(status,
@@ -1215,7 +1215,7 @@ void BFChassisManager::TransceiverEventHandler(int slot, int port,
   return status;
 }
 
-::util::StatusOr<int> BFChassisManager::GetUnitFromNodeId(
+::util::StatusOr<int> BfChassisManager::GetUnitFromNodeId(
     uint64 node_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -1227,7 +1227,7 @@ void BFChassisManager::TransceiverEventHandler(int slot, int port,
   return *unit;
 }
 
-::util::StatusOr<uint32> BFChassisManager::GetSdkPortId(uint64 node_id,
+::util::StatusOr<uint32> BfChassisManager::GetSdkPortId(uint64 node_id,
                                                         uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -1246,7 +1246,7 @@ void BFChassisManager::TransceiverEventHandler(int slot, int port,
   return *sdk_port_id;
 }
 
-void BFChassisManager::CleanupInternalState() {
+void BfChassisManager::CleanupInternalState() {
   unit_to_node_id_.clear();
   node_id_to_unit_.clear();
   node_id_to_port_id_to_port_state_.clear();
@@ -1258,7 +1258,7 @@ void BFChassisManager::CleanupInternalState() {
   xcvr_port_key_to_xcvr_state_.clear();
 }
 
-::util::Status BFChassisManager::Shutdown() {
+::util::Status BfChassisManager::Shutdown() {
   ::util::Status status = ::util::OkStatus();
   {
     absl::ReaderMutexLock l(&chassis_lock);

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.h
@@ -27,9 +27,9 @@ namespace barefoot {
 // Lock which protects chassis state across the entire switch.
 extern absl::Mutex chassis_lock;
 
-class BFChassisManager {
+class BfChassisManager {
  public:
-  virtual ~BFChassisManager();
+  virtual ~BfChassisManager();
 
   virtual ::util::Status PushChassisConfig(const ChassisConfig& config)
       EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
@@ -78,20 +78,20 @@ class BFChassisManager {
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
   // Factory function for creating the instance of the class.
-  static std::unique_ptr<BFChassisManager> CreateInstance(
+  static std::unique_ptr<BfChassisManager> CreateInstance(
       OperationMode mode, PhalInterface* phal_interface,
       BfSdeInterface* bf_sde_interface);
 
-  // BFChassisManager is neither copyable nor movable.
-  BFChassisManager(const BFChassisManager&) = delete;
-  BFChassisManager& operator=(const BFChassisManager&) = delete;
-  BFChassisManager(BFChassisManager&&) = delete;
-  BFChassisManager& operator=(BFChassisManager&&) = delete;
+  // BfChassisManager is neither copyable nor movable.
+  BfChassisManager(const BfChassisManager&) = delete;
+  BfChassisManager& operator=(const BfChassisManager&) = delete;
+  BfChassisManager(BfChassisManager&&) = delete;
+  BfChassisManager& operator=(BfChassisManager&&) = delete;
 
  private:
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
-  BFChassisManager(OperationMode mode, PhalInterface* phal_interface,
+  BfChassisManager(OperationMode mode, PhalInterface* phal_interface,
                    BfSdeInterface* bf_sde_interface);
 
   // Maximum depth of port status change event channel.
@@ -252,7 +252,7 @@ class BFChassisManager {
   // Pointer to a BfSdeInterface implementation that wraps all the SDE calls.
   BfSdeInterface* bf_sde_interface_;  // not owned by this class.
 
-  friend class BFChassisManagerTest;
+  friend class BfChassisManagerTest;
 };
 
 }  // namespace barefoot

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -57,7 +57,7 @@ constexpr LoopbackState kDefaultLoopbackMode = LOOPBACK_STATE_UNKNOWN;
 class ChassisConfigBuilder {
  public:
   explicit ChassisConfigBuilder(uint64 node_id = kNodeId) : node_id(node_id) {
-    config_.set_description("Test config for BFChassisManager");
+    config_.set_description("Test config for BfChassisManager");
     auto* chassis = config_.mutable_chassis();
     chassis->set_platform(PLT_GENERIC_BAREFOOT_TOFINO);
     chassis->set_name("Tofino");
@@ -108,15 +108,15 @@ class ChassisConfigBuilder {
 
 }  // namespace
 
-class BFChassisManagerTest : public ::testing::Test {
+class BfChassisManagerTest : public ::testing::Test {
  protected:
-  BFChassisManagerTest() {}
+  BfChassisManagerTest() {}
 
   void SetUp() override {
     phal_mock_ = absl::make_unique<PhalMock>();
     bf_sde_mock_ = absl::make_unique<BfSdeMock>();
     // TODO(max): create parametrized test suite over mode.
-    bf_chassis_manager_ = BFChassisManager::CreateInstance(
+    bf_chassis_manager_ = BfChassisManager::CreateInstance(
         OPERATION_MODE_STANDALONE, phal_mock_.get(), bf_sde_mock_.get());
     ON_CALL(*bf_sde_mock_, IsValidPort(_, _))
         .WillByDefault(
@@ -239,24 +239,24 @@ class BFChassisManagerTest : public ::testing::Test {
 
   std::unique_ptr<PhalMock> phal_mock_;
   std::unique_ptr<BfSdeMock> bf_sde_mock_;
-  std::unique_ptr<BFChassisManager> bf_chassis_manager_;
+  std::unique_ptr<BfChassisManager> bf_chassis_manager_;
 
   static constexpr int kTestTransceiverWriterId = 20;
 };
 
-TEST_F(BFChassisManagerTest, PreFirstConfigPushState) {
+TEST_F(BfChassisManagerTest, PreFirstConfigPushState) {
   ASSERT_OK(CheckCleanInternalState());
   EXPECT_FALSE(Initialized());
   // TODO(antonin): add more checks (to verify that method calls fail as
   // expected)
 }
 
-TEST_F(BFChassisManagerTest, FirstConfigPush) {
+TEST_F(BfChassisManagerTest, FirstConfigPush) {
   ASSERT_OK(PushBaseChassisConfig());
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, RemovePort) {
+TEST_F(BfChassisManagerTest, RemovePort) {
   ChassisConfigBuilder builder;
   ASSERT_OK(PushBaseChassisConfig(&builder));
 
@@ -267,7 +267,7 @@ TEST_F(BFChassisManagerTest, RemovePort) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, AddPortFec) {
+TEST_F(BfChassisManagerTest, AddPortFec) {
   ChassisConfigBuilder builder;
   ASSERT_OK(PushBaseChassisConfig(&builder));
 
@@ -284,7 +284,7 @@ TEST_F(BFChassisManagerTest, AddPortFec) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, SetPortLoopback) {
+TEST_F(BfChassisManagerTest, SetPortLoopback) {
   ChassisConfigBuilder builder;
   ASSERT_OK(PushBaseChassisConfig(&builder));
 
@@ -300,7 +300,7 @@ TEST_F(BFChassisManagerTest, SetPortLoopback) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, ApplyPortShaping) {
+TEST_F(BfChassisManagerTest, ApplyPortShaping) {
   const std::string kVendorConfigText = R"PROTO(
     tofino_config {
       node_id_to_port_shaping_config {
@@ -340,7 +340,7 @@ TEST_F(BFChassisManagerTest, ApplyPortShaping) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, ApplyDeflectOnDrop) {
+TEST_F(BfChassisManagerTest, ApplyDeflectOnDrop) {
   const std::string kVendorConfigText = R"PROTO(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
@@ -376,7 +376,7 @@ TEST_F(BFChassisManagerTest, ApplyDeflectOnDrop) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, ReplayPorts) {
+TEST_F(BfChassisManagerTest, ReplayPorts) {
   const std::string kVendorConfigText = R"PROTO(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
@@ -444,7 +444,7 @@ TEST_F(BFChassisManagerTest, ReplayPorts) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, TransceiverEvent) {
+TEST_F(BfChassisManagerTest, TransceiverEvent) {
   ASSERT_OK(PushBaseChassisConfig());
   auto xcvr_event_writer = GetTransceiverEventWriter();
 
@@ -461,7 +461,7 @@ TEST_F(BFChassisManagerTest, TransceiverEvent) {
 }
 
 template <typename T>
-T GetPortData(BFChassisManager* bf_chassis_manager_, uint64 node_id,
+T GetPortData(BfChassisManager* bf_chassis_manager_, uint64 node_id,
               int port_id,
               DataRequest::Request::Port* (
                   DataRequest::Request::*get_mutable_message_func)(),
@@ -479,7 +479,7 @@ T GetPortData(BFChassisManager* bf_chassis_manager_, uint64 node_id,
 }
 
 template <typename T, typename U>
-void GetPortDataTest(BFChassisManager* bf_chassis_manager_, uint64 node_id,
+void GetPortDataTest(BfChassisManager* bf_chassis_manager_, uint64 node_id,
                      int port_id,
                      DataRequest::Request::Port* (
                          DataRequest::Request::*get_mutable_message_func)(),
@@ -495,7 +495,7 @@ void GetPortDataTest(BFChassisManager* bf_chassis_manager_, uint64 node_id,
 }
 
 template <typename T>
-void GetPortDataTest(BFChassisManager* bf_chassis_manager_, uint64 node_id,
+void GetPortDataTest(BfChassisManager* bf_chassis_manager_, uint64 node_id,
                      int port_id,
                      DataRequest::Request::Port* (
                          DataRequest::Request::*get_mutable_message_func)(),
@@ -510,7 +510,7 @@ void GetPortDataTest(BFChassisManager* bf_chassis_manager_, uint64 node_id,
   EXPECT_THAT(val, EqualsProto(expected_msg));
 }
 
-TEST_F(BFChassisManagerTest, GetPortData) {
+TEST_F(BfChassisManagerTest, GetPortData) {
   ChassisConfigBuilder builder;
   ASSERT_OK(PushBaseChassisConfig(&builder));
 
@@ -655,7 +655,7 @@ TEST_F(BFChassisManagerTest, GetPortData) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, UpdateInvalidPort) {
+TEST_F(BfChassisManagerTest, UpdateInvalidPort) {
   ASSERT_OK(PushBaseChassisConfig());
   ChassisConfigBuilder builder;
   const uint32 portId = kPortId + 1;
@@ -686,7 +686,7 @@ TEST_F(BFChassisManagerTest, UpdateInvalidPort) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, ResetPortsConfig) {
+TEST_F(BfChassisManagerTest, ResetPortsConfig) {
   ASSERT_OK(PushBaseChassisConfig());
   EXPECT_OK(bf_chassis_manager_->ResetPortsConfig(kNodeId));
 
@@ -700,7 +700,7 @@ TEST_F(BFChassisManagerTest, ResetPortsConfig) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, GetSdkPortId) {
+TEST_F(BfChassisManagerTest, GetSdkPortId) {
   ChassisConfigBuilder builder;
   ASSERT_OK(PushBaseChassisConfig(&builder));
 
@@ -712,7 +712,7 @@ TEST_F(BFChassisManagerTest, GetSdkPortId) {
   ASSERT_OK(ShutdownAndTestCleanState());
 }
 
-TEST_F(BFChassisManagerTest, VerifyChassisConfigSuccess) {
+TEST_F(BfChassisManagerTest, VerifyChassisConfigSuccess) {
   const std::string kConfigText1 = R"(
       description: "Sample Generic Tofino config 2x25G ports."
       chassis {

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -26,7 +26,7 @@ namespace barefoot {
 
 using ::stratum::hal::pi::PINode;
 
-BFSwitch::BFSwitch(PhalInterface* phal_interface,
+BfSwitch::BfSwitch(PhalInterface* phal_interface,
                    BfChassisManager* bf_chassis_manager,
                    BfSdeInterface* bf_sde_interface,
                    const std::map<int, PINode*>& unit_to_pi_node)
@@ -42,9 +42,9 @@ BFSwitch::BFSwitch(PhalInterface* phal_interface,
   }
 }
 
-BFSwitch::~BFSwitch() {}
+BfSwitch::~BfSwitch() {}
 
-::util::Status BFSwitch::PushChassisConfig(const ChassisConfig& config) {
+::util::Status BfSwitch::PushChassisConfig(const ChassisConfig& config) {
   // Verify the config first. No need to continue if verification is not OK.
   // Push config to PHAL first and then the rest of the managers.
   RETURN_IF_ERROR(VerifyChassisConfig(config));
@@ -67,7 +67,7 @@ BFSwitch::~BFSwitch() {}
   return ::util::OkStatus();
 }
 
-::util::Status BFSwitch::VerifyChassisConfig(const ChassisConfig& config) {
+::util::Status BfSwitch::VerifyChassisConfig(const ChassisConfig& config) {
   // First make sure PHAL is happy with the config then continue with the rest
   // of the managers and nodes.
   absl::ReaderMutexLock l(&chassis_lock);
@@ -124,7 +124,7 @@ namespace {
 }
 }  // namespace
 
-::util::Status BFSwitch::PushForwardingPipelineConfig(
+::util::Status BfSwitch::PushForwardingPipelineConfig(
     uint64 node_id, const ::p4::v1::ForwardingPipelineConfig& _config) {
   absl::WriterMutexLock l(&chassis_lock);
 
@@ -149,7 +149,7 @@ namespace {
   return ::util::OkStatus();
 }
 
-::util::Status BFSwitch::SaveForwardingPipelineConfig(
+::util::Status BfSwitch::SaveForwardingPipelineConfig(
     uint64 node_id, const ::p4::v1::ForwardingPipelineConfig& _config) {
   absl::WriterMutexLock l(&chassis_lock);
 
@@ -166,7 +166,7 @@ namespace {
   return ::util::OkStatus();
 }
 
-::util::Status BFSwitch::CommitForwardingPipelineConfig(uint64 node_id) {
+::util::Status BfSwitch::CommitForwardingPipelineConfig(uint64 node_id) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   RETURN_IF_ERROR(pi_node->CommitForwardingPipelineConfig());
 
@@ -176,7 +176,7 @@ namespace {
   return ::util::OkStatus();
 }
 
-::util::Status BFSwitch::VerifyForwardingPipelineConfig(
+::util::Status BfSwitch::VerifyForwardingPipelineConfig(
     uint64 node_id, const ::p4::v1::ForwardingPipelineConfig& _config) {
   ::p4::v1::ForwardingPipelineConfig config;
   RETURN_IF_ERROR(ConvertToLegacyForwardingPipelineConfig(_config, &config));
@@ -185,17 +185,17 @@ namespace {
   return pi_node->VerifyForwardingPipelineConfig(config);
 }
 
-::util::Status BFSwitch::Shutdown() {
+::util::Status BfSwitch::Shutdown() {
   ::util::Status status = ::util::OkStatus();
   APPEND_STATUS_IF_ERROR(status, bf_chassis_manager_->Shutdown());
   return status;
 }
 
-::util::Status BFSwitch::Freeze() { return ::util::OkStatus(); }
+::util::Status BfSwitch::Freeze() { return ::util::OkStatus(); }
 
-::util::Status BFSwitch::Unfreeze() { return ::util::OkStatus(); }
+::util::Status BfSwitch::Unfreeze() { return ::util::OkStatus(); }
 
-::util::Status BFSwitch::WriteForwardingEntries(
+::util::Status BfSwitch::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
   CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in WriteRequest.";
@@ -206,7 +206,7 @@ namespace {
   return pi_node->WriteForwardingEntries(req, results);
 }
 
-::util::Status BFSwitch::ReadForwardingEntries(
+::util::Status BfSwitch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
@@ -218,32 +218,32 @@ namespace {
   return pi_node->ReadForwardingEntries(req, writer, details);
 }
 
-::util::Status BFSwitch::RegisterStreamMessageResponseWriter(
+::util::Status BfSwitch::RegisterStreamMessageResponseWriter(
     uint64 node_id,
     std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   return pi_node->RegisterStreamMessageResponseWriter(writer);
 }
-::util::Status BFSwitch::UnregisterStreamMessageResponseWriter(uint64 node_id) {
+::util::Status BfSwitch::UnregisterStreamMessageResponseWriter(uint64 node_id) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   return pi_node->UnregisterStreamMessageResponseWriter();
 }
-::util::Status BFSwitch::HandleStreamMessageRequest(
+::util::Status BfSwitch::HandleStreamMessageRequest(
     uint64 node_id, const ::p4::v1::StreamMessageRequest& request) {
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   return pi_node->HandleStreamMessageRequest(request);
 }
 
-::util::Status BFSwitch::RegisterEventNotifyWriter(
+::util::Status BfSwitch::RegisterEventNotifyWriter(
     std::shared_ptr<WriterInterface<GnmiEventPtr>> writer) {
   return bf_chassis_manager_->RegisterEventNotifyWriter(writer);
 }
 
-::util::Status BFSwitch::UnregisterEventNotifyWriter() {
+::util::Status BfSwitch::UnregisterEventNotifyWriter() {
   return bf_chassis_manager_->UnregisterEventNotifyWriter();
 }
 
-::util::Status BFSwitch::RetrieveValue(uint64 node_id,
+::util::Status BfSwitch::RetrieveValue(uint64 node_id,
                                        const DataRequest& request,
                                        WriterInterface<DataResponse>* writer,
                                        std::vector<::util::Status>* details) {
@@ -296,30 +296,30 @@ namespace {
   return ::util::OkStatus();
 }
 
-::util::Status BFSwitch::SetValue(uint64 node_id, const SetRequest& request,
+::util::Status BfSwitch::SetValue(uint64 node_id, const SetRequest& request,
                                   std::vector<::util::Status>* details) {
   (void)node_id;
   (void)request;
   (void)details;
-  LOG(INFO) << "BFSwitch::SetValue is not implemented yet, but changes will "
+  LOG(INFO) << "BfSwitch::SetValue is not implemented yet, but changes will "
             << "be performed when ChassisConfig is pushed again.";
   // TODO(antonin)
   return ::util::OkStatus();
 }
 
-::util::StatusOr<std::vector<std::string>> BFSwitch::VerifyState() {
+::util::StatusOr<std::vector<std::string>> BfSwitch::VerifyState() {
   return std::vector<std::string>();
 }
 
-std::unique_ptr<BFSwitch> BFSwitch::CreateInstance(
+std::unique_ptr<BfSwitch> BfSwitch::CreateInstance(
     PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
     BfSdeInterface* bf_sde_interface,
     const std::map<int, PINode*>& unit_to_pi_node) {
-  return absl::WrapUnique(new BFSwitch(phal_interface, bf_chassis_manager,
+  return absl::WrapUnique(new BfSwitch(phal_interface, bf_chassis_manager,
                                        bf_sde_interface, unit_to_pi_node));
 }
 
-::util::StatusOr<PINode*> BFSwitch::GetPINodeFromUnit(int unit) const {
+::util::StatusOr<PINode*> BfSwitch::GetPINodeFromUnit(int unit) const {
   PINode* pi_node = gtl::FindPtrOrNull(unit_to_pi_node_, unit);
   if (pi_node == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM) << "Unit " << unit << " is unknown.";
@@ -327,7 +327,7 @@ std::unique_ptr<BFSwitch> BFSwitch::CreateInstance(
   return pi_node;
 }
 
-::util::StatusOr<PINode*> BFSwitch::GetPINodeFromNodeId(uint64 node_id) const {
+::util::StatusOr<PINode*> BfSwitch::GetPINodeFromNodeId(uint64 node_id) const {
   PINode* pi_node = gtl::FindPtrOrNull(node_id_to_pi_node_, node_id);
   if (pi_node == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -27,7 +27,7 @@ namespace barefoot {
 using ::stratum::hal::pi::PINode;
 
 BFSwitch::BFSwitch(PhalInterface* phal_interface,
-                   BFChassisManager* bf_chassis_manager,
+                   BfChassisManager* bf_chassis_manager,
                    BfSdeInterface* bf_sde_interface,
                    const std::map<int, PINode*>& unit_to_pi_node)
     : phal_interface_(ABSL_DIE_IF_NULL(phal_interface)),
@@ -312,7 +312,7 @@ namespace {
 }
 
 std::unique_ptr<BFSwitch> BFSwitch::CreateInstance(
-    PhalInterface* phal_interface, BFChassisManager* bf_chassis_manager,
+    PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
     BfSdeInterface* bf_sde_interface,
     const std::map<int, PINode*>& unit_to_pi_node) {
   return absl::WrapUnique(new BFSwitch(phal_interface, bf_chassis_manager,

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -67,7 +67,7 @@ class BFSwitch : public SwitchInterface {
 
   // Factory function for creating the instance of the class.
   static std::unique_ptr<BFSwitch> CreateInstance(
-      PhalInterface* phal_interface, BFChassisManager* bf_chassis_manager,
+      PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
       BfSdeInterface* bf_sde_interface,
       const std::map<int, pi::PINode*>& unit_to_pi_node);
 
@@ -80,7 +80,7 @@ class BFSwitch : public SwitchInterface {
  private:
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
-  BFSwitch(PhalInterface* phal_interface, BFChassisManager* bf_chassis_manager,
+  BFSwitch(PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
            BfSdeInterface* bf_sde_interface,
            const std::map<int, pi::PINode*>& unit_to_pi_node);
 
@@ -102,7 +102,7 @@ class BFSwitch : public SwitchInterface {
 
   // Per chassis Managers. Note that there is only one instance of this class
   // per chassis.
-  BFChassisManager* bf_chassis_manager_;  // not owned by the class.
+  BfChassisManager* bf_chassis_manager_;  // not owned by the class.
 
   // Map from zero-based unit number corresponding to a node/ASIC to a pointer
   // to PINode which contain all the per-node managers for that node/ASIC. This

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -20,9 +20,9 @@ namespace stratum {
 namespace hal {
 namespace barefoot {
 
-class BFSwitch : public SwitchInterface {
+class BfSwitch : public SwitchInterface {
  public:
-  ~BFSwitch() override;
+  ~BfSwitch() override;
 
   // SwitchInterface public methods.
   ::util::Status PushChassisConfig(const ChassisConfig& config) override;
@@ -66,21 +66,21 @@ class BFSwitch : public SwitchInterface {
   ::util::StatusOr<std::vector<std::string>> VerifyState() override;
 
   // Factory function for creating the instance of the class.
-  static std::unique_ptr<BFSwitch> CreateInstance(
+  static std::unique_ptr<BfSwitch> CreateInstance(
       PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
       BfSdeInterface* bf_sde_interface,
       const std::map<int, pi::PINode*>& unit_to_pi_node);
 
-  // BFSwitch is neither copyable nor movable.
-  BFSwitch(const BFSwitch&) = delete;
-  BFSwitch& operator=(const BFSwitch&) = delete;
-  BFSwitch(BFSwitch&&) = delete;
-  BFSwitch& operator=(BFSwitch&&) = delete;
+  // BfSwitch is neither copyable nor movable.
+  BfSwitch(const BfSwitch&) = delete;
+  BfSwitch& operator=(const BfSwitch&) = delete;
+  BfSwitch(BfSwitch&&) = delete;
+  BfSwitch& operator=(BfSwitch&&) = delete;
 
  private:
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
-  BFSwitch(PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
+  BfSwitch(PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
            BfSdeInterface* bf_sde_interface,
            const std::map<int, pi::PINode*>& unit_to_pi_node);
 

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -24,7 +24,7 @@ namespace hal {
 namespace barefoot {
 
 BfrtSwitch::BfrtSwitch(PhalInterface* phal_interface,
-                       BFChassisManager* bf_chassis_manager,
+                       BfChassisManager* bf_chassis_manager,
                        BfSdeInterface* bf_sde_interface,
                        const std::map<int, BfrtNode*>& device_id_to_bfrt_node)
     : phal_interface_(ABSL_DIE_IF_NULL(phal_interface)),
@@ -263,7 +263,7 @@ BfrtSwitch::~BfrtSwitch() {}
 }
 
 std::unique_ptr<BfrtSwitch> BfrtSwitch::CreateInstance(
-    PhalInterface* phal_interface, BFChassisManager* bf_chassis_manager,
+    PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
     BfSdeInterface* bf_sde_interface,
     const std::map<int, BfrtNode*>& device_id_to_bfrt_node) {
   return absl::WrapUnique(new BfrtSwitch(phal_interface, bf_chassis_manager,

--- a/stratum/hal/lib/barefoot/bfrt_switch.h
+++ b/stratum/hal/lib/barefoot/bfrt_switch.h
@@ -76,7 +76,7 @@ class BfrtSwitch : public SwitchInterface {
 
   // Factory function for creating the instance of the class.
   static std::unique_ptr<BfrtSwitch> CreateInstance(
-      PhalInterface* phal_interface, BFChassisManager* bf_chassis_manager,
+      PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
       BfSdeInterface* bf_sde_interface,
       const std::map<int, BfrtNode*>& device_id_to_bfrt_node);
 
@@ -90,7 +90,7 @@ class BfrtSwitch : public SwitchInterface {
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
   BfrtSwitch(PhalInterface* phal_interface,
-             BFChassisManager* bf_chassis_manager,
+             BfChassisManager* bf_chassis_manager,
              BfSdeInterface* bf_sde_interface,
              const std::map<int, BfrtNode*>& device_id_to_bfrt_node);
 
@@ -112,7 +112,7 @@ class BfrtSwitch : public SwitchInterface {
 
   // Per chassis Managers. Note that there is only one instance of this class
   // per chassis.
-  BFChassisManager* bf_chassis_manager_;  // not owned by the class.
+  BfChassisManager* bf_chassis_manager_;  // not owned by the class.
 
   // Map from zero-based device_id number corresponding to a node/ASIC to a
   // pointer to BfrtNode which contain all the per-node managers for that


### PR DESCRIPTION
From `BFChassisManager` to `BfChassisManager` and from `BFSwitch` to `BfSwitch`.