### PR TITLE
Replace `unit` with `device` in Barefoot code

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -47,8 +47,8 @@ BfChassisManager::BfChassisManager(OperationMode mode,
       xcvr_event_writer_id_(kInvalidWriterId),
       xcvr_event_channel_(nullptr),
       gnmi_event_writer_(nullptr),
-      unit_to_node_id_(),
-      node_id_to_unit_(),
+      device_to_node_id_(),
+      node_id_to_device_(),
       node_id_to_port_id_to_port_state_(),
       node_id_to_port_id_to_time_last_changed_(),
       node_id_to_port_id_to_port_config_(),
@@ -67,8 +67,8 @@ BfChassisManager::BfChassisManager()
       xcvr_event_writer_id_(kInvalidWriterId),
       xcvr_event_channel_(nullptr),
       gnmi_event_writer_(nullptr),
-      unit_to_node_id_(),
-      node_id_to_unit_(),
+      device_to_node_id_(),
+      node_id_to_device_(),
       node_id_to_port_id_to_port_state_(),
       node_id_to_port_id_to_time_last_changed_(),
       node_id_to_port_id_to_port_config_(),
@@ -83,7 +83,7 @@ BfChassisManager::BfChassisManager()
 BfChassisManager::~BfChassisManager() = default;
 
 ::util::Status BfChassisManager::AddPortHelper(
-    uint64 node_id, int unit, uint32 sdk_port_id,
+    uint64 node_id, int device, uint32 sdk_port_id,
     const SingletonPort& singleton_port /* desired config */,
     /* out */ PortConfig* config /* new config */) {
   config->admin_state = ADMIN_STATE_UNKNOWN;
@@ -104,20 +104,21 @@ BfChassisManager::~BfChassisManager() = default;
 
   LOG(INFO) << "Adding port " << port_id << " in node " << node_id
             << " (SDK Port " << sdk_port_id << ").";
-  RETURN_IF_ERROR(bf_sde_interface_->AddPort(
-      unit, sdk_port_id, singleton_port.speed_bps(), config_params.fec_mode()));
+  RETURN_IF_ERROR(bf_sde_interface_->AddPort(device, sdk_port_id,
+                                             singleton_port.speed_bps(),
+                                             config_params.fec_mode()));
   config->speed_bps = singleton_port.speed_bps();
   config->admin_state = ADMIN_STATE_DISABLED;
   config->fec_mode = config_params.fec_mode();
 
   if (config_params.mtu() != 0) {
-    RETURN_IF_ERROR(
-        bf_sde_interface_->SetPortMtu(unit, sdk_port_id, config_params.mtu()));
+    RETURN_IF_ERROR(bf_sde_interface_->SetPortMtu(device, sdk_port_id,
+                                                  config_params.mtu()));
   }
   config->mtu = config_params.mtu();
   if (config_params.autoneg() != TRI_STATE_UNKNOWN) {
     RETURN_IF_ERROR(bf_sde_interface_->SetPortAutonegPolicy(
-        unit, sdk_port_id, config_params.autoneg()));
+        device, sdk_port_id, config_params.autoneg()));
   }
   config->autoneg = config_params.autoneg();
 
