### PR TITLE
Add deadline param to `SwitchInterface::ReadForwardingEntries`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -209,13 +209,13 @@ namespace {
 ::util::Status BfSwitch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
-  return pi_node->ReadForwardingEntries(req, writer, details);
+  return pi_node->ReadForwardingEntries(req, writer, details, deadline);
 }
 
 ::util::Status BfSwitch::RegisterStreamMessageResponseWriter(

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -46,7 +46,7 @@ class BfSwitch : public SwitchInterface {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) override;
+      std::vector<::util::Status>* details, absl::Time deadline) override;
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -259,7 +259,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
 ::util::Status BfrtNode::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   absl::ReaderMutexLock l(&lock_);
   CHECK_RETURN_IF_FALSE(req.device_id() == node_id_)
       << "Request device id must be same as id of this BfrtNode.";
@@ -270,6 +270,10 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   bool success = true;
   ASSIGN_OR_RETURN(auto session, bf_sde_interface_->CreateSession());
   for (const auto& entity : req.entities()) {
+    // if (deadline < absl::Now()) {
+    //   break;
+    //   return MAKE_ERROR(ERR_CANCELLED) << "";
+    // }
     switch (entity.entity_case()) {
       case ::p4::v1::Entity::kTableEntry: {
         auto status = bfrt_table_manager_->ReadTableEntry(

--- a/stratum/hal/lib/barefoot/bfrt_node.h
+++ b/stratum/hal/lib/barefoot/bfrt_node.h
@@ -52,7 +52,7 @@ class BfrtNode final {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) LOCKS_EXCLUDED(lock_);
+      std::vector<::util::Status>* details, absl::Time deadline) LOCKS_EXCLUDED(lock_);
   ::util::Status RegisterStreamMessageResponseWriter(
       const std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>>&
           writer) LOCKS_EXCLUDED(lock_);

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -151,14 +151,14 @@ BfrtSwitch::~BfrtSwitch() {}
 ::util::Status BfrtSwitch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
 
   absl::ReaderMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(req.device_id()));
-  return bfrt_node->ReadForwardingEntries(req, writer, details);
+  return bfrt_node->ReadForwardingEntries(req, writer, details, deadline);
 }
 
 ::util::Status BfrtSwitch::RegisterStreamMessageResponseWriter(

--- a/stratum/hal/lib/barefoot/bfrt_switch.h
+++ b/stratum/hal/lib/barefoot/bfrt_switch.h
@@ -49,7 +49,7 @@ class BfrtSwitch : public SwitchInterface {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) override
+      std::vector<::util::Status>* details, absl::Time deadline) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -176,7 +176,7 @@ BcmNode::~BcmNode() {}
 ::util::Status BcmNode::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
 

--- a/stratum/hal/lib/bcm/bcm_node.h
+++ b/stratum/hal/lib/bcm/bcm_node.h
@@ -79,7 +79,7 @@ class BcmNode {
   virtual ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) SHARED_LOCKS_REQUIRED(chassis_lock)
+      std::vector<::util::Status>* details, absl::Time deadline) SHARED_LOCKS_REQUIRED(chassis_lock)
       LOCKS_EXCLUDED(lock_);
 
   // Registers a writer to be invoked on receipt of a packet on any port on this

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -174,7 +174,7 @@ BcmSwitch::~BcmSwitch() {}
 ::util::Status BcmSwitch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
@@ -185,7 +185,7 @@ BcmSwitch::~BcmSwitch() {}
   }
   // Get BcmNode which the device_id is associated with.
   ASSIGN_OR_RETURN(auto* bcm_node, GetBcmNodeFromNodeId(req.device_id()));
-  return bcm_node->ReadForwardingEntries(req, writer, details);
+  return bcm_node->ReadForwardingEntries(req, writer, details, deadline);
 }
 
 ::util::Status BcmSwitch::RegisterStreamMessageResponseWriter(

--- a/stratum/hal/lib/bcm/bcm_switch.h
+++ b/stratum/hal/lib/bcm/bcm_switch.h
@@ -53,7 +53,7 @@ class BcmSwitch : public SwitchInterface {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) override
+      std::vector<::util::Status>* details, absl::Time deadline) override
       LOCKS_EXCLUDED(chassis_lock);
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -128,13 +128,13 @@ Bmv2Switch::~Bmv2Switch() {}
 ::util::Status Bmv2Switch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
