### PR TITLE
Add SKU info to `GetBfChipType` and log on Stratum startup

### DIFF
--- a/stratum/hal/bin/barefoot/main_bfrt.cc
+++ b/stratum/hal/bin/barefoot/main_bfrt.cc
@@ -48,6 +48,7 @@ namespace barefoot {
       is_sw_model ? OPERATION_MODE_SIM : OPERATION_MODE_STANDALONE;
   VLOG(1) << "Detected is_sw_model: " << is_sw_model;
   VLOG(1) << "SDE version: " << bf_sde_wrapper->GetSdeVersion();
+  VLOG(1) << "Switch SKU: " << bf_sde_wrapper->GetBfChipType(device_id);
 
   auto bfrt_table_manager =
       BfrtTableManager::CreateInstance(mode, bf_sde_wrapper, device_id);


### PR DESCRIPTION
Logging additional information about the switch and its chip on startup can help us debugging problems in the future.

Example:

```
I20210526 21:10:10.509681   462 main_bfrt.cc:51] Switch SKU: TOFINO_32Q, revision B0, chip_id 0x3048493364367285
```