### PR TITLE
Enable singleton port ID validation in `BfChassisManager::VerifyChassisConfig`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -633,9 +633,8 @@ BfChassisManager::~BfChassisManager() = default;
   std::map<uint64, std::set<uint32>> node_id_to_port_ids;
   std::set<PortKey> singleton_port_keys;
   for (const auto& singleton_port : config.singleton_ports()) {
-    // TODO(max): enable once we decoupled port ids from sdk ports.
-    // CHECK_RETURN_IF_FALSE(singleton_port.id() > 0)
-    //     << "No positive ID in " << PrintSingletonPort(singleton_port) << ".";
+    CHECK_RETURN_IF_FALSE(singleton_port.id() > 0)
+        << "No positive ID in " << PrintSingletonPort(singleton_port) << ".";
     CHECK_RETURN_IF_FALSE(singleton_port.id() != kCpuPortId)
         << "SingletonPort " << PrintSingletonPort(singleton_port)
         << " has the reserved CPU port ID (" << kCpuPortId << ").";


### PR DESCRIPTION
Port IDs have been decoupled from SDE dev port IDs for a while now. Let's reject non-zero singleton port IDs.