@@ -126,25 +127,25 @@ BfChassisManager::~BfChassisManager() = default;
               << config_params.loopback_mode() << " (SDK Port " << sdk_port_id
               << ").";
     RETURN_IF_ERROR(bf_sde_interface_->SetPortLoopbackMode(
-        unit, sdk_port_id, config_params.loopback_mode()));
+        device, sdk_port_id, config_params.loopback_mode()));
   }
   config->loopback_mode = config_params.loopback_mode();
 
   if (config_params.admin_state() == ADMIN_STATE_ENABLED) {
     LOG(INFO) << "Enabling port " << port_id << " in node " << node_id
               << " (SDK Port " << sdk_port_id << ").";
-    RETURN_IF_ERROR(bf_sde_interface_->EnablePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(bf_sde_interface_->EnablePort(device, sdk_port_id));
     config->admin_state = ADMIN_STATE_ENABLED;
   }
 
-  RETURN_IF_ERROR(
-      bf_sde_interface_->EnablePortShaping(unit, sdk_port_id, TRI_STATE_FALSE));
+  RETURN_IF_ERROR(bf_sde_interface_->EnablePortShaping(device, sdk_port_id,
+                                                       TRI_STATE_FALSE));
 
   return ::util::OkStatus();
 }
 
 ::util::Status BfChassisManager::UpdatePortHelper(
-    uint64 node_id, int unit, uint32 sdk_port_id,
+    uint64 node_id, int device, uint32 sdk_port_id,
     const SingletonPort& singleton_port /* desired config */,
     const PortConfig& config_old /* current config */,
     /* out */ PortConfig* config /* new config */) {
@@ -152,7 +153,7 @@ BfChassisManager::~BfChassisManager() = default;
   // SingletonPort ID is the SDN/Stratum port ID
   uint32 port_id = singleton_port.id();
 
-  if (!bf_sde_interface_->IsValidPort(unit, sdk_port_id)) {
+  if (!bf_sde_interface_->IsValidPort(device, sdk_port_id)) {
     config->admin_state = ADMIN_STATE_UNKNOWN;
     config->speed_bps.reset();
     config->fec_mode.reset();
@@ -163,11 +164,11 @@ BfChassisManager::~BfChassisManager() = default;
 
   const auto& config_params = singleton_port.config_params();
   if (singleton_port.speed_bps() != config_old.speed_bps) {
-    RETURN_IF_ERROR(bf_sde_interface_->DisablePort(unit, sdk_port_id));
-    RETURN_IF_ERROR(bf_sde_interface_->DeletePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(bf_sde_interface_->DisablePort(device, sdk_port_id));
+    RETURN_IF_ERROR(bf_sde_interface_->DeletePort(device, sdk_port_id));
 
     ::util::Status status =
-        AddPortHelper(node_id, unit, sdk_port_id, singleton_port, config);
+        AddPortHelper(node_id, device, sdk_port_id, singleton_port, config);
     if (status.ok()) {
       return ::util::OkStatus();
     } else {
@@ -184,7 +185,7 @@ BfChassisManager::~BfChassisManager() = default;
         port_old.mutable_config_params()->set_mtu(*config_old.mtu);
       if (config_old.fec_mode)
         port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
-      AddPortHelper(node_id, unit, sdk_port_id, port_old, config);
+      AddPortHelper(node_id, device, sdk_port_id, port_old, config);
       RETURN_ERROR(ERR_INVALID_PARAM)
           << "Could not add port " << port_id << " with new speed "
           << singleton_port.speed_bps() << " to BF SDE"
@@ -217,8 +218,8 @@ BfChassisManager::~BfChassisManager() = default;
             << " changed"
             << " (SDK Port " << sdk_port_id << ").";
     config->mtu.reset();
-    RETURN_IF_ERROR(
-        bf_sde_interface_->SetPortMtu(unit, sdk_port_id, config_params.mtu()));
+    RETURN_IF_ERROR(bf_sde_interface_->SetPortMtu(device, sdk_port_id,
+                                                  config_params.mtu()));
     config->mtu = config_params.mtu();
     config_changed = true;
   }
@@ -228,19 +229,19 @@ BfChassisManager::~BfChassisManager() = default;
             << " (SDK Port " << sdk_port_id << ").";
     config->autoneg.reset();
     RETURN_IF_ERROR(bf_sde_interface_->SetPortAutonegPolicy(
-        unit, sdk_port_id, config_params.autoneg()));
+        device, sdk_port_id, config_params.autoneg()));
     config->autoneg = config_params.autoneg();
     config_changed = true;
   }
   if (config_params.loopback_mode() != config_old.loopback_mode) {
     config->loopback_mode.reset();
     RETURN_IF_ERROR(bf_sde_interface_->SetPortLoopbackMode(
-        unit, sdk_port_id, config_params.loopback_mode()));
+        device, sdk_port_id, config_params.loopback_mode()));
     config->loopback_mode = config_params.loopback_mode();
     config_changed = true;
   }
   if (config_old.shaping_config) {
-    RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, unit, sdk_port_id,
+    RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, device, sdk_port_id,
                                            *config_old.shaping_config));
     config_changed = true;
   }
