### PR TITLE
Clean up `OnLinkscanEvent` code in BcmSdkWrappers

### DIFF
--- a/.circleci/check-cpp-format.sh
+++ b/.circleci/check-cpp-format.sh
@@ -76,6 +76,8 @@ stratum/hal/lib/bcm/bcm_packetio_manager_mock.h
 stratum/hal/lib/bcm/bcm_packetio_manager_test.cc
 stratum/hal/lib/bcm/bcm_packetio_manager.cc
 stratum/hal/lib/bcm/bcm_packetio_manager.h
+stratum/hal/lib/bcm/bcm_sdk_interface.h
+stratum/hal/lib/bcm/bcm_sdk_mock.h
 stratum/hal/lib/bcm/bcm_serdes_db_manager_mock.h
 stratum/hal/lib/bcm/bcm_serdes_db_manager_test.cc
 stratum/hal/lib/bcm/bcm_serdes_db_manager.cc

--- a/stratum/hal/lib/bcm/bcm_sdk_interface.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_interface.h
@@ -7,10 +7,10 @@
 
 #include <functional>
 #include <map>
-#include <string>
-#include <vector>
 #include <memory>
 #include <set>
+#include <string>
+#include <vector>
 
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
@@ -183,8 +183,8 @@ class BcmSdkInterface {
 
   // Generates the configuration file (content) for the SDK.
   virtual ::util::StatusOr<std::string> GenerateBcmConfigFile(
-    const BcmChassisMap& base_bcm_chassis_map,
-    const BcmChassisMap& target_bcm_chassis_map, OperationMode mode) = 0;
+      const BcmChassisMap& base_bcm_chassis_map,
+      const BcmChassisMap& target_bcm_chassis_map, OperationMode mode) = 0;
 
   // Finds the BCM SOC device given PCI bus/PCI slot, creates a soc_cm_dev_t
   // entry that is the main internal SDK data structure that identifies the
