### PR TITLE
Retain port state on ChassisConfig push for Stratum-bf

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager_mock.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_mock.h
@@ -33,7 +33,7 @@ class BfChassisManagerMock : public BfChassisManager {
                ::util::StatusOr<absl::Time>(uint64 node_id, uint32 port_id));
   MOCK_METHOD3(GetPortCounters, ::util::Status(uint64 node_id, uint32 port_id,
                                                PortCounters* counters));
-  MOCK_METHOD1(ReplayPortsConfig, ::util::Status(uint64 node_id));
+  MOCK_METHOD1(ReplayChassisConfig, ::util::Status(uint64 node_id));
   MOCK_METHOD3(GetFrontPanelPortInfo,
                ::util::Status(uint64 node_id, uint32 port_id,
                               FrontPanelPortInfo* fp_port_info));

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -226,9 +226,9 @@ class BfChassisManagerTest : public ::testing::Test {
     return ::util::OkStatus();
   }
 
-  ::util::Status ReplayPortsConfig(uint64 node_id) {
+  ::util::Status ReplayChassisConfig(uint64 node_id) {
     absl::WriterMutexLock l(&chassis_lock);
-    return bf_chassis_manager_->ReplayPortsConfig(node_id);
+    return bf_chassis_manager_->ReplayChassisConfig(node_id);
   }
 
   ::util::Status PushBaseChassisConfig() {
@@ -552,7 +552,7 @@ TEST_F(BfChassisManagerTest, ReplayPorts) {
   EXPECT_CALL(*bf_sde_mock_, SetTmCpuPort(kDevice, kCpuPort))
       .WillRepeatedly(Return(::util::OkStatus()));
 
-  EXPECT_OK(ReplayPortsConfig(kNodeId));
+  EXPECT_OK(ReplayChassisConfig(kNodeId));
 
   ASSERT_OK(ShutdownAndTestCleanState());
 }

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -133,7 +133,7 @@ namespace {
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   RETURN_IF_ERROR(pi_node->PushForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(bf_chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(bf_chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config pushed successfully to "
             << "node with ID " << node_id << ".";
@@ -150,7 +150,7 @@ namespace {
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(node_id));
   RETURN_IF_ERROR(pi_node->SaveForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(bf_chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(bf_chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config saved successfully to "
             << "node with ID " << node_id << ".";

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -74,7 +74,7 @@ BfrtSwitch::~BfrtSwitch() {}
   RETURN_IF_ERROR(DoVerifyForwardingPipelineConfig(node_id, config));
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(node_id));
   RETURN_IF_ERROR(bfrt_node->PushForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(bf_chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(bf_chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config pushed successfully to "
             << "node with ID " << node_id << ".";
@@ -87,7 +87,7 @@ BfrtSwitch::~BfrtSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(node_id));
   RETURN_IF_ERROR(bfrt_node->SaveForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(bf_chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(bf_chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config saved successfully to "
             << "node with ID " << node_id << ".";


### PR DESCRIPTION
A `ChassisConfig` push does not necessitate discarding the port state for known ports as it does not reset the ASIC. This PR changes the behavior so we retain the old state. At runtime we should no longer encounter missing ports in the `node_id_to_port_id_to_port_state_` map and can make that an error.