@@ -265,13 +266,13 @@ BfChassisManager::~BfChassisManager() = default;
   if (need_disable) {
     LOG(INFO) << "Disabling port " << port_id << " in node " << node_id
               << " (SDK Port " << sdk_port_id << ").";
-    RETURN_IF_ERROR(bf_sde_interface_->DisablePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(bf_sde_interface_->DisablePort(device, sdk_port_id));
     config->admin_state = ADMIN_STATE_DISABLED;
   }
   if (need_enable) {
     LOG(INFO) << "Enabling port " << port_id << " in node " << node_id
               << " (SDK Port " << sdk_port_id << ").";
-    RETURN_IF_ERROR(bf_sde_interface_->EnablePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(bf_sde_interface_->EnablePort(device, sdk_port_id));
     config->admin_state = ADMIN_STATE_ENABLED;
   }
 
@@ -283,8 +284,8 @@ BfChassisManager::~BfChassisManager() = default;
   if (!initialized_) RETURN_IF_ERROR(RegisterEventWriters());
 
   // new maps
-  std::map<int, uint64> unit_to_node_id;
-  std::map<uint64, int> node_id_to_unit;
+  std::map<int, uint64> device_to_node_id;
+  std::map<uint64, int> node_id_to_device;
   std::map<uint64, std::map<uint32, PortState>>
       node_id_to_port_id_to_port_state;
   std::map<uint64, std::map<uint32, absl::Time>>
@@ -300,11 +301,11 @@ BfChassisManager::~BfChassisManager() = default;
   std::map<PortKey, HwState> xcvr_port_key_to_xcvr_state;
 
   {
-    int unit = 0;
+    int device = 0;
     for (const auto& node : config.nodes()) {
-      unit_to_node_id[unit] = node.id();
-      node_id_to_unit[node.id()] = unit;
-      unit++;
+      device_to_node_id[device] = node.id();
+      node_id_to_device[node.id()] = device;
+      device++;
     }
   }
 
@@ -312,8 +313,8 @@ BfChassisManager::~BfChassisManager() = default;
     uint32 port_id = singleton_port.id();
     uint64 node_id = singleton_port.node();
 
-    auto* unit = gtl::FindOrNull(node_id_to_unit, node_id);
-    if (unit == nullptr) {
+    auto* device = gtl::FindOrNull(node_id_to_device, node_id);
+    if (device == nullptr) {
       RETURN_ERROR(ERR_INVALID_PARAM)
           << "Invalid ChassisConfig, unknown node id " << node_id
           << " for port " << port_id << ".";
@@ -329,7 +330,7 @@ BfChassisManager::~BfChassisManager() = default;
 
     // Translate the logical SDN port to SDK port (BF device port ID)
     ASSIGN_OR_RETURN(uint32 sdk_port, bf_sde_interface_->GetPortIdFromPortKey(
-                                          *unit, singleton_port_key));
+                                          *device, singleton_port_key));
     node_id_to_port_id_to_sdk_port_id[node_id][port_id] = sdk_port;
     node_id_to_sdk_port_id_to_port_id[node_id][sdk_port] = port_id;
 
@@ -341,7 +342,7 @@ BfChassisManager::~BfChassisManager() = default;
     uint32 port_id = singleton_port.id();
     uint64 node_id = singleton_port.node();
     // we checked that node_id was valid in the previous loop
-    auto unit = node_id_to_unit[node_id];
+    auto device = node_id_to_device[node_id];
 
     // TODO(antonin): we currently ignore slot
     // Stratum requires slot and port to be set. We use port and channel to
@@ -360,17 +361,17 @@ BfChassisManager::~BfChassisManager() = default;
       // if anything fails, config.admin_state will be set to
       // ADMIN_STATE_UNKNOWN (invalid)
       RETURN_IF_ERROR(
-          AddPortHelper(node_id, unit, sdk_port_id, singleton_port, &config));
+          AddPortHelper(node_id, device, sdk_port_id, singleton_port, &config));
     } else {  // port already exists, config may have changed
       if (config_old->admin_state == ADMIN_STATE_UNKNOWN) {
         // something is wrong with the port, we make sure the port is deleted
         // first (and ignore the error status if there is one), then add the
         // port again.
-        if (bf_sde_interface_->IsValidPort(unit, sdk_port_id)) {
-          bf_sde_interface_->DeletePort(unit, sdk_port_id);
+        if (bf_sde_interface_->IsValidPort(device, sdk_port_id)) {
+          bf_sde_interface_->DeletePort(device, sdk_port_id);
         }
-        RETURN_IF_ERROR(
-            AddPortHelper(node_id, unit, sdk_port_id, singleton_port, &config));
+        RETURN_IF_ERROR(AddPortHelper(node_id, device, sdk_port_id,
+                                      singleton_port, &config));
         continue;
       }
 
@@ -386,7 +387,7 @@ BfChassisManager::~BfChassisManager() = default;
 
       // if anything fails, config.admin_state will be set to
       // ADMIN_STATE_UNKNOWN (invalid)
-      RETURN_IF_ERROR(UpdatePortHelper(node_id, unit, sdk_port_id,
+      RETURN_IF_ERROR(UpdatePortHelper(node_id, device, sdk_port_id,
                                        singleton_port, *config_old, &config));
     }
   }
@@ -401,8 +402,8 @@ BfChassisManager::~BfChassisManager() = default;
       const TofinoConfig::BfPortShapingConfig& port_id_to_shaping_config =
           key.second;
       CHECK_RETURN_IF_FALSE(node_id_to_port_id_to_sdk_port_id.count(node_id));
-      CHECK_RETURN_IF_FALSE(node_id_to_unit.count(node_id));
-      int unit = node_id_to_unit[node_id];
+      CHECK_RETURN_IF_FALSE(node_id_to_device.count(node_id));
+      int device = node_id_to_device[node_id];
       for (const auto& e :
            port_id_to_shaping_config.per_port_shaping_configs()) {
         const uint32 port_id = e.first;
@@ -412,8 +413,8 @@ BfChassisManager::~BfChassisManager() = default;
             node_id_to_port_id_to_sdk_port_id[node_id].count(port_id));
         const uint32 sdk_port_id =
             node_id_to_port_id_to_sdk_port_id[node_id][port_id];
-        RETURN_IF_ERROR(
-            ApplyPortShapingConfig(node_id, unit, sdk_port_id, shaping_config));
+        RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, device, sdk_port_id,
+                                               shaping_config));
         node_id_to_port_id_to_port_config[node_id][port_id].shaping_config =
             shaping_config;
       }