-  return pi_node->ReadForwardingEntries(req, writer, details);
+  return pi_node->ReadForwardingEntries(req, writer, details, deadline);
 }
 
 ::util::Status Bmv2Switch::RegisterStreamMessageResponseWriter(

--- a/stratum/hal/lib/bmv2/bmv2_switch.h
+++ b/stratum/hal/lib/bmv2/bmv2_switch.h
@@ -45,7 +45,7 @@ class Bmv2Switch : public SwitchInterface {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) override;
+      std::vector<::util::Status>* details, absl::Time deadline) override;
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -694,6 +694,7 @@ stratum_cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "@com_github_openconfig_gnmi_proto//:gnmi_cc_grpc",

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -337,8 +337,13 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   ServerWriterWrapper<::p4::v1::ReadResponse> wrapper(writer);
   std::vector<::util::Status> details = {};
   absl::Time timestamp = absl::Now();
-  ::util::Status status =
-      switch_interface_->ReadForwardingEntries(*req, &wrapper, &details);
+  // auto deadline = min(context->deadline() - 100ms), 0);
+  // TODO(max): check where deadline comes from, and relation to isCancelled()
+  absl::Time deadline = absl::FromChrono(context->deadline());
+  LOG(ERROR) << absl::FormatTime(deadline);
+  auto t = absl::InfiniteFuture();
+  ::util::Status status = switch_interface_->ReadForwardingEntries(
+      *req, &wrapper, &details, deadline);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to read forwarding entries from node "
                << req->device_id() << ": " << status.error_message();

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -755,7 +755,7 @@ TEST_P(P4ServiceTest, ReadSuccess) {
   EXPECT_CALL(*auth_policy_checker_mock_, Authorize("P4Service", "Read", _))
       .WillOnce(Return(::util::OkStatus()));
   const std::vector<::util::Status> kExpectedResults = {::util::OkStatus()};
-  EXPECT_CALL(*switch_mock_, ReadForwardingEntries(EqualsProto(req), _, _))
+  EXPECT_CALL(*switch_mock_, ReadForwardingEntries(EqualsProto(req), _, _, _))
       .WillOnce(DoAll(SetArgPointee<2>(kExpectedResults),
                       Return(::util::OkStatus())));
 
@@ -816,7 +816,7 @@ TEST_P(P4ServiceTest, ReadFailureWhenReadForwardingEntriesFails) {
 
   const std::vector<::util::Status> kExpectedDetails = {
       ::util::Status(StratumErrorSpace(), ERR_TABLE_FULL, kOperErrorMsg)};
-  EXPECT_CALL(*switch_mock_, ReadForwardingEntries(EqualsProto(req), _, _))
+  EXPECT_CALL(*switch_mock_, ReadForwardingEntries(EqualsProto(req), _, _, _))
       .WillOnce(DoAll(SetArgPointee<2>(kExpectedDetails),
                       Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL,
                                             kAggrErrorMsg))));

--- a/stratum/hal/lib/common/switch_interface.h
+++ b/stratum/hal/lib/common/switch_interface.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/time/time.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
@@ -144,10 +145,13 @@ class SwitchInterface {
   // some of the entries requested are not supported, the returned status may
   // still be OK and the non supported entries will be specified in `details`).
   // Note that there is no requirement on the order of entries in this vector.
+  // If `deadline` is not InfiniteFuture, this method "may" return before
+  // finishing the entire request. Note that not all implementations support
+  // early cancellation.
   virtual ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) = 0;
+      std::vector<::util::Status>* details, absl::Time deadline) = 0;
 
   // Registers a writer to be invoked when we receive a StreamMessageResponse on
   // the specified node which are destined for the controller. A

