### PR TITLE
Make calling `delete` on non-virtual dtor an error

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -53,6 +53,7 @@ STRATUM_DISABLED_COMPILER_WARNINGS = STRATUM_DISABLED_COMPILER_WARNINGS_COMMON +
 
 # Compiler warnings that are threated as errors.
 STRATUM_COMPILER_ERRORS_COMMON = [
+    "-Werror=delete-non-virtual-dtor",
     "-Werror=ignored-attributes",
     "-Werror=uninitialized",
     "-Werror=unreachable-code",

--- a/stratum/hal/lib/phal/tai/tai_interface.h
+++ b/stratum/hal/lib/phal/tai/tai_interface.h
@@ -19,6 +19,8 @@ namespace tai {
 // components such as module, network interface, and host interface.
 class TaiInterface {
  public:
+  virtual ~TaiInterface() {}
+
   // Initialize the TAI interface.
   virtual util::Status Initialize() = 0;
 


### PR DESCRIPTION
This PR adds the `-Wdelete-non-virtual-dtor` compiler flag to the common error flags, thus failing any code in violation.

Only the `TaiInterface` needed to be fixed.