### PR TITLE
[stratum-bcm] Add support for VLAN tagged traffic

### DIFF
--- a/stratum/hal/lib/bcm/bcm_l2_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_l2_manager_test.cc
@@ -170,7 +170,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForEmptyVlanConfig) {
   node->set_id(kNodeId);
   node->mutable_config_params()->add_vlan_configs();
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .Times(2)
       .WillRepeatedly(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
@@ -211,7 +211,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   //    try to remove the my station entry again.
 
   // 1st config push
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -232,7 +232,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -246,7 +246,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -262,7 +262,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   auto* l2_config = node->mutable_config_params()->mutable_l2_config();
   l2_config->set_l2_age_duration_sec(300);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -271,7 +271,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -290,7 +290,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   node->mutable_config_params()->add_vlan_configs();
   node->mutable_config_params()->clear_l2_config();
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -307,7 +307,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // 5th config push
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -329,7 +329,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   auto vlan_config = node->mutable_config_params()->add_vlan_configs();
 
   // Failue when L2 is enabled -- scenario 1
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(DefaultError()));
 
   EXPECT_THAT(bcm_l2_manager_->PushChassisConfig(config, kNodeId),
@@ -338,7 +338,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is enabled -- scenario 2
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -350,7 +350,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is enabled -- scenario 3
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -364,7 +364,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is enabled -- scenario 4
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -388,7 +388,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   auto* l2_config = node->mutable_config_params()->mutable_l2_config();
   l2_config->set_l2_age_duration_sec(300);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(DefaultError()));
 
   EXPECT_THAT(bcm_l2_manager_->PushChassisConfig(config, kNodeId),
@@ -397,7 +397,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 2
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -409,7 +409,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 3
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -423,7 +423,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 4
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -439,7 +439,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 5
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -460,7 +460,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 6
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -474,7 +474,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(DefaultError()));
 
   EXPECT_THAT(bcm_l2_manager_->PushChassisConfig(config, kNodeId),
@@ -484,7 +484,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
 
   // Failue when L2 is disabled -- scenario 7
   // AddMyStationEntry will not be called from now on
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -493,7 +493,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -505,7 +505,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 8
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -514,7 +514,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -528,7 +528,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 9
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -537,7 +537,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -564,7 +564,7 @@ TEST_F(BcmL2ManagerTest, VerifyChassisConfigSuccess) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -578,7 +578,7 @@ TEST_F(BcmL2ManagerTest, VerifyChassisConfigSuccess) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -603,7 +603,7 @@ TEST_F(BcmL2ManagerTest, VerifyChassisConfigFailure) {
   node->set_id(kNodeId);
   node->mutable_config_params()->add_vlan_configs();
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -663,7 +663,7 @@ TEST_F(BcmL2ManagerTest, Shutdown) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -677,7 +677,7 @@ TEST_F(BcmL2ManagerTest, Shutdown) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))

--- a/stratum/hal/lib/bcm/bcm_sdk_interface.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_interface.h
@@ -505,11 +505,12 @@ class BcmSdkInterface {
 
   // Adds a VLAN with a given ID if it does not exist (NOOP if the VLAN
   // already exists). If a new VLAN is created  all the ports including CPU
-  // will be added to the regular member ports and all the ports excluding CPU
-  // will be added to untagged member ports. Untagged member ports are referring
-  // to the ports where VLAN tags for all egress packets are stripped before
-  // sending the packet out.
-  virtual ::util::Status AddVlanIfNotFound(int unit, int vlan) = 0;
+  // will be added to the regular member ports and, if add_untagged_ports
+  // is true, all the ports excluding CPU will be added to untagged member
+  // ports. Untagged member ports are referring to the ports where VLAN
+  // tags for all egress packets are stripped before sending the packet out.
+  virtual ::util::Status AddVlanIfNotFound(int unit, int vlan,
+                                           bool add_untagged_ports = true) = 0;
 
   // Delete a VLAN given its ID if it exists (NOOP if the VLAN is already
   // deleted).

--- a/stratum/hal/lib/bcm/bcm_sdk_mock.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_mock.h
@@ -145,7 +145,8 @@ class BcmSdkMock : public BcmSdkInterface {
   MOCK_METHOD1(DeletePacketReplicationEntry,
                ::util::Status(const BcmPacketReplicationEntry& entry));
   MOCK_METHOD2(DeleteL2EntriesByVlan, ::util::Status(int unit, int vlan));
-  MOCK_METHOD2(AddVlanIfNotFound, ::util::Status(int unit, int vlan));
+  MOCK_METHOD3(AddVlanIfNotFound,
+               ::util::Status(int unit, int vlan, bool add_untagged_ports));
   MOCK_METHOD2(DeleteVlanIfFound, ::util::Status(int unit, int vlan));
   MOCK_METHOD6(ConfigureVlanBlock,
                ::util::Status(int unit, int vlan, bool block_broadcast,

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -2172,7 +2172,8 @@ void PopulateL3HostAction(int class_id, int egress_intf_id,
   return ::util::OkStatus();
 }
 
-::util::Status BcmSdkWrapper::AddVlanIfNotFound(int unit, int vlan) {
+::util::Status BcmSdkWrapper::AddVlanIfNotFound(int unit, int vlan,
+                                                bool add_untagged_ports) {
   int retval = bcm_vlan_create(unit, vlan);
   if (retval == BCM_E_EXISTS) {
     VLOG(1) << "VLAN " << vlan << " already exists on unit " << unit << ".";
@@ -2185,8 +2186,16 @@ void PopulateL3HostAction(int class_id, int egress_intf_id,
 
   bcm_port_config_t port_cfg;
   RETURN_IF_BCM_ERROR(bcm_port_config_get(unit, &port_cfg));
+
+  // Add ports to vlan
+  bcm_pbmp_t untagged_pbmap;
+  if (add_untagged_ports) {
+    untagged_pbmap = port_cfg.all;
+  } else {
+    BCM_PBMP_CLEAR(untagged_pbmap);
+  }
   RETURN_IF_BCM_ERROR(
-      bcm_vlan_port_add(unit, vlan, port_cfg.all, port_cfg.all));
+      bcm_vlan_port_add(unit, vlan, port_cfg.all, untagged_pbmap));
 
   VLOG(1) << "Added VLAN " << vlan << " on unit " << unit << ".";
 

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
@@ -227,7 +227,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                         uint64 dst_mac,
                                         uint64 dst_mac_mask) override;
   ::util::Status DeleteL2EntriesByVlan(int unit, int vlan) override;
-  ::util::Status AddVlanIfNotFound(int unit, int vlan) override;
+  ::util::Status AddVlanIfNotFound(int unit, int vlan,
+                                   bool add_untagged_ports = true) override;
   ::util::Status DeleteVlanIfFound(int unit, int vlan) override;
   ::util::Status ConfigureVlanBlock(int unit, int vlan, bool block_broadcast,
                                     bool block_known_multicast,

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
@@ -196,7 +196,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                         uint64 dst_mac,
                                         uint64 dst_mac_mask) override;
   ::util::Status DeleteL2EntriesByVlan(int unit, int vlan) override;
-  ::util::Status AddVlanIfNotFound(int unit, int vlan) override;
+  ::util::Status AddVlanIfNotFound(int unit, int vlan,
+                                   bool add_untagged_ports = true) override;
   ::util::Status DeleteVlanIfFound(int unit, int vlan) override;
   ::util::Status ConfigureVlanBlock(int unit, int vlan, bool block_broadcast,
                                     bool block_known_multicast,

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -466,6 +466,7 @@ control ingress(inout parsed_packet_t hdr,
     @switchstack("pipeline_stage: L2")
     table my_station_table {
         key = {
+            hdr.vlan_tag[0].vid: ternary;
             hdr.ethernet.dst_addr: ternary;
         }
         actions = {


### PR DESCRIPTION
## Description

Currently, stratum-bcm is not able to handle vlan tagged traffic unless a reactive approach is employed (by forwarding all traffic to the controller using, for example, the fwd application). The root cause of the problem is the fact that neither the VLAN is created anywhere in the codebase nor the respective port bitmaps are associated to the respective VLAN. This PR tries to solve the issue by creating (or removing) the VLANS on-demand whenever flow rules which reference a given VLAN are added (or removed) to/from the `my_station_table`. The VLAN id was already used by `BcmL2Manager::InsertMyStationEntry` but not exposed to the p4 pipeline.
Previously, the only way to achieve traffic forwarding would be to manually configure the VLANS in the bcm cli (for opennsa):

```
>> vlan create 10
>> vlan add 10 portBitMap=ce16,ce20
```

## How Has This Been Tested?

This was tested with the scenario illustrated below both with the Opennsa and SDKLT versions of stratum_bcm:

```
                 ┌──────────────────┐
                 │                  │
┌─────────┐      │                  │     ┌────────────┐
│    h1   │      │  stratum-bcm     │     │     h2     │
│         ├──────┤                  ├─────┤            │
└─────────┘      │                  │     └────────────┘
                 │                  │
10.66.5.2        └──────────────────┘      10.66.5.3

00:00:00:00:00:01                          00:00:00:00:00:02

 VLAN=10                                    VLAN=10
```

Using p4runtime-shell the following entries were created:

```
my_station_table:

H1 -> H2
t2=table_entry["ingress.my_station_table"](action="NoAction")
t2.match["hdr.ethernet.dst_addr"]="00:00:00:00:00:02"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.priority=50000
t2.insert()

H2 -> H1

t2=table_entry["ingress.my_station_table"](action="NoAction")
t2.match["hdr.ethernet.dst_addr"]="00:00:00:00:00:01"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.priority=50000
t2.insert()

punt/ACL table:

t=table_entry["ingress.punt.punt_table"](action="ingress.punt.set_egress_port")
t.match["hdr.ipv4_base.dst_addr"]="10.66.5.2"
t.match["hdr.vlan_tag[0].vid"]="10"
t.action["port"]="17"
t.priority=50000
t.insert()

t2=table_entry["ingress.punt.punt_table"](action="ingress.punt.set_egress_port")
t2.match["hdr.ipv4_base.dst_addr"]="10.66.5.3"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.action["port"]="102"
t2.priority=50000
t2.insert()
```

Traffic forwarding between both hosts was confirmed after installing the aforementioned rules. Removing the flows from `my_station_table` was also confirmed to remove the respective VLAN from the switch.

Regards
