### PR TITLE
Create port status event timestamp inside `BfSdeWrapper` callback

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -1083,12 +1083,14 @@ void BfChassisManager::ReadPortStatusEvents(
       continue;
     }
     // Handle received message.
-    PortStatusEventHandler(event.device, event.port, event.state);
+    PortStatusEventHandler(event.device, event.port, event.state,
+                           event.time_last_changed);
   } while (true);
 }
 
 void BfChassisManager::PortStatusEventHandler(int device, int port,
-                                              PortState new_state) {
+                                              PortState new_state,
+                                              absl::Time time_last_changed) {
   absl::WriterMutexLock l(&chassis_lock);
   // TODO(max): check for shutdown here
   // if (shutdown) {
@@ -1114,7 +1116,8 @@ void BfChassisManager::PortStatusEventHandler(int device, int port,
     return;
   }
   node_id_to_port_id_to_port_state_[*node_id][*port_id] = new_state;
-  node_id_to_port_id_to_time_last_changed_[*node_id][*port_id] = absl::Now();
+  node_id_to_port_id_to_time_last_changed_[*node_id][*port_id] =
+      time_last_changed;
 
   // Notify the managers about the change of port state.
   // Nothing to do for now.

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.h
@@ -171,7 +171,8 @@ class BfChassisManager {
   // used by the SDE. NOTE: This method should never be executed directly from a
   // context which first accesses the internal structures of a class below
   // BfChassisManager as this may result in deadlock.
-  void PortStatusEventHandler(int device, int port, PortState new_state)
+  void PortStatusEventHandler(int device, int port, PortState new_state,
+                              absl::Time time_last_changed)
       LOCKS_EXCLUDED(chassis_lock);
 
   // Thread function for reading port status events from

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -34,6 +34,7 @@ class BfSdeInterface {
     int device;
     int port;
     PortState state;
+    absl::Time time_last_changed;
   };
 
   // SessionInterface is a proxy class for BfRt sessions. Most API calls require

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -374,7 +374,8 @@ class BfSdeWrapper : public BfSdeInterface {
   // Called whenever a port status event is received from SDK. It forwards the
   // port status event to the module who registered a callback by calling
   // RegisterPortStatusEventWriter().
-  ::util::Status OnPortStatusEvent(int device, int dev_port, bool up)
+  ::util::Status OnPortStatusEvent(int device, int dev_port, bool up,
+                                   absl::Time timestamp)
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
   // BfSdeWrapper is neither copyable nor movable.


### PR DESCRIPTION
This makes the timestamp more accurate, opens up the possibility of fetching the value from the SDE, and allows for accurate unit testing.