### PR TITLE
Make shifting a negative integer an error

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -55,6 +55,7 @@ STRATUM_DISABLED_COMPILER_WARNINGS = STRATUM_DISABLED_COMPILER_WARNINGS_COMMON +
 STRATUM_COMPILER_ERRORS_COMMON = [
     "-Werror=delete-non-virtual-dtor",
     "-Werror=ignored-attributes",
+    "-Werror=shift-negative-value",
     "-Werror=uninitialized",
     "-Werror=unreachable-code",
 ]

--- a/stratum/hal/lib/phal/buffer_tools.h
+++ b/stratum/hal/lib/phal/buffer_tools.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_BUFFER_TOOLS_H_
 #define STRATUM_HAL_LIB_PHAL_BUFFER_TOOLS_H_
 
@@ -45,7 +44,7 @@ static T ParseSignedIntegralBytes(const char* source, size_t num_bytes,
   if (num_bytes < sizeof(T) && value & (1 << (8 * num_bytes - 1))) {
     // This is an incomplete 1's complement value. Prepend 1's
     // up to the length of the type.
-    return value | (~0 << (8 * num_bytes));
+    return value | (~0U << (8 * num_bytes));
   } else {
     return value;
   }


### PR DESCRIPTION
This PR adds the `-Wshift-negative-value` compiler flag to the common error flags, thus failing any code in violation.