### PR TITLE
Reject `ActionProfileGroups` with watch ports on Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_action_profile_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_action_profile_manager.cc
@@ -259,6 +259,10 @@ BfrtActionProfileManager::CreateInstance(BfSdeInterface* bf_sde_interface,
   std::vector<uint32> member_ids;
   std::vector<bool> member_status;
   for (const auto& member : action_profile_group.members()) {
+    CHECK_RETURN_IF_FALSE(
+        member.watch_kind_case() ==
+        ::p4::v1::ActionProfileGroup::Member::WATCH_KIND_NOT_SET)
+        << "Watch ports are not supported.";
     member_ids.push_back(member.member_id());
     member_status.push_back(true);  // Activate the member.
   }


### PR DESCRIPTION
Watch ports are not supported, thus we should rejects request with them.