### PR TITLE
Prevent `GetCounterData` from reading non-existent fields

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -486,13 +486,12 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
     result.mutable_action()->set_action_profile_group_id(selector_group_id);
   }
 
-  // Counter data
+  // Counter data, if applicable.
   uint64 bytes, packets;
-  if (table_data->GetCounterData(&bytes, &packets).ok()) {
-    if (request.has_counter_data()) {
-      result.mutable_counter_data()->set_byte_count(bytes);
-      result.mutable_counter_data()->set_packet_count(packets);
-    }
+  if (request.has_counter_data() &&
+      table_data->GetCounterData(&bytes, &packets).ok()) {
+    result.mutable_counter_data()->set_byte_count(bytes);
+    result.mutable_counter_data()->set_packet_count(packets);
   }
 
   return result;


### PR DESCRIPTION
This change adapts the `GetCounterData` function to only read the byte or packet counter data field if they actually exist. The SDE should not print spurious error logs for this anymore.

Fixes #668