@@ -429,8 +430,8 @@ BfChassisManager::~BfChassisManager() = default;
       const auto& deflect_config = key.second;
       for (const auto& drop_target : deflect_config.drop_targets()) {
         CHECK_RETURN_IF_FALSE(node_id_to_port_id_to_sdk_port_id.count(node_id));
-        CHECK_RETURN_IF_FALSE(node_id_to_unit.count(node_id));
-        const int unit = node_id_to_unit[node_id];
+        CHECK_RETURN_IF_FALSE(node_id_to_device.count(node_id));
+        const int device = node_id_to_device[node_id];
         uint32 sdk_port_id;
         switch (drop_target.port_type_case()) {
           case TofinoConfig::DeflectOnPacketDropConfig::DropTarget::kPort: {
@@ -450,7 +451,7 @@ BfChassisManager::~BfChassisManager() = default;
                 << drop_target.ShortDebugString();
         }
         RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(
-            unit, sdk_port_id, drop_target.queue()));
+            device, sdk_port_id, drop_target.queue()));
         LOG(INFO) << "Configured deflect-on-drop to SDK port " << sdk_port_id
                   << " in node " << node_id << ".";
       }
@@ -468,18 +469,18 @@ BfChassisManager::~BfChassisManager() = default;
           node_id_to_port_id_to_port_config[node_id].count(port_id) > 0) {
         continue;
       }
-      auto unit = node_id_to_unit_[node_id];
+      auto device = node_id_to_device_[node_id];
       uint32 sdk_port_id = node_id_to_port_id_to_sdk_port_id_[node_id][port_id];
       // remove ports which are no longer present in the ChassisConfig
       // TODO(bocon): Collect these errors and keep trying to remove old ports
       LOG(INFO) << "Deleting port " << port_id << " in node " << node_id
                 << " (SDK port " << sdk_port_id << ").";
-      RETURN_IF_ERROR(bf_sde_interface_->DeletePort(unit, sdk_port_id));
+      RETURN_IF_ERROR(bf_sde_interface_->DeletePort(device, sdk_port_id));
     }
   }
 
-  unit_to_node_id_ = unit_to_node_id;
-  node_id_to_unit_ = node_id_to_unit;
+  device_to_node_id_ = device_to_node_id;
+  node_id_to_device_ = node_id_to_device;
   node_id_to_port_id_to_port_state_ = node_id_to_port_id_to_port_state;
   node_id_to_port_id_to_time_last_changed_ =
       node_id_to_port_id_to_time_last_changed;
