### PR TITLE
Add `last_change` to `OperStatus` message

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -995,7 +995,7 @@ void BfChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
   // the memory allocated to this event object once the event is handled by
   // the GnmiPublisher.
   if (!gnmi_event_writer_->Write(GnmiEventPtr(
-          new PortOperStateChangedEvent(node_id, port_id, new_state)))) {
+          new PortOperStateChangedEvent(node_id, port_id, new_state, 0)))) {
     // Remove WriterInterface if it is no longer operational.
     gnmi_event_writer_.reset();
   }

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -1878,7 +1878,7 @@ void BcmChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
   // the memory allocated to this event object once the event is handled by
   // the GnmiPublisher.
   if (!gnmi_event_writer_->Write(GnmiEventPtr(
-          new PortOperStateChangedEvent(node_id, port_id, new_state)))) {
+          new PortOperStateChangedEvent(node_id, port_id, new_state, 0)))) {
     // Remove WriterInterface if it is no longer operational.
     gnmi_event_writer_.reset();
   }

--- a/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
@@ -4522,9 +4522,9 @@ TEST_P(BcmChassisManagerTest, GetPortStateAfterConfigPushAndLinkEvent) {
   // WriterInterface for reporting gNMI events.
   auto gnmi_event_writer = std::make_shared<WriterMock<GnmiEventPtr>>();
   GnmiEventPtr link_up(
-      new PortOperStateChangedEvent(kNodeId, kPortId, PORT_STATE_UP));
+      new PortOperStateChangedEvent(kNodeId, kPortId, PORT_STATE_UP, 0));
   GnmiEventPtr link_down(
-      new PortOperStateChangedEvent(kNodeId, kPortId, PORT_STATE_DOWN));
+      new PortOperStateChangedEvent(kNodeId, kPortId, PORT_STATE_DOWN, 0));
 
   // Expectations for the mock objects.
   EXPECT_CALL(*bcm_serdes_db_manager_mock_, Load());
@@ -5201,7 +5201,7 @@ TEST_P(BcmChassisManagerTest, TestSendTransceiverGnmiEvent) {
 
   // Test successful Write() with new state to writer.
   GnmiEventPtr event(
-      new PortOperStateChangedEvent(kNodeId, 1234, PORT_STATE_UP));
+      new PortOperStateChangedEvent(kNodeId, 1234, PORT_STATE_UP, 0));
   EXPECT_CALL(*writer, Write(Matcher<const GnmiEventPtr&>(GnmiEventEq(event))))
       .WillOnce(Return(true));
   SendPortOperStateGnmiEvent(kNodeId, 1234, PORT_STATE_UP);

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -410,7 +410,7 @@ void Bmv2ChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
   // the memory allocated to this event object once the event is handled by
   // the GnmiPublisher.
   if (!gnmi_event_writer_->Write(GnmiEventPtr(
-          new PortOperStateChangedEvent(node_id, port_id, new_state)))) {
+          new PortOperStateChangedEvent(node_id, port_id, new_state, 0)))) {
     // Remove WriterInterface if it is no longer operational.
     gnmi_event_writer_.reset();
   }

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -1106,7 +1106,8 @@ message OpticalTransceiverInfo {
 
 // Wrapper around oper state of a port.
 message OperStatus {
-  PortState state = 1;  // required
+  PortState state = 1;           // required
+  uint64 time_last_changed = 2;  // optional
 }
 
 // Wrapper around loopback state of a port.

--- a/stratum/hal/lib/common/gnmi_events.h
+++ b/stratum/hal/lib/common/gnmi_events.h
@@ -161,14 +161,19 @@ class PortOperStateChangedEvent
     : public PerPortGnmiEvent<PortOperStateChangedEvent> {
  public:
   PortOperStateChangedEvent(uint64 node_id, uint32 port_id,
-                            const PortState& new_state)
-      : PerPortGnmiEvent(node_id, port_id), new_state_(new_state) {}
+                            const PortState& new_state,
+                            uint64 time_last_changed)
+      : PerPortGnmiEvent(node_id, port_id),
+        new_state_(new_state),
+        time_last_changed_(time_last_changed) {}
   ~PortOperStateChangedEvent() override {}
 
   PortState GetNewState() const { return new_state_; }
+  uint64 GetTimeLastChanged() const { return time_last_changed_; }
 
  private:
   PortState new_state_;
+  uint64 time_last_changed_;
 };
 
 // A Port's Administrative State Has Changed event.

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -914,11 +914,20 @@ void SetUpRoot(TreeNode* node, YangParseTree* tree) {
 
 ////////////////////////////////////////////////////////////////////////////////
 // /interfaces/interface[name=<name>]/state/last-change
-void SetUpInterfacesInterfaceStateLastChange(TreeNode* node) {
-  auto poll_functor = UnsupportedFunc();
-  auto on_change_functor = UnsupportedFunc();
+void SetUpInterfacesInterfaceStateLastChange(uint64 node_id, uint32 port_id,
+                                             TreeNode* node,
+                                             YangParseTree* tree) {
+  auto poll_functor =
+      GetOnPollFunctor(node_id, port_id, tree, &DataResponse::oper_status,
+                       &DataResponse::has_oper_status,
+                       &DataRequest::Request::mutable_oper_status,
+                       &OperStatus::time_last_changed);
+  auto on_change_functor = GetOnChangeFunctor(
+      node_id, port_id, &PortOperStateChangedEvent::GetTimeLastChanged);
+  auto register_functor = RegisterFunc<PortOperStateChangedEvent>();
   node->SetOnTimerHandler(poll_functor)
       ->SetOnPollHandler(poll_functor)
+      ->SetOnChangeRegistration(register_functor)
       ->SetOnChangeHandler(on_change_functor);
 }
 
@@ -3329,7 +3338,7 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   // No need to lock the mutex - it is locked by method calling this one.
   TreeNode* node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("last-change")());
-  SetUpInterfacesInterfaceStateLastChange(node);
+  SetUpInterfacesInterfaceStateLastChange(node_id, port_id, node, tree);
 
   node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("ifindex")());

--- a/stratum/hal/lib/dummy/dummy_node.cc
+++ b/stratum/hal/lib/dummy/dummy_node.cc
@@ -117,8 +117,8 @@ bool DummyNode::DummyNodeEventWriter::Write(const DummyNodeEventPtr& msg) {
   GnmiEvent* event = nullptr;
   switch (state_update.response_case()) {
     case DataResponse::kOperStatus:
-      event = new PortOperStateChangedEvent(node_id, port_id,
-                                            state_update.oper_status().state());
+      event = new PortOperStateChangedEvent(
+          node_id, port_id, state_update.oper_status().state(), 0);
       port_state.oper_status = state_update.oper_status();
       break;
     case DataResponse::kAdminStatus:

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -336,7 +336,7 @@ void NP4ChassisManager::SendPortOperStateGnmiEvent(uint64 node_id,
   // the memory allocated to this event object once the event is handled by
   // the GnmiPublisher.
   if (!gnmi_event_writer_->Write(GnmiEventPtr(
-          new PortOperStateChangedEvent(node_id, port_id, new_state)))) {
+          new PortOperStateChangedEvent(node_id, port_id, new_state, 0)))) {
     // Remove WriterInterface if it is no longer operational.
     gnmi_event_writer_.reset();
   }


### PR DESCRIPTION
This PR adds the `last_change` field to the common `OperStatus` message. It is optional and contains the time stamp when the port state last transitioned. This change does not contain the actual `SwitchInterface` implementations for any of the platforms. We will add them in later PRs on a case-by-case basis.