### PR TITLE
Use Docker host networking for Stratum-bf[rt] containers on Wedge

### DIFF
--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -17,7 +17,12 @@ elif [[ -z "$PLATFORM" ]]; then
 fi
 
 # Set Docker network options.
-if [[ "$PLATFORM" == 'barefoot-tofino-model' ]]; then
+# On tofino-model and certain switches we run Stratum directly on the host
+# network. The BSP on Wedge devices needs access to the usb0 interface.
+if [[ "$PLATFORM" == 'barefoot-tofino-model' ]] || \
+   [[ "$PLATFORM" == "x86-64-accton-wedge100bf-32x-r0" ]] || \
+   [[ "$PLATFORM" == "x86-64-accton-wedge100bf-32qs-r0" ]] || \
+   [[ "$PLATFORM" == "x86-64-accton-wedge100bf-65x-r0" ]]; then
     DOCKER_NET_OPTS="--network host "
 else
     DOCKER_NET_OPTS="-p 9339:9339 "


### PR DESCRIPTION
The BSP on Wedge100bf switches talks to the BMC over the `usb0` interface during startup. By default, docker isolates the interface from the container, causing the startup procedure to fail with `2021-07-01 22:06:27.571944 BF_PLTFM ERROR - Error Getting the Board info from BMC. Hence exiting ****`. This change binds the Stratum container to the host network, when run on applicable switches, fixing the error.