### PR TITLE
Remove flag and env file from Stratum-bf

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -77,10 +77,6 @@ Files: bazel/patches/ygot.patch
 Copyright: 2019-present Open Networking Foundation
 License: Apache-2.0
 
-Files: stratum/hal/bin/barefoot/docker/stratum.flags
-Copyright: 2019-present Open Networking Foundation
-License: Apache-2.0
-
 Files: stratum/hal/bin/bmv2/debian/description
 Copyright: 2019-present Open Networking Foundation
 License: Apache-2.0
@@ -99,10 +95,6 @@ License: Apache-2.0
 
 Files: stratum/hal/bin/np4intel/dummy.json
 Copyright: 2020 Dell EMC
-License: Apache-2.0
-
-Files: stratum/hal/bin/barefoot/deb/stratum.flags
-Copyright: 2019-present Open Networking Foundation
 License: Apache-2.0
 
 Files: stratum/docs/tai/img/* stratum/docs/tai/imgsrc/*

--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -127,8 +127,6 @@ pkg_tar(
 pkg_tar(
     name = "stratum_configs",
     srcs = [
-        "deb/stratum.flags",
-        "deb/stratum_bf.env",
         "//stratum/hal/lib/common:gnmi_caps.pb.txt",
     ],
     mode = "0644",

--- a/stratum/hal/bin/barefoot/deb/start-stratum.sh
+++ b/stratum/hal/bin/barefoot/deb/start-stratum.sh
@@ -2,8 +2,6 @@
 # Copyright 2020-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-FLAG_FILE=${FLAG_FILE:-/etc/stratum/stratum.flags}
-
 # Find kernel module if KDRV_PATH is not set
 if [ -z "$KDRV_PATH" ]; then
     # First, look for kernel-specific module
@@ -60,7 +58,7 @@ fi
 # Set up port map for device
 PORT_MAP="/etc/stratum/$PLATFORM/port_map.json"
 if [ ! -f "$PORT_MAP" ]; then
-    if [[ "$PLATFORM" != 'barefoot-tofino-model' ]]; then 
+    if [[ "$PLATFORM" != 'barefoot-tofino-model' ]]; then
         echo "Cannot find port map file $PORT_MAP for $PLATFORM"
         exit 255
     fi
@@ -89,5 +87,6 @@ mkdir -p /var/run/stratum /var/log/stratum
 exec /usr/bin/stratum_bf \
     -chassis_config_file=/etc/stratum/$PLATFORM/chassis_config.pb.txt \
     -log_dir=/var/log/stratum \
-    -flagfile=$FLAG_FILE \
+    -bf_switchd_cfg=/usr/share/stratum/tofino_skip_p4_no_bsp.conf \
+    -bf_switchd_background=true \
     $@

--- a/stratum/hal/bin/barefoot/deb/stratum.flags
+++ b/stratum/hal/bin/barefoot/deb/stratum.flags
@@ -1,2 +1,0 @@
--bf_switchd_cfg=/usr/share/stratum/tofino_skip_p4_no_bsp.conf
--bf_switchd_background=true

--- a/stratum/hal/bin/barefoot/deb/stratum_bf.env
+++ b/stratum/hal/bin/barefoot/deb/stratum_bf.env
@@ -1,3 +1,0 @@
-# Copyright 2020-present Open Networking Foundation
-# SPDX-License-Identifier: Apache-2.0
-FLAG_FILE=/etc/stratum/stratum.flags

--- a/stratum/hal/bin/barefoot/deb/stratum_bf.service
+++ b/stratum/hal/bin/barefoot/deb/stratum_bf.service
@@ -13,7 +13,6 @@ Restart=on-failure
 WorkingDirectory=/var/run/stratum
 SyslogIdentifier=stratum-bf
 RuntimeDirectory=stratum
-EnvironmentFile=/etc/stratum/stratum_bf.env
 StandardOutput=syslog
 StandardError=syslog
 

--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -33,10 +33,6 @@ if [ -d "/etc/onl" ]; then
               -v /etc/onl:/etc/onl"
 fi
 
-# Mount user configuration.
-if [ -n "$FLAG_FILE" ]; then
-    FLAG_FILE_MOUNT="-v $FLAG_FILE:/etc/stratum/stratum.flags"
-fi
 if [ -n "$CHASSIS_CONFIG" ]; then
     CHASSIS_CONFIG_MOUNT="-v $CHASSIS_CONFIG:/etc/stratum/$PLATFORM/chassis_config.pb.txt"
 fi
@@ -49,7 +45,6 @@ docker run -it --rm --privileged \
     --env PLATFORM=$PLATFORM \
     $DOCKER_NET_OPTS \
     $ONLP_MOUNT \
-    $FLAG_FILE_MOUNT \
     $CHASSIS_CONFIG_MOUNT \
     -v $LOG_DIR:/var/log/stratum \
     $DOCKER_IMAGE:$DOCKER_IMAGE_TAG \


### PR DESCRIPTION
Exposing two ways (flag file and cli args) to do the same thing (configuring Stratum) is bad design. This PR removes the flag file for Stratum-bf. Users can still use the gflags flag file feature, but have to mount the file path into Docker manually.

This change was triggered by #748 where we want to configure the `-bf_switchd_cfg` flag based on the platform. Currently this flag is set by a flag file, which means we can't modify it dynamically. Always overriding it in our own scripts seems like needless duplication.