### PR TITLE
Fix unreachable code error in `Uint32ToLeByteStream`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
@@ -23,7 +23,7 @@ namespace barefoot {
 namespace {
 // Helper function to convert a uint32 to a little-endian byte string.
 std::string Uint32ToLeByteStream(uint32 val) {
-  uint32 tmp = (htonl(1) == 1) ? __builtin_bswap32(val) : val;
+  uint32 tmp = (htonl(1) == (1)) ? __builtin_bswap32(val) : val;
   std::string bytes = "";
   bytes.assign(reinterpret_cast<char*>(&tmp), sizeof(uint32));
   return bytes;


### PR DESCRIPTION
Code handling little and big endianess will, by design, have unreachable code. This change adds parentheses to silence the compiler warning.