### PR TITLE
Missing the conversion from bits to bytes

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -2641,7 +2641,7 @@ namespace {
       table->dataFieldSizeGet(field_id, &data_field_size_bits));
   // The SDE expects a string with the full width.
   std::string value = P4RuntimeByteStringToPaddedByteString(
-      register_data, data_field_size_bits);
+      register_data, NumBitsToNumBytes(data_field_size_bits));
   RETURN_IF_BFRT_ERROR(table_data->setValue(
       field_id, reinterpret_cast<const uint8*>(value.data()), value.size()));
 


### PR DESCRIPTION
The second parameter of P4RuntimeByteStringToPaddedByteString is a byte, need
to use NumBitsToNumBytes to convert bits first before pass to it.