### PR TITLE
Disable logging of Tofino port maps on startup

### DIFF
--- a/stratum/hal/config/x86-64-accton-wedge100bf-32qs-r0/port_map.json
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-32qs-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-accton-wedge100bf-32qs-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/port_map.json
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-accton-wedge100bf-32x-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-accton-wedge100bf-65x-r0/port_map.json
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-65x-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-accton-wedge100bf-65x-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-delta-ag9064v1-r0/port_map.json
+++ b/stratum/hal/config/x86-64-delta-ag9064v1-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-delta-ag9064v1-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-inventec-d10056-r0/port_map.json
+++ b/stratum/hal/config/x86-64-inventec-d10056-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-inventec-d10056-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 2,

--- a/stratum/hal/config/x86-64-inventec-d10064-r0/port_map.json
+++ b/stratum/hal/config/x86-64-inventec-d10064-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-inventec-d10064-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-inventec-d5254-r0/port_map.json
+++ b/stratum/hal/config/x86-64-inventec-d5254-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-inventec-d5254-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-inventec-d5264q28b-r0/port_map.json
+++ b/stratum/hal/config/x86-64-inventec-d5264q28b-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-inventec-d5264-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-netberg-aurora-610-r0/port_map.json
+++ b/stratum/hal/config/x86-64-netberg-aurora-610-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-netberg-aurora-610-r0",
- "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 2,

--- a/stratum/hal/config/x86-64-netberg-aurora-710-r0/port_map.json
+++ b/stratum/hal/config/x86-64-netberg-aurora-710-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-netberg-aurora-710-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-netberg-aurora-750-r0/port_map.json
+++ b/stratum/hal/config/x86-64-netberg-aurora-750-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-netberg-aurora-750-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,

--- a/stratum/hal/config/x86-64-stordis-bf2556x-1t-r0/port_map.json
+++ b/stratum/hal/config/x86-64-stordis-bf2556x-1t-r0/port_map.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Auto-generated configuration file for bspless support (pltfm_bd_map_mavericks_P0C.h) on x86-64-stordis-bf2556x-1t-r0",
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,
@@ -1351,6 +1352,5 @@
       "mac_block": 32,
       "media_type": "optical"
     }
-  ],
-  "enable_debug_log": 1
+  ]
 }

--- a/stratum/hal/config/x86-64-stordis-bf6064x-t-r0/port_map.json
+++ b/stratum/hal/config/x86-64-stordis-bf6064x-t-r0/port_map.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Configuration file for bspless support on x86-64-stordis-bf6064x-t-r0",
-  "enable_debug_log": 1,
+  "enable_debug_log": 0,
   "board_lane_map_entry": [
     {
       "connector": 1,


### PR DESCRIPTION
The debug logs provide little additional value to the common log reader. If needed the port map files can be inspected directly, or the user can enable logging again without any code change.