### PR TITLE
Bump PI_COMMIT used for stratum-bmv2

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BAZELISK_VERSION=1.8.0
-ARG PI_COMMIT=b2760a818e0b8ade5864604d29b3008a684c6d5f
+ARG PI_COMMIT=74f4a82610b3f0b62453ac510277ab7347975813
 ARG BMV2_COMMIT=6dfd5b41426310eb081fedc8fee05b675f780e31
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-11 main"


### PR DESCRIPTION
To include a fix for packet-out metadata serialization:
https://github.com/p4lang/PI/issues/554
https://github.com/p4lang/PI/pull/555