@@ -234,9 +234,6 @@ class BcmSdkInterface {
 
   // Stops linkscan.
   virtual ::util::Status StopLinkscan(int unit) = 0;
-
-  // Create link scan event message
-  virtual void OnLinkscanEvent(int unit, int port, PortState linkstatus) = 0;
 
   // Registers a Writer through which to send any linkscan events. The message
   // contains a tuple (unit, port, state), where port refers to the Broadcom SDK

--- a/stratum/hal/lib/bcm/bcm_sdk_mock.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_mock.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_SDK_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_SDK_MOCK_H_
 
@@ -10,8 +9,8 @@
 #include <string>
 #include <vector>
 
-#include "stratum/hal/lib/bcm/bcm_sdk_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/bcm/bcm_sdk_interface.h"
 
 namespace stratum {
 namespace hal {
@@ -44,7 +43,6 @@ class BcmSdkMock : public BcmSdkInterface {
   MOCK_METHOD0(StartDiagShellServer, ::util::Status());
   MOCK_METHOD1(StartLinkscan, ::util::Status(int unit));
   MOCK_METHOD1(StopLinkscan, ::util::Status(int unit));
-  MOCK_METHOD3(OnLinkscanEvent, void(int unit, int port, PortState linkstatus));
   MOCK_METHOD2(
       RegisterLinkscanEventWriter,
       ::util::StatusOr<int>(std::unique_ptr<ChannelWriter<LinkscanEvent>>,

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -508,8 +508,7 @@ extern "C" void sdk_linkscan_callback(int unit, bcm_port_t port,
     LOG(ERROR) << "BcmSdkWrapper singleton instance is not initialized.";
     return;
   }
-  LOG(INFO) << "Unit: " << unit << " Port: " << port << " Link: "
-            << "changed.";
+  VLOG(1) << "Link on unit: " << unit << " Port: " << port << " changed.";
   // Forward the event.
   bcm_sdk_wrapper->OnLinkscanEvent(unit, port, info);
 }
@@ -5133,27 +5132,6 @@ void BcmSdkWrapper::OnLinkscanEvent(int unit, int port, bcm_port_info_t* info) {
     uint32 value) {
   // TODO(unknown): Implement this function.
   return ::util::OkStatus();
-}
-
-void BcmSdkWrapper::OnLinkscanEvent(int unit, int port, PortState linkstatus) {
-  /* Create LinkscanEvent message. */
-  PortState state;
-  if (linkstatus == PORT_STATE_UP) {
-    state = PORT_STATE_UP;
-  } else if (linkstatus == PORT_STATE_DOWN) {
-    state = PORT_STATE_DOWN;
-  } else {
-    state = PORT_STATE_UNKNOWN;
-  }
-  LinkscanEvent event = {unit, port, state};
-
-  {
-    absl::ReaderMutexLock l(&linkscan_writers_lock_);
-    // Invoke the Writers based on priority.
-    for (const auto& w : linkscan_event_writers_) {
-      w.writer->Write(event, kWriteTimeout).IgnoreError();
-    }
-  }
 }
 
 }  // namespace bcm

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
@@ -32,13 +32,17 @@
 #include "stratum/hal/lib/common/constants.h"
 
 extern "C" {
+// The include order here is significant. First, we undefine symbols clashing
+// with the SDK.
 #include "stratum/hal/lib/bcm/sdk_build_undef.h"  // NOLINT
+// Then we add the defines from the SDK.
 #include "sdk_build_flags.h"  // NOLINT
+// Finally, the regular SDK includes.
 #include "bcm/field.h"
 #include "bcm/port.h"
 #include "bcm/types.h"
-#include "ibde.h"             // NOLINT
-#include "linux-bde.h"        // NOLINT
+#include "ibde.h"       // NOLINT
+#include "linux-bde.h"  // NOLINT
 #include "soc/cmext.h"
 #include "stratum/hal/lib/bcm/sdk_build_undef.h"  // NOLINT
 }
@@ -138,7 +142,6 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status StartDiagShellServer() override;
   ::util::Status StartLinkscan(int unit) override;
   ::util::Status StopLinkscan(int unit) override;
-  void OnLinkscanEvent(int unit, int port, PortState linkstatus) override;
   ::util::StatusOr<int> RegisterLinkscanEventWriter(
       std::unique_ptr<ChannelWriter<LinkscanEvent>> writer,
       int priority) override LOCKS_EXCLUDED(linkscan_writers_lock_);

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
@@ -111,7 +111,6 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status StartDiagShellServer() override;
   ::util::Status StartLinkscan(int unit) override LOCKS_EXCLUDED(data_lock_);
   ::util::Status StopLinkscan(int unit) override LOCKS_EXCLUDED(data_lock_);
-  void OnLinkscanEvent(int unit, int port, PortState linkstatus) override;
   ::util::StatusOr<int> RegisterLinkscanEventWriter(
       std::unique_ptr<ChannelWriter<LinkscanEvent>> writer,
       int priority) override LOCKS_EXCLUDED(linkscan_writers_lock_);
@@ -281,6 +280,12 @@ class BcmSdkWrapper : public BcmSdkInterface {
 
   // Thread id for the currently running diag shell thread.
   pthread_t GetDiagShellThreadId() const;
+
+  // Called whenever a linkscan event is received from SDK. It forwards the
+  // linkscan event to the module who registered a callback by calling
+  // RegisterLinkscanEventWriter().
+  void OnLinkscanEvent(int unit, int port, PortState port_state)
+      LOCKS_EXCLUDED(linkscan_writers_lock_);
 
   // BcmSdkWrapper is neither copyable nor movable.
   BcmSdkWrapper(const BcmSdkWrapper&) = delete;


### PR DESCRIPTION
`OnLinkscanEvent` is SDK specific and therefore does not belong in the SdkInterface.