### PR TITLE
Implement `BfrtSwitch::VerifyChassisConfig` and verify on push

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -895,8 +895,10 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 ::util::StatusOr<std::map<uint64, int>> BfChassisManager::GetNodeIdToDeviceMap()
     const {
   if (!initialized_) {
-    return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
+    return MAKE_ERROR(ERR_NOT_INITIALIZED).without_logging()
+           << "Not initialized!";
   }
+
   return node_id_to_device_;
 }
 

--- a/stratum/hal/lib/barefoot/bfrt_switch.h
+++ b/stratum/hal/lib/barefoot/bfrt_switch.h
@@ -99,6 +99,10 @@ class BfrtSwitch : public SwitchInterface {
       uint64 node_id, const ::p4::v1::ForwardingPipelineConfig& config)
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
+  // Internal version of VerifyChassisConfig() which takes no locks.
+  ::util::Status DoVerifyChassisConfig(const ChassisConfig& config)
+      SHARED_LOCKS_REQUIRED(chassis_lock);
+
   // Helper to get BfrtNode pointer from device_id number or return error
   // indicating invalid device_id.
   ::util::StatusOr<BfrtNode*> GetBfrtNodeFromDeviceId(int device_id) const;


### PR DESCRIPTION
This change also disables logging of the `ERR_NOT_INITIALIZED` error in `BfChassisManager::GetNodeIdToDeviceMap`, as it causes a otherwise harmless error log message to be emitted on startup. This is consistent with `BcmChassisManager`.