@@ -496,21 +497,21 @@ BfChassisManager::~BfChassisManager() = default;
 }
 
 ::util::Status BfChassisManager::ApplyPortShapingConfig(
-    uint64 node_id, int unit, uint32 sdk_port_id,
+    uint64 node_id, int device, uint32 sdk_port_id,
     const TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig&
         shaping_config) {
   switch (shaping_config.shaping_case()) {
     case TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig::
         kPacketShaping:
       RETURN_IF_ERROR(bf_sde_interface_->SetPortShapingRate(
-          unit, sdk_port_id, true,
+          device, sdk_port_id, true,
           shaping_config.packet_shaping().max_burst_packets(),
           shaping_config.packet_shaping().max_rate_pps()));
       break;
     case TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig::
         kByteShaping:
       RETURN_IF_ERROR(bf_sde_interface_->SetPortShapingRate(
-          unit, sdk_port_id, false,
+          device, sdk_port_id, false,
           shaping_config.byte_shaping().max_burst_bytes(),
           shaping_config.byte_shaping().max_rate_bps()));
       break;
@@ -519,8 +520,8 @@ BfChassisManager::~BfChassisManager() = default;
           << "Invalid port shaping config " << shaping_config.ShortDebugString()
           << ".";
   }
-  RETURN_IF_ERROR(
-      bf_sde_interface_->EnablePortShaping(unit, sdk_port_id, TRI_STATE_TRUE));
+  RETURN_IF_ERROR(bf_sde_interface_->EnablePortShaping(device, sdk_port_id,
+                                                       TRI_STATE_TRUE));
   LOG(INFO) << "Configured port shaping on SDK port " << sdk_port_id
             << " in node " << node_id << ": "
             << shaping_config.ShortDebugString() << ".";
@@ -551,24 +552,24 @@ BfChassisManager::~BfChassisManager() = default;
   }
 
   // Validate Node messages. Make sure there is no two nodes with the same id.
-  std::map<uint64, int> node_id_to_unit;
-  std::map<int, uint64> unit_to_node_id;
+  std::map<uint64, int> node_id_to_device;
+  std::map<int, uint64> device_to_node_id;
   for (const auto& node : config.nodes()) {
     CHECK_RETURN_IF_FALSE(node.slot() > 0)
         << "No positive slot in " << node.ShortDebugString();
     CHECK_RETURN_IF_FALSE(node.id() > 0)
         << "No positive ID in " << node.ShortDebugString();
     CHECK_RETURN_IF_FALSE(
-        gtl::InsertIfNotPresent(&node_id_to_unit, node.id(), -1))
+        gtl::InsertIfNotPresent(&node_id_to_device, node.id(), -1))
         << "The id for Node " << PrintNode(node) << " was already recorded "
         << "for another Node in the config.";
   }
   {
-    int unit = 0;
+    int device = 0;
     for (const auto& node : config.nodes()) {
-      unit_to_node_id[unit] = node.id();
-      node_id_to_unit[node.id()] = unit;
-      ++unit;
+      device_to_node_id[device] = node.id();
+      node_id_to_device[node.id()] = device;
+      ++device;
     }
   }
 
@@ -605,7 +606,7 @@ BfChassisManager::~BfChassisManager() = default;
     singleton_port_keys.insert(singleton_port_key);
     CHECK_RETURN_IF_FALSE(singleton_port.node() > 0)
         << "No valid node ID in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(node_id_to_unit.count(singleton_port.node()))
+    CHECK_RETURN_IF_FALSE(node_id_to_device.count(singleton_port.node()))
         << "Node ID " << singleton_port.node() << " given for SingletonPort "
         << PrintSingletonPort(singleton_port)
         << " has not been given to any Node in the config.";
@@ -630,11 +631,11 @@ BfChassisManager::~BfChassisManager() = default;
         singleton_port_key;
 
     // Make sure that the port exists by getting the SDK port ID.
-    const int* unit = gtl::FindOrNull(node_id_to_unit, node_id);
-    CHECK_RETURN_IF_FALSE(unit != nullptr)
+    const int* device = gtl::FindOrNull(node_id_to_device, node_id);
+    CHECK_RETURN_IF_FALSE(device != nullptr)
         << "Node " << node_id << " not found for port " << port_id << ".";
     RETURN_IF_ERROR(
-        bf_sde_interface_->GetPortIdFromPortKey(*unit, singleton_port_key)
+        bf_sde_interface_->GetPortIdFromPortKey(*device, singleton_port_key)
             .status());
   }
 
@@ -649,10 +650,10 @@ BfChassisManager::~BfChassisManager() = default;
           << "needs to be rebooted to finish config push.";
     }
 
-    if (node_id_to_unit != node_id_to_unit_) {
+    if (node_id_to_device != node_id_to_device_) {
       RETURN_ERROR(ERR_REBOOT_REQUIRED)
           << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in node_id_to_unit. The stack "
+          << "pushed config requires a change in node_id_to_device. The stack "
           << "needs to be rebooted to finish config push.";
     }
   }
@@ -842,7 +843,7 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(auto unit, GetUnitFromNodeId(node_id));
+  ASSIGN_OR_RETURN(auto device, GetDeviceFromNodeId(node_id));
 
   auto* port_id_to_port_state =
       gtl::FindOrNull(node_id_to_port_id_to_port_state_, node_id);
