### PR TITLE
Make QoS queue rates in `ChassisConfig` optional on Tofino

### DIFF
--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -369,8 +369,8 @@ vendor_config {
           key: 1  # singleton port id reference
           value {
             byte_shaping {
-              max_rate_bps: 1000000000 # 1G
-              max_burst_bytes: 16384 # 2x MTU
+              rate_bps: 1000000000 # 1G
+              burst_bytes: 16384 # 2x MTU
             }
           }
         }
@@ -484,12 +484,14 @@ vendor_config {
             base_use_limit: 200
             baf: BAF_80_PERCENT
             hysteresis: 50
-            max_shaping_is_in_pps: false
-            max_rate: 100000000
-            max_burst: 9000
-            min_shaping_is_in_pps: false
-            min_rate: 1000000
-            min_burst: 4500
+            max_rate_bytes {
+              rate_bps: 100000000
+              burst_bytes: 9000
+            }
+            min_rate_bytes {
+              rate_bps: 1000000
+              burst_bytes: 4500
+            }
           }
           queue_mapping {
             queue_id: 1
@@ -500,12 +502,14 @@ vendor_config {
             base_use_limit: 200
             baf: BAF_80_PERCENT
             hysteresis: 50
-            max_shaping_is_in_pps: false
-            max_rate: 100000000
-            max_burst: 9000
-            min_shaping_is_in_pps: false
-            min_rate: 1000000
-            min_burst: 4500
+            max_rate_bytes {
+              rate_bps: 100000000
+              burst_bytes: 9000
+            }
+            min_rate_bytes {
+              rate_bps: 1000000
+              burst_bytes: 4500
+            }
           }
         }
         queue_configs {
@@ -519,12 +523,14 @@ vendor_config {
             base_use_limit: 200
             baf: BAF_80_PERCENT
             hysteresis: 50
-            max_shaping_is_in_pps: false
-            max_rate: 100000000
-            max_burst: 9000
-            min_shaping_is_in_pps: false
-            min_rate: 1000000
-            min_burst: 4500
+            max_rate_bytes {
+              rate_bps: 100000000
+              burst_bytes: 9000
+            }
+            min_rate_bytes {
+              rate_bps: 1000000
+              burst_bytes: 4500
+            }
           }
           queue_mapping {
             queue_id: 1
@@ -535,12 +541,14 @@ vendor_config {
             base_use_limit: 200
             baf: BAF_80_PERCENT
             hysteresis: 50
-            max_shaping_is_in_pps: false
-            max_rate: 100000000
-            max_burst: 9000
-            min_shaping_is_in_pps: false
-            min_rate: 1000000
-            min_burst: 4500
+            max_rate_bytes {
+              rate_bps: 100000000
+              burst_bytes: 9000
+            }
+            min_rate_bytes {
+              rate_bps: 1000000
+              burst_bytes: 4500
+            }
           }
         }
       }

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -553,15 +553,15 @@ BfChassisManager::~BfChassisManager() = default;
         kPacketShaping:
       RETURN_IF_ERROR(bf_sde_interface_->SetPortShapingRate(
           device, sdk_port_id, true,
-          shaping_config.packet_shaping().max_burst_packets(),
-          shaping_config.packet_shaping().max_rate_pps()));
+          shaping_config.packet_shaping().burst_packets(),
+          shaping_config.packet_shaping().rate_pps()));
       break;
     case TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig::
         kByteShaping:
       RETURN_IF_ERROR(bf_sde_interface_->SetPortShapingRate(
           device, sdk_port_id, false,
-          shaping_config.byte_shaping().max_burst_bytes(),
-          shaping_config.byte_shaping().max_rate_bps()));
+          shaping_config.byte_shaping().burst_bytes(),
+          shaping_config.byte_shaping().rate_bps()));
       break;
     default:
       RETURN_ERROR(ERR_INVALID_PARAM)

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -352,8 +352,8 @@ TEST_F(BfChassisManagerTest, ApplyPortShaping) {
             key: 12345
             value {
               byte_shaping {
-                max_rate_bps: 10000000000 # 10G
-                max_burst_bytes: 16384 # 2x jumbo frame
+                rate_bps: 10000000000 # 10G
+                burst_bytes: 16384 # 2x jumbo frame
               }
             }
           }
@@ -453,12 +453,14 @@ TEST_F(BfChassisManagerTest, ApplyQoSConfig) {
               base_use_limit: 200
               baf: BAF_80_PERCENT
               hysteresis: 50
-              max_shaping_is_in_pps: false
-              max_rate: 100000000
-              max_burst: 9000
-              min_shaping_is_in_pps: false
-              min_rate: 1000000
-              min_burst: 4500
+              max_rate_bytes {
+                rate_bps: 100000000
+                burst_bytes: 9000
+              }
+              min_rate_bytes {
+                rate_bps: 1000000
+                burst_bytes: 4500
+              }
             }
           }
         }
@@ -505,8 +507,8 @@ TEST_F(BfChassisManagerTest, ReplayPorts) {
             key: 12345
             value {
               byte_shaping {
-                max_rate_bps: 10000000000
-                max_burst_bytes: 16384
+                rate_bps: 10000000000
+                burst_bytes: 16384
               }
             }
           }

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -659,16 +659,16 @@ message GoogleConfig {
 
 // Config specific to Tofino chassis.
 message TofinoConfig {
+  message PacketShape {
+    uint64 rate_pps = 1;
+    uint32 burst_packets = 2;
+  }
+  message ByteShape {
+    uint64 rate_bps = 1;
+    uint32 burst_bytes = 2;
+  }
   message BfPortShapingConfig {
     message BfPerPortShapingConfig {
-      message PacketShape {
-        uint64 max_rate_pps = 1;
-        uint32 max_burst_packets = 2;
-      }
-      message ByteShape {
-        uint64 max_rate_bps = 1;
-        uint32 max_burst_bytes = 2;
-      }
       oneof shaping {
         PacketShape packet_shaping = 1;
         ByteShape byte_shaping = 2;
@@ -757,12 +757,14 @@ message TofinoConfig {
         uint32 base_use_limit = 6;
         Baf baf = 7;
         uint32 hysteresis = 8;
-        bool max_shaping_is_in_pps = 9;
-        uint64 max_rate = 10;
-        uint32 max_burst = 11;
-        bool min_shaping_is_in_pps = 12;
-        uint64 min_rate = 13;
-        uint32 min_burst = 14;
+        oneof max_rate {
+          PacketShape max_rate_packets = 9;
+          ByteShape max_rate_bytes = 10;
+        }
+        oneof min_rate {
+          PacketShape min_rate_packets = 11;
+          ByteShape min_rate_bytes = 12;
+        }
       }
       uint32 sdk_port = 1;  // required
       repeated QueueMapping queue_mapping = 3;


### PR DESCRIPTION
We discovered that it can be useful to not explicitly set any maximum or minimum rates on queues. Currently, omitting the max rates will set it to zero, effectively disabling the queue. This change makes these parameters fully optional by disabling shaping/gminrate when not set. We also enhance ergonomics by making the bytes and packet rate mutually exclusive.