### PR TITLE
Make ignored function qualifiers an error

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -55,6 +55,7 @@ STRATUM_DISABLED_COMPILER_WARNINGS = STRATUM_DISABLED_COMPILER_WARNINGS_COMMON +
 STRATUM_COMPILER_ERRORS_COMMON = [
     "-Werror=delete-non-virtual-dtor",
     "-Werror=ignored-attributes",
+    "-Werror=ignored-qualifiers",
     "-Werror=shift-negative-value",
     "-Werror=uninitialized",
     "-Werror=unreachable-code",

--- a/stratum/glue/status/status_test.cc
+++ b/stratum/glue/status/status_test.cc
@@ -50,7 +50,7 @@ static const util::ErrorSpace* OkSpace() {
   return ::util::Status::OK.error_space();
 }
 
-static const int CanonicalCode(const ::util::Status& s) {
+static int CanonicalCode(const ::util::Status& s) {
   return s.ToCanonical().error_code();
 }
 


### PR DESCRIPTION
This PR adds the `-Wignored-qualifiers` compiler flag to the common error flags, thus failing any code in violation.