### PR TITLE
Remove `-bf_sim` flag from Stratum for Tofino

### DIFF
--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -15,7 +15,6 @@ stratum_bf_common_deps = [
     "//stratum/glue:init_google",
     "//stratum/glue:logging",
     "//stratum/hal/lib/common:hal",
-    "//stratum/hal/lib/phal:phal_sim",
     "//stratum/hal/lib/phal",
     "//stratum/lib/security:auth_policy_checker",
     "//stratum/lib/security:credentials_manager",

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -207,7 +207,6 @@ In another terminal window, run Stratum in its own container:
 ```bash
 PLATFORM=barefoot-tofino-model \
 stratum/hal/bin/barefoot/docker/start-stratum-container.sh \
-  -bf_sim \
   -bf_switchd_background=false \
   -enable_onlp=false
 ```
@@ -539,13 +538,12 @@ vendor_config {
 ### Running with BSP or on Tofino model
 
 ```bash
-start-stratum.sh -bf_sim -enable_onlp=false
+start-stratum.sh -enable_onlp=false
 ```
 
-The `-bf_sim` flag tells Stratum not to use the Phal ONLP implementation, but
-`PhalSim`, a "fake" Phal implementation, instead. Use this flag when you are
-using a vendor-provided BSP or running Stratum with the Tofino software model.
-Additionally, the ONLP plugin has to be disabled with `-enable_onlp=false`.
+The `-enable_onlp=false` flag tells Stratum not to use the ONLP PHAL plugin. Use
+this flag when you are using a vendor-provided BSP or running Stratum with the
+Tofino software model.
 
 ### Running the binary in BSP-less mode
 

--- a/tools/mininet/tofino-model.py
+++ b/tools/mininet/tofino-model.py
@@ -113,7 +113,6 @@ class StratumTofinoModel(Switch):
             [
                 STRATUM_BIN,
                 f'-chassis_config_file={self.chassisConfigFile}',
-                '-bf_sim',
                 '-enable_onlp=false',
                 '-bf_switchd_background=false',
                 '-v=2',


### PR DESCRIPTION
Using `PhalSim` for targets without ONLP support is no longer necessary, since we moved to the plugin model. On those platforms ONLP can be disabled by using the `-enable_onlp=false` flag. This change removes the `-bf_sim` flag from Stratum-bf and -bfrt.