--- a/stratum/hal/lib/common/switch_mock.h
+++ b/stratum/hal/lib/common/switch_mock.h
@@ -40,10 +40,11 @@ class SwitchMock : public SwitchInterface {
   MOCK_METHOD2(WriteForwardingEntries,
                ::util::Status(const ::p4::v1::WriteRequest& req,
                               std::vector<::util::Status>* results));
-  MOCK_METHOD3(ReadForwardingEntries,
+  MOCK_METHOD4(ReadForwardingEntries,
                ::util::Status(const ::p4::v1::ReadRequest& req,
                               WriterInterface<::p4::v1::ReadResponse>* writer,
-                              std::vector<::util::Status>* details));
+                              std::vector<::util::Status>* details,
+                              absl::Time deadline));
   MOCK_METHOD2(
       RegisterStreamMessageResponseWriter,
       ::util::Status(

--- a/stratum/hal/lib/dummy/dummy_node.cc
+++ b/stratum/hal/lib/dummy/dummy_node.cc
@@ -76,7 +76,7 @@ namespace dummy_switch {
 ::util::Status DummyNode::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   // TODO(Yi Tseng): Implement this method.
   absl::ReaderMutexLock l(&node_lock_);
   return ::util::OkStatus();

--- a/stratum/hal/lib/dummy/dummy_node.h
+++ b/stratum/hal/lib/dummy/dummy_node.h
@@ -87,7 +87,7 @@ class DummyNode {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) SHARED_LOCKS_REQUIRED(chassis_lock)
+      std::vector<::util::Status>* details, absl::Time deadline) SHARED_LOCKS_REQUIRED(chassis_lock)
       LOCKS_EXCLUDED(node_lock_);
 
   // Register/Unregister a packet receive writer.

--- a/stratum/hal/lib/dummy/dummy_switch.cc
+++ b/stratum/hal/lib/dummy/dummy_switch.cc
@@ -168,13 +168,13 @@ namespace dummy_switch {
 ::util::Status DummySwitch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   absl::ReaderMutexLock l(&chassis_lock);
   LOG(INFO) << __FUNCTION__;
   uint64 node_id = req.device_id();
   DummyNode* node = nullptr;
   ASSIGN_OR_RETURN(node, GetDummyNode(node_id));
-  return node->ReadForwardingEntries(req, writer, details);
+  return node->ReadForwardingEntries(req, writer, details, deadline);
 }
 
 ::util::Status DummySwitch::RegisterStreamMessageResponseWriter(

--- a/stratum/hal/lib/dummy/dummy_switch.h
+++ b/stratum/hal/lib/dummy/dummy_switch.h
@@ -52,7 +52,7 @@ class DummySwitch : public SwitchInterface {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details)
+      std::vector<::util::Status>* details, absl::Time deadline)
       LOCKS_EXCLUDED(chassis_lock) override;
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -136,13 +136,13 @@ NP4Switch::~NP4Switch() {}
 ::util::Status NP4Switch::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
-  return pi_node->ReadForwardingEntries(req, writer, details);
+  return pi_node->ReadForwardingEntries(req, writer, details, deadline);
 }
 
 ::util::Status NP4Switch::RegisterStreamMessageResponseWriter(

--- a/stratum/hal/lib/np4intel/np4_switch.h
+++ b/stratum/hal/lib/np4intel/np4_switch.h
@@ -47,7 +47,7 @@ class NP4Switch : public SwitchInterface {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details) override;
+      std::vector<::util::Status>* details, absl::Time deadline) override;
   ::util::Status RegisterStreamMessageResponseWriter(
       uint64 node_id,
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -161,7 +161,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
 ::util::Status PINode::ReadForwardingEntries(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
-    std::vector<::util::Status>* details) {
+    std::vector<::util::Status>* details, absl::Time deadline) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
     RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";

--- a/stratum/hal/lib/pi/pi_node.h
+++ b/stratum/hal/lib/pi/pi_node.h
@@ -45,7 +45,7 @@ class PINode final {
   ::util::Status ReadForwardingEntries(
       const ::p4::v1::ReadRequest& req,
       WriterInterface<::p4::v1::ReadResponse>* writer,
-      std::vector<::util::Status>* details);
+      std::vector<::util::Status>* details, absl::Time deadline);
   ::util::Status RegisterStreamMessageResponseWriter(
       std::shared_ptr<WriterInterface<::p4::v1::StreamMessageResponse>> writer)
       LOCKS_EXCLUDED(rx_writer_lock_);

--- a/stratum/testing/tests/bcm_sim_test.cc
+++ b/stratum/testing/tests/bcm_sim_test.cc
@@ -71,7 +71,8 @@ TEST_F(BcmSimTest, TestBasicFunctionality) {
   request.add_entities()->mutable_table_entry();
   request.add_entities()->mutable_action_profile_group();
   request.add_entities()->mutable_action_profile_member();
-  status = bcm_switch_->ReadForwardingEntries(request, &buffer, &details);
+  status = bcm_switch_->ReadForwardingEntries(request, &buffer, &details,
+                                              absl::InfiniteFuture());
   if (!status.ok()) {
     std::string msg = "Failed to read forwarding entries. Details:";
     for (const auto& d : details) {


### PR DESCRIPTION
This PR makes `SwitchInterface::ReadForwardingEntries` deadline aware so that long running requests can be aborted early without handling all entities.

However, while this allows checking for a deadline, I'm not sure if `TryCancel` attempts from the client are covered by this.
The [gRPC error handling guide](https://grpc.io/blog/deadlines/#checking-deadlines) says to check `context->IsCancelled()`, which includes deadline, network errors and cancelations. We could pass this down as a functor?