@@ -861,7 +862,7 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
             << ".";
   ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
   ASSIGN_OR_RETURN(auto port_state,
-                   bf_sde_interface_->GetPortState(unit, sdk_port_id));
+                   bf_sde_interface_->GetPortState(device, sdk_port_id));
   LOG(INFO) << "State of port " << port_id << " in node " << node_id
             << " (SDK port " << sdk_port_id
             << "): " << PrintPortState(port_state);
@@ -886,24 +887,24 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(auto unit, GetUnitFromNodeId(node_id));
+  ASSIGN_OR_RETURN(auto device, GetDeviceFromNodeId(node_id));
   ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
-  return bf_sde_interface_->GetPortCounters(unit, sdk_port_id, counters);
+  return bf_sde_interface_->GetPortCounters(device, sdk_port_id, counters);
 }
 
-::util::StatusOr<std::map<uint64, int>> BfChassisManager::GetNodeIdToUnitMap()
+::util::StatusOr<std::map<uint64, int>> BfChassisManager::GetNodeIdToDeviceMap()
     const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  return node_id_to_unit_;
+  return node_id_to_device_;
 }
 
 ::util::Status BfChassisManager::ReplayPortsConfig(uint64 node_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(auto unit, GetUnitFromNodeId(node_id));
+  ASSIGN_OR_RETURN(auto device, GetDeviceFromNodeId(node_id));
 
   for (auto& p : node_id_to_port_id_to_port_state_[node_id])
     p.second = PORT_STATE_UNKNOWN;
@@ -914,7 +915,7 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
   LOG(INFO) << "Replaying ports for node " << node_id << ".";
 
-  auto replay_one_port = [node_id, unit, this](
+  auto replay_one_port = [node_id, device, this](
                              uint32 port_id, const PortConfig& config,
                              PortConfig* config_new) -> ::util::Status {
     VLOG(1) << "Replaying port " << port_id << " in node " << node_id << ".";
@@ -938,36 +939,36 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
     ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
     RETURN_IF_ERROR(bf_sde_interface_->AddPort(
-        unit, sdk_port_id, *config.speed_bps, *config.fec_mode));
+        device, sdk_port_id, *config.speed_bps, *config.fec_mode));
     config_new->speed_bps = *config.speed_bps;
     config_new->admin_state = ADMIN_STATE_DISABLED;
     config_new->fec_mode = *config.fec_mode;
 
     if (config.mtu) {
       RETURN_IF_ERROR(
-          bf_sde_interface_->SetPortMtu(unit, sdk_port_id, *config.mtu));
+          bf_sde_interface_->SetPortMtu(device, sdk_port_id, *config.mtu));
       config_new->mtu = *config.mtu;
     }
     if (config.autoneg) {
-      RETURN_IF_ERROR(bf_sde_interface_->SetPortAutonegPolicy(unit, sdk_port_id,
-                                                              *config.autoneg));
+      RETURN_IF_ERROR(bf_sde_interface_->SetPortAutonegPolicy(
+          device, sdk_port_id, *config.autoneg));
       config_new->autoneg = *config.autoneg;
     }
     if (config.loopback_mode) {
       RETURN_IF_ERROR(bf_sde_interface_->SetPortLoopbackMode(
-          unit, sdk_port_id, *config.loopback_mode));
+          device, sdk_port_id, *config.loopback_mode));
       config_new->loopback_mode = *config.loopback_mode;
     }
 
     if (config.admin_state == ADMIN_STATE_ENABLED) {
       VLOG(1) << "Enabling port " << port_id << " in node " << node_id
               << " (SDK port " << sdk_port_id << ").";
-      RETURN_IF_ERROR(bf_sde_interface_->EnablePort(unit, sdk_port_id));
+      RETURN_IF_ERROR(bf_sde_interface_->EnablePort(device, sdk_port_id));
       config_new->admin_state = ADMIN_STATE_ENABLED;
     }
 
     if (config.shaping_config) {
-      RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, unit, sdk_port_id,
+      RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, device, sdk_port_id,
                                              *config.shaping_config));
       config_new->shaping_config = config.shaping_config;
     }
@@ -1005,7 +1006,7 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     }
 
     RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(
-        unit, sdk_port_id, drop_target.queue()));
+        device, sdk_port_id, drop_target.queue()));
     LOG(INFO) << "Configured deflect on drop target port " << sdk_port_id
               << " in node " << node_id << ".";
   }
