### PR TITLE
Move BF traffic manager CPU port init in `BfChassisManager`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -1011,6 +1011,10 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
               << " in node " << node_id << ".";
   }
 
+  // Re-configure the CPU port in the traffic manager.
+  ASSIGN_OR_RETURN(auto cpu_port, bf_sde_interface_->GetPcieCpuPort(device));
+  RETURN_IF_ERROR(bf_sde_interface_->SetTmCpuPort(device, cpu_port));
+
   return status;
 }
 

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -453,6 +453,8 @@ TEST_F(BfChassisManagerTest, ReplayPorts) {
     }
   )PROTO";
 
+  constexpr int kCpuPort = 64;
+
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
 
@@ -483,6 +485,10 @@ TEST_F(BfChassisManagerTest, ReplayPorts) {
   EXPECT_CALL(*bf_sde_mock_,
               EnablePortShaping(kDevice, sdkPortId, TRI_STATE_TRUE))
       .Times(AtLeast(1));
+  EXPECT_CALL(*bf_sde_mock_, GetPcieCpuPort(kDevice))
+      .WillRepeatedly(Return(kCpuPort));
+  EXPECT_CALL(*bf_sde_mock_, SetTmCpuPort(kDevice, kCpuPort))
+      .WillRepeatedly(Return(::util::OkStatus()));
 
   EXPECT_OK(ReplayPortsConfig(kNodeId));
 

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -138,14 +138,6 @@ namespace {
   LOG(INFO) << "P4-based forwarding pipeline config pushed successfully to "
             << "node with ID " << node_id << ".";
 
-  ASSIGN_OR_RETURN(const auto& node_id_to_device,
-                   bf_chassis_manager_->GetNodeIdToDeviceMap());
-
-  CHECK_RETURN_IF_FALSE(gtl::ContainsKey(node_id_to_device, node_id))
-      << "Unable to find device number for node " << node_id;
-  int device = gtl::FindOrDie(node_id_to_device, node_id);
-  ASSIGN_OR_RETURN(auto cpu_port, bf_sde_interface_->GetPcieCpuPort(device));
-  RETURN_IF_ERROR(bf_sde_interface_->SetTmCpuPort(device, cpu_port));
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -77,14 +77,6 @@ BfrtSwitch::~BfrtSwitch() {}
   LOG(INFO) << "P4-based forwarding pipeline config pushed successfully to "
             << "node with ID " << node_id << ".";
 
-  ASSIGN_OR_RETURN(const auto& node_id_to_device_id,
-                   bf_chassis_manager_->GetNodeIdToDeviceMap());
-
-  CHECK_RETURN_IF_FALSE(gtl::ContainsKey(node_id_to_device_id, node_id))
-      << "Unable to find device_id number for node " << node_id;
-  int device_id = gtl::FindOrDie(node_id_to_device_id, node_id);
-  ASSIGN_OR_RETURN(auto cpu_port, bf_sde_interface_->GetPcieCpuPort(device_id));
-  RETURN_IF_ERROR(bf_sde_interface_->SetTmCpuPort(device_id, cpu_port));
   return ::util::OkStatus();
 }
 


### PR DESCRIPTION
It has to be re-configured after each pipeline push, for which the ChassisManager already has common logic.