### PR TITLE
Translate P4 table ID to BfRt ID when reading registers

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -769,9 +769,8 @@ BfrtTableManager::ReadDirectCounterEntry(
   std::vector<uint32> register_indices;
   std::vector<uint64> register_datas;
   RETURN_IF_ERROR(bf_sde_interface_->ReadRegisters(
-      device_, session, table_id, optional_register_index,
-      &register_indices, &register_datas,
-      absl::Milliseconds(FLAGS_bfrt_table_sync_timeout_ms)));
+      device_, session, table_id, optional_register_index, &register_indices,
+      &register_datas, absl::Milliseconds(FLAGS_bfrt_table_sync_timeout_ms)));
 
   ::p4::v1::ReadResponse resp;
   for (size_t i = 0; i < register_indices.size(); ++i) {

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -764,11 +764,12 @@ BfrtTableManager::ReadDirectCounterEntry(
     optional_register_index = register_entry.index().index();
   }
 
-  // TODO(max): we don't translate p4rt id to bfrt here?
+  ASSIGN_OR_RETURN(uint32 table_id,
+                   bf_sde_interface_->GetBfRtId(register_entry.register_id()));
   std::vector<uint32> register_indices;
   std::vector<uint64> register_datas;
   RETURN_IF_ERROR(bf_sde_interface_->ReadRegisters(
-      device_, session, register_entry.register_id(), optional_register_index,
+      device_, session, table_id, optional_register_index,
       &register_indices, &register_datas,
       absl::Milliseconds(FLAGS_bfrt_table_sync_timeout_ms)));
 


### PR DESCRIPTION
The register id(and name) in bfrt.json can be different from the one in p4info, here is an example from the P4 info

bfrt.json

```
    {
      "name" : "pipe.FabricEgress.int_egress.queue_report_quota",
      "id" : 2342202179,
...
```

p4info

```
registers {
  preamble {
    id: 379267907
    name: "FabricEgress.int_egress.queue_report_quota"
    alias: "queue_report_quota"
  }
...
```