@@ -1100,7 +1101,7 @@ void BfChassisManager::PortStatusEventHandler(int device, int port,
   // }
 
   // Update the state.
-  const uint64* node_id = gtl::FindOrNull(unit_to_node_id_, device);
+  const uint64* node_id = gtl::FindOrNull(device_to_node_id_, device);
   if (node_id == nullptr) {
     LOG(ERROR) << "Inconsistent state. Device " << device << " is not known!";
     return;
@@ -1329,21 +1330,21 @@ void BfChassisManager::TransceiverEventHandler(int slot, int port,
   return status;
 }
 
-::util::StatusOr<int> BfChassisManager::GetUnitFromNodeId(
+::util::StatusOr<int> BfChassisManager::GetDeviceFromNodeId(
     uint64 node_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  const int* unit = gtl::FindOrNull(node_id_to_unit_, node_id);
-  CHECK_RETURN_IF_FALSE(unit != nullptr)
+  const int* device = gtl::FindOrNull(node_id_to_device_, node_id);
+  CHECK_RETURN_IF_FALSE(device != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
-  return *unit;
+  return *device;
 }
 
 void BfChassisManager::CleanupInternalState() {
-  unit_to_node_id_.clear();
-  node_id_to_unit_.clear();
+  device_to_node_id_.clear();
+  node_id_to_device_.clear();
   node_id_to_port_id_to_port_state_.clear();
   node_id_to_port_id_to_time_last_changed_.clear();
   node_id_to_port_id_to_port_config_.clear();

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.h
@@ -64,10 +64,10 @@ class BfChassisManager {
                                                FrontPanelPortInfo* fp_port_info)
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToUnitMap() const
+  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToDeviceMap() const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<int> GetUnitFromNodeId(uint64 node_id) const
+  virtual ::util::StatusOr<int> GetDeviceFromNodeId(uint64 node_id) const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
   // Factory function for creating the instance of the class.
@@ -188,19 +188,19 @@ class BfChassisManager {
           reader) LOCKS_EXCLUDED(chassis_lock);
 
   // helper to add / configure / enable a port with BfSdeInterface
-  ::util::Status AddPortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status AddPortHelper(uint64 node_id, int device, uint32 port_id,
                                const SingletonPort& singleton_port,
                                PortConfig* config);
 
   // helper to update port configuration with BfSdeInterface
-  ::util::Status UpdatePortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status UpdatePortHelper(uint64 node_id, int device, uint32 port_id,
                                   const SingletonPort& singleton_port,
                                   const PortConfig& config_old,
                                   PortConfig* config);
 
   // Helper to apply a port shaping config to a single port.
   ::util::Status ApplyPortShapingConfig(
-      uint64 node_id, int unit, uint32 sdk_port_id,
+      uint64 node_id, int device, uint32 sdk_port_id,
       const TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig&
           shaping_config);
 
@@ -234,11 +234,11 @@ class BfChassisManager {
   std::shared_ptr<WriterInterface<GnmiEventPtr>> gnmi_event_writer_
       GUARDED_BY(gnmi_event_lock_);
 
-  // Map from unit number to the node ID as specified by the config.
-  std::map<int, uint64> unit_to_node_id_ GUARDED_BY(chassis_lock);
+  // Map from device number to the node ID as specified by the config.
+  std::map<int, uint64> device_to_node_id_ GUARDED_BY(chassis_lock);
 
-  // Map from node ID to unit number.
-  std::map<uint64, int> node_id_to_unit_ GUARDED_BY(chassis_lock);
+  // Map from node ID to device number.
+  std::map<uint64, int> node_id_to_device_ GUARDED_BY(chassis_lock);
 
   // Map from node ID to another map from port ID to PortState representing
   // the state of the singleton port uniquely identified by (node ID, port ID).

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_mock.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_mock.h
@@ -37,9 +37,10 @@ class BfChassisManagerMock : public BfChassisManager {
   MOCK_METHOD3(GetFrontPanelPortInfo,
                ::util::Status(uint64 node_id, uint32 port_id,
                               FrontPanelPortInfo* fp_port_info));
-  MOCK_CONST_METHOD0(GetNodeIdToUnitMap,
+  MOCK_CONST_METHOD0(GetNodeIdToDeviceMap,
                      ::util::StatusOr<std::map<uint64, int>>());
-  MOCK_CONST_METHOD1(GetUnitFromNodeId, ::util::StatusOr<int>(uint64 node_id));
+  MOCK_CONST_METHOD1(GetDeviceFromNodeId,
+                     ::util::StatusOr<int>(uint64 node_id));
 };
 
 }  // namespace barefoot

--- a/stratum/hal/lib/barefoot/bf_switch.h
+++ b/stratum/hal/lib/barefoot/bf_switch.h
@@ -69,7 +69,7 @@ class BfSwitch : public SwitchInterface {
   static std::unique_ptr<BfSwitch> CreateInstance(
       PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
       BfSdeInterface* bf_sde_interface,
-      const std::map<int, pi::PINode*>& unit_to_pi_node);
+      const std::map<int, pi::PINode*>& device_to_pi_node);
 
   // BfSwitch is neither copyable nor movable.
   BfSwitch(const BfSwitch&) = delete;
@@ -82,11 +82,11 @@ class BfSwitch : public SwitchInterface {
   // class.
   BfSwitch(PhalInterface* phal_interface, BfChassisManager* bf_chassis_manager,
            BfSdeInterface* bf_sde_interface,
-           const std::map<int, pi::PINode*>& unit_to_pi_node);
+           const std::map<int, pi::PINode*>& device_to_pi_node);
 
-  // Helper to get PINode pointer from unit number or return error indicating
-  // invalid unit.
-  ::util::StatusOr<pi::PINode*> GetPINodeFromUnit(int unit) const;
+  // Helper to get PINode pointer from device number or return error indicating
+  // invalid device.
+  ::util::StatusOr<pi::PINode*> GetPINodeFromDevice(int device) const;
 
   // Helper to get PINode pointer from node id or return error indicating
   // invalid/unknown/uninitialized node.
@@ -104,11 +104,11 @@ class BfSwitch : public SwitchInterface {
   // per chassis.
   BfChassisManager* bf_chassis_manager_;  // not owned by the class.
 
-  // Map from zero-based unit number corresponding to a node/ASIC to a pointer
+  // Map from zero-based device number corresponding to a node/ASIC to a pointer
   // to PINode which contain all the per-node managers for that node/ASIC. This
   // map is initialized in the constructor and will not change during the
   // lifetime of the class.
-  const std::map<int, pi::PINode*> unit_to_pi_node_;  // pointers not owned.
+  const std::map<int, pi::PINode*> device_to_pi_node_;  // pointers not owned.
 
   // Map from the node ids to to a pointer to PINode which contain all the
   // per-node managers for that node/ASIC. Created everytime a config is pushed.

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -47,7 +47,7 @@ BfrtSwitch::~BfrtSwitch() {}
   RETURN_IF_ERROR(phal_interface_->PushChassisConfig(config));
   RETURN_IF_ERROR(bf_chassis_manager_->PushChassisConfig(config));
   ASSIGN_OR_RETURN(const auto& node_id_to_device_id,
-                   bf_chassis_manager_->GetNodeIdToUnitMap());
+                   bf_chassis_manager_->GetNodeIdToDeviceMap());
   node_id_to_bfrt_node_.clear();
   for (const auto& entry : node_id_to_device_id) {
     uint64 node_id = entry.first;
@@ -78,7 +78,7 @@ BfrtSwitch::~BfrtSwitch() {}
             << "node with ID " << node_id << ".";
 
   ASSIGN_OR_RETURN(const auto& node_id_to_device_id,
-                   bf_chassis_manager_->GetNodeIdToUnitMap());
+                   bf_chassis_manager_->GetNodeIdToDeviceMap());
 
   CHECK_RETURN_IF_FALSE(gtl::ContainsKey(node_id_to_device_id, node_id))
       << "Unable to find device_id number for node " << node_id;
@@ -221,7 +221,7 @@ BfrtSwitch::~BfrtSwitch() {}
       }
       case DataRequest::Request::kNodeInfo: {
         auto device_id =
-            bf_chassis_manager_->GetUnitFromNodeId(req.node_info().node_id());
+            bf_chassis_manager_->GetDeviceFromNodeId(req.node_info().node_id());
         if (!device_id.ok()) {
           status.Update(device_id.status());
         } else {
@@ -276,7 +276,7 @@ std::unique_ptr<BfrtSwitch> BfrtSwitch::CreateInstance(
   BfrtNode* bfrt_node = gtl::FindPtrOrNull(device_id_to_bfrt_node_, device_id);
   if (bfrt_node == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-           << "Unit " << device_id << " is unknown.";
+           << "Device " << device_id << " is unknown.";
   }
   return bfrt_node;
 }


### PR DESCRIPTION
`unit` is a Broadcom specific term and has no established meaning on Tofino, where `device` is used for the same purpose. To reduce cognitive load and prevent unnecessary confusion, we replace the term.

This PR does contain any functional changes.