### PR TITLE
[stratum-bcm] Add support for VLAN tagged traffic

### DIFF
--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -314,6 +314,7 @@ message BcmField {
   // Type field is irrelevant to programming and verification but can be used
   // for bookkeeping.
   uint32 udf_chunk_id = 4;  // optional
+  uint32 header_depth = 5;  // optional
 }
 
 // BcmAction, as part of a flow entry, refers to the action that we take upon a

--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -305,6 +305,8 @@ message BcmField {
     VFP_DST_CLASS_ID = 24;    // VFP Destination Class ID.
     L3_DST_CLASS_ID = 25;     // L3 Destination Class ID.
     CLONE_PORT = 26;          // Logical destination port for packet clone.
+    MPLS_LABEL = 27;          // MPLS label.
+    MPLS_BOS = 28;            // MPLS bottom-of-stack bit.
   };
   Type type = 1;                 // required
   BcmTableEntryValue value = 2;  // required
@@ -449,6 +451,7 @@ message BcmFlowEntry {
     BCM_TABLE_L2_MULTICAST = 7;
     BCM_TABLE_TUNNEL = 8;
     BCM_TABLE_L2_UNICAST = 9;
+    BCM_TABLE_MPLS = 10; // OK
   }
   // The unit to program this flow.
   int32 unit = 1;  // required
@@ -490,6 +493,24 @@ message BcmAclStats {
   BcmPacketCounter green = 4;
 }
 
+// BcmTunnelInit is used to represent a tunnel entry.
+// TODO: This is intended to be used universally for L3 MPLS, GRE, MPLS PW, ...
+message BcmTunnelInit {
+  // TODO: prefix with Bcm
+  message MplsTunnelInit {
+    // TODO: prefix with Bcm
+    message MplsLabel {
+      uint32 mpls_label = 1;
+      uint32 mpls_ttl = 2;
+    }
+    repeated MplsLabel labels = 1;
+  }
+
+  oneof type {
+    MplsTunnelInit mpls_tunnel_init = 1;  // On the patch was 3. puledko suggested 1
+  }
+}
+
 // BcmNexthop uniquely defines a nexthop.
 message BcmNonMultipathNexthop {
   enum Type {
@@ -509,6 +530,11 @@ message BcmNonMultipathNexthop {
     int32 logical_port = 6;  // For type PORT only. 0-based.
     int32 trunk_port = 7;    // For type TRUNK only. 0-based.
   }
+  // TODO(max): Decide how to structure mpls and/or general tunnel information.
+  // We could have separate messages for Mpls, GRE, IPIP etc. or just plain fields.
+  uint32 mpls_swap_label = 8;
+  uint32 mpls_swap_ttl = 9;
+  BcmTunnelInit tunnel_init = 10;
 }
 
 // BcmPortGroup defines a collection of ports forming an ECMP/WCMP group.

--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -452,6 +452,7 @@ message BcmFlowEntry {
     BCM_TABLE_TUNNEL = 8;
     BCM_TABLE_L2_UNICAST = 9;
     BCM_TABLE_MPLS = 10; // OK
+    BCM_TABLE_L2_VLAN = 11;
   }
   // The unit to program this flow.
   int32 unit = 1;  // required

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -2145,6 +2145,10 @@ void BcmChassisManager::TransceiverEventHandler(int slot, int port,
                        << PrintBcmPort(*bcm_port) << ".";
         }
       }
+    } else {
+              LOG(ERROR) << "Could not get FrontPanelPortInfo for slot "
+                         << port_group_key.slot << " port " << port_group_key.port
+                         << ".";
     }
   }
   // The option applies to all the ports.

--- a/stratum/hal/lib/bcm/bcm_l2_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_l2_manager.cc
@@ -184,6 +184,12 @@ BcmL2Manager::~BcmL2Manager() {}
   return ::util::OkStatus();
 }
 
+::util::Status BcmL2Manager::InsertL2VlanEntry(const BcmFlowEntry& bcm_flow_entry)
+{
+  LOG(INFO) << "\n\n\nInsert L2 Vlan Entry\n\n\n";
+  return ::util::OkStatus();
+}
+
 ::util::Status BcmL2Manager::InsertMulticastGroup(
     const BcmFlowEntry& bcm_flow_entry) {
   // We will have two cases here:

--- a/stratum/hal/lib/bcm/bcm_l2_manager.h
+++ b/stratum/hal/lib/bcm/bcm_l2_manager.h
@@ -66,6 +66,8 @@ class BcmL2Manager {
   // exists.
   virtual ::util::Status DeleteL2Entry(const BcmFlowEntry& bcm_flow_entry);
 
+  virtual ::util::Status InsertL2VlanEntry(const BcmFlowEntry& bcm_flow_entry);
+
   // Creates an L2 multicast or broadcast group. Each multicast or broadcast
   // group is specified by a multicast_group_id given by an action of type
   // SET_L2_MCAST_GROUP which has an action param of type L2_MCAST_GROUP_ID.

--- a/stratum/hal/lib/bcm/bcm_l2_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_l2_manager_test.cc
@@ -170,7 +170,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForEmptyVlanConfig) {
   node->set_id(kNodeId);
   node->mutable_config_params()->add_vlan_configs();
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .Times(2)
       .WillRepeatedly(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
@@ -211,7 +211,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   //    try to remove the my station entry again.
 
   // 1st config push
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -232,7 +232,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -246,7 +246,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -262,7 +262,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   auto* l2_config = node->mutable_config_params()->mutable_l2_config();
   l2_config->set_l2_age_duration_sec(300);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -271,7 +271,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -290,7 +290,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   node->mutable_config_params()->add_vlan_configs();
   node->mutable_config_params()->clear_l2_config();
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -307,7 +307,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigSuccessForNonEmptyVlanConfig) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // 5th config push
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -329,7 +329,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   auto vlan_config = node->mutable_config_params()->add_vlan_configs();
 
   // Failue when L2 is enabled -- scenario 1
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(DefaultError()));
 
   EXPECT_THAT(bcm_l2_manager_->PushChassisConfig(config, kNodeId),
@@ -338,7 +338,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is enabled -- scenario 2
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -350,7 +350,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is enabled -- scenario 3
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -364,7 +364,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is enabled -- scenario 4
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -388,7 +388,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   auto* l2_config = node->mutable_config_params()->mutable_l2_config();
   l2_config->set_l2_age_duration_sec(300);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(DefaultError()));
 
   EXPECT_THAT(bcm_l2_manager_->PushChassisConfig(config, kNodeId),
@@ -397,7 +397,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 2
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -409,7 +409,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 3
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -423,7 +423,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 4
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -439,7 +439,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 5
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -460,7 +460,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 6
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -474,7 +474,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(DefaultError()));
 
   EXPECT_THAT(bcm_l2_manager_->PushChassisConfig(config, kNodeId),
@@ -484,7 +484,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
 
   // Failue when L2 is disabled -- scenario 7
   // AddMyStationEntry will not be called from now on
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -493,7 +493,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -505,7 +505,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 8
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -514,7 +514,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -528,7 +528,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
   EXPECT_FALSE(l2_learning_disabled_for_default_vlan());
 
   // Failue when L2 is disabled -- scenario 9
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -537,7 +537,7 @@ TEST_F(BcmL2ManagerTest, PushChassisConfigFailure) {
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, DeleteL2EntriesByVlan(kUnit, kDefaultVlan))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -564,7 +564,7 @@ TEST_F(BcmL2ManagerTest, VerifyChassisConfigSuccess) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -578,7 +578,7 @@ TEST_F(BcmL2ManagerTest, VerifyChassisConfigSuccess) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))
@@ -603,7 +603,7 @@ TEST_F(BcmL2ManagerTest, VerifyChassisConfigFailure) {
   node->set_id(kNodeId);
   node->mutable_config_params()->add_vlan_configs();
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, ConfigureVlanBlock(kUnit, kDefaultVlan, false,
                                                  false, false, false))
@@ -663,7 +663,7 @@ TEST_F(BcmL2ManagerTest, Shutdown) {
   vlan_config->set_block_unknown_unicast(true);
   vlan_config->set_disable_l2_learning(true);
 
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kDefaultVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kDefaultVlan, false, false, true, true))
@@ -677,7 +677,7 @@ TEST_F(BcmL2ManagerTest, Shutdown) {
       AddMyStationEntry(kUnit, kL3PromoteMyStationEntryPriority, kDefaultVlan,
                         0xfff, 0ULL, kNonMulticastDstMacMask))
       .WillOnce(Return(kStationId));
-  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan))
+  EXPECT_CALL(*bcm_sdk_mock_, AddVlanIfNotFound(kUnit, kArpVlan, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               ConfigureVlanBlock(kUnit, kArpVlan, false, false, true, true))

--- a/stratum/hal/lib/bcm/bcm_l3_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.cc
@@ -77,6 +77,7 @@ BcmL3Manager::~BcmL3Manager() {}
   int vlan = nexthop.vlan();
   uint64 src_mac = nexthop.src_mac();
   uint64 dst_mac = nexthop.dst_mac();
+  uint32 mpls_swap_label = nexthop.mpls_swap_label();
   int router_intf_id = -1, egress_intf_id = -1;
 
   // Given the router intf, find or create the egress intf.
@@ -91,10 +92,14 @@ BcmL3Manager::~BcmL3Manager() {}
         ASSIGN_OR_RETURN(
             router_intf_id,
             bcm_sdk_interface_->FindOrCreateL3RouterIntf(unit_, src_mac, vlan));
-        ASSIGN_OR_RETURN(
-            egress_intf_id,
-            bcm_sdk_interface_->FindOrCreateL3PortEgressIntf(
-                unit_, dst_mac, logical_port, vlan, router_intf_id));
+          if (nexthop.has_tunnel_init()){
+            RETURN_IF_ERROR(bcm_sdk_interface_->AttachMplsEncapTunnel(
+                unit_,router_intf_id,nexthop.tunnel_init()));
+          }
+          ASSIGN_OR_RETURN(egress_intf_id,
+                      bcm_sdk_interface_->FindOrCreateL3PortEgressIntf(
+                          unit_, dst_mac, logical_port, vlan, router_intf_id,
+                          mpls_swap_label));
       } else {
         return MAKE_ERROR(ERR_INVALID_PARAM)
                << "Invalid nexthop of type NEXTHOP_TYPE_PORT: "
@@ -190,6 +195,7 @@ BcmL3Manager::~BcmL3Manager() {}
   int vlan = nexthop.vlan();
   uint64 src_mac = nexthop.src_mac();
   uint64 dst_mac = nexthop.dst_mac();
+  uint32 mpls_swap_label = nexthop.mpls_swap_label();
   int old_router_intf_id = -1, new_router_intf_id = -1;
 
   // First find the old router intf the given egress intf is using. If the old
@@ -210,8 +216,12 @@ BcmL3Manager::~BcmL3Manager() {}
         ASSIGN_OR_RETURN(
             new_router_intf_id,
             bcm_sdk_interface_->FindOrCreateL3RouterIntf(unit_, src_mac, vlan));
+        if (nexthop.has_tunnel_init()) {
+            RETURN_IF_ERROR(bcm_sdk_interface_->AttachMplsEncapTunnel(
+                          unit_, new_router_intf_id, nexthop.tunnel_init()));
+        }
         RETURN_IF_ERROR(bcm_sdk_interface_->ModifyL3PortEgressIntf(
-            unit_, egress_intf_id, dst_mac, logical_port, vlan,
+            unit_, egress_intf_id, dst_mac, logical_port, vlan, mpls_swap_label,
             new_router_intf_id));
       } else {
         return MAKE_ERROR(ERR_INVALID_PARAM)
@@ -326,7 +336,11 @@ BcmL3Manager::~BcmL3Manager() {}
   BcmFlowEntry bcm_flow_entry;
   RETURN_IF_ERROR(bcm_table_manager_->FillBcmFlowEntry(
       entry, ::p4::v1::Update::INSERT, &bcm_flow_entry));
-  RETURN_IF_ERROR(InsertLpmOrHostFlow(bcm_flow_entry));
+  if (bcm_flow_entry.bcm_table_type() == BcmFlowEntry::BCM_TABLE_MPLS) {
+      RETURN_IF_ERROR(InsertMplsFlow(bcm_flow_entry));
+  } else {
+      RETURN_IF_ERROR(InsertLpmOrHostFlow(bcm_flow_entry));
+  }
   RETURN_IF_ERROR(bcm_table_manager_->AddTableEntry(entry));
 
   return ::util::OkStatus();
@@ -374,7 +388,11 @@ BcmL3Manager::~BcmL3Manager() {}
   BcmFlowEntry bcm_flow_entry;
   RETURN_IF_ERROR(bcm_table_manager_->FillBcmFlowEntry(
       entry, ::p4::v1::Update::MODIFY, &bcm_flow_entry));
-  RETURN_IF_ERROR(ModifyLpmOrHostFlow(bcm_flow_entry));
+  if (bcm_flow_entry.bcm_table_type() == BcmFlowEntry::BCM_TABLE_MPLS) {
+      RETURN_IF_ERROR(ModifyMplsFlow(bcm_flow_entry));
+  } else {
+      RETURN_IF_ERROR(ModifyLpmOrHostFlow(bcm_flow_entry));
+  }
   RETURN_IF_ERROR(bcm_table_manager_->UpdateTableEntry(entry));
 
   return ::util::OkStatus();
@@ -418,7 +436,11 @@ BcmL3Manager::~BcmL3Manager() {}
   BcmFlowEntry bcm_flow_entry;
   RETURN_IF_ERROR(bcm_table_manager_->FillBcmFlowEntry(
       entry, ::p4::v1::Update::DELETE, &bcm_flow_entry));
-  RETURN_IF_ERROR(DeleteLpmOrHostFlow(bcm_flow_entry));
+  if (bcm_flow_entry.bcm_table_type() == BcmFlowEntry::BCM_TABLE_MPLS) {
+     RETURN_IF_ERROR(DeleteMplsFlow(bcm_flow_entry));
+  } else {
+     RETURN_IF_ERROR(DeleteLpmOrHostFlow(bcm_flow_entry));
+  }
   RETURN_IF_ERROR(bcm_table_manager_->DeleteTableEntry(entry));
 
   return ::util::OkStatus();
@@ -463,6 +485,52 @@ BcmL3Manager::~BcmL3Manager() {}
              << BcmFlowEntry::BcmTableType_Name(bcm_table_type) << ", found in "
              << bcm_flow_entry.ShortDebugString() << ".";
   }
+}
+
+::util::Status BcmL3Manager::InsertMplsFlow(
+    const BcmFlowEntry& bcm_flow_entry) {
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.unit() == unit_)
+      << "Received Mpls flow for unit " << bcm_flow_entry.unit() << " on unit "
+      << unit_ << ".";
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.bcm_table_type() ==
+                        BcmFlowEntry::BCM_TABLE_MPLS);
+
+  MplsKey key;
+  MplsActionParams action_params;
+  RETURN_IF_ERROR(ExtractMplsKey(bcm_flow_entry, &key));
+  RETURN_IF_ERROR(ExtractMplsActionParams(bcm_flow_entry, &action_params));
+
+  return bcm_sdk_interface_->AddMplsRoute(unit_, key.mpls_label,
+                                          action_params.egress_intf_id,
+                                          action_params.is_intf_multipath);
+}
+
+::util::Status BcmL3Manager::ModifyMplsFlow(
+    const BcmFlowEntry& bcm_flow_entry) {
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.unit() == unit_)
+      << "Received Mpls flow for unit " << bcm_flow_entry.unit() << " on unit "
+      << unit_ << ".";
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.bcm_table_type() ==
+                        BcmFlowEntry::BCM_TABLE_MPLS);
+  MplsKey key;
+  MplsActionParams action_params;
+  RETURN_IF_ERROR(ExtractMplsKey(bcm_flow_entry, &key));
+  RETURN_IF_ERROR(ExtractMplsActionParams(bcm_flow_entry, &action_params));
+  return bcm_sdk_interface_->ModifyMplsRoute(unit_, key.mpls_label,
+                                             action_params.egress_intf_id,
+                                             action_params.is_intf_multipath);
+}
+
+::util::Status BcmL3Manager::DeleteMplsFlow(
+    const BcmFlowEntry& bcm_flow_entry) {
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.unit() == unit_)
+      << "Received Mpls flow for unit " << bcm_flow_entry.unit() << " on unit "
+      << unit_ << ".";
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.bcm_table_type() ==
+                        BcmFlowEntry::BCM_TABLE_MPLS);
+  MplsKey key;
+  RETURN_IF_ERROR(ExtractMplsKey(bcm_flow_entry, &key));
+  return bcm_sdk_interface_->DeleteMplsRoute(unit_, key.mpls_label);
 }
 
 std::unique_ptr<BcmL3Manager> BcmL3Manager::CreateInstance(
@@ -656,6 +724,83 @@ std::unique_ptr<BcmL3Manager> BcmL3Manager::CreateInstance(
         return MAKE_ERROR(ERR_INVALID_PARAM)
                << "Invalid action type. Expecting OUTPUT_{PORT,TRUNK,GROUP} or "
                << "SET_L3_DST_CLASS_ID types: "
+               << bcm_flow_entry.ShortDebugString() << ".";
+    }
+  }
+
+  if (action_params->egress_intf_id <= 0) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Could not resolve an egress_intf_id for "
+           << bcm_flow_entry.ShortDebugString() << ".";
+  }
+
+  return ::util::OkStatus();
+}
+
+::util::Status BcmL3Manager::ExtractMplsKey(const BcmFlowEntry& bcm_flow_entry,
+                                            MplsKey* key) {
+  CHECK_RETURN_IF_FALSE(key != nullptr) << "Null key!";
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.bcm_table_type() ==
+                        BcmFlowEntry::BCM_TABLE_MPLS);
+  CHECK_RETURN_IF_FALSE(bcm_flow_entry.fields_size() == 1)
+      << "Expected at exactly one field of type MPLS_LABEL label: "
+      << bcm_flow_entry.ShortDebugString() << ".";
+
+  for (const auto& field : bcm_flow_entry.fields()) {
+    if (field.type() == BcmField::MPLS_LABEL) {
+      key->mpls_label = field.value().u32();
+    } else {
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid field type. Expecting only MPLS_LABEL type, but got: "
+             << bcm_flow_entry.ShortDebugString() << ".";
+    }
+  }
+  // Validations
+  if (!key->mpls_label) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Missing Mpls label key in: " << bcm_flow_entry.ShortDebugString()
+           << ".";
+  }
+
+  return ::util::OkStatus();
+}
+
+::util::Status BcmL3Manager::ExtractMplsActionParams(
+    const BcmFlowEntry& bcm_flow_entry, MplsActionParams* action_params) {
+  CHECK_RETURN_IF_FALSE(action_params != nullptr) << "Null action_params!";
+
+  // Find the egress_intf_id.
+  if (bcm_flow_entry.actions_size() > 1) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Expected at most one action of type OUTPUT_{PORT,TRUNK,L3}: "
+           << bcm_flow_entry.ShortDebugString() << ".";
+  }
+  for (const auto& action : bcm_flow_entry.actions()) {
+    switch (action.type()) {
+      case BcmAction::OUTPUT_L3:
+      case BcmAction::OUTPUT_PORT:
+      case BcmAction::OUTPUT_TRUNK: {
+        // We only support the simple case where the egress interface is already
+        // created by the controller.
+        if (action.params_size() == 1 &&
+            action.params(0).type() == BcmAction::Param::EGRESS_INTF_ID) {
+          action_params->egress_intf_id =
+              static_cast<int>(action.params(0).value().u32());
+          if (action.type() == BcmAction::OUTPUT_L3) {
+            action_params->is_intf_multipath = true;
+          }
+        } else {
+          return MAKE_ERROR(ERR_INVALID_PARAM)
+                 << "Invalid action parameters for an action of type "
+                 << "OUTPUT_{PORT,TRUNK,L3}: "
+                 << bcm_flow_entry.ShortDebugString() << ".";
+        }
+        break;
+      }
+      default:
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Invalid action type. Expecting OUTPUT_{PORT,TRUNK,L3} "
+                  "types: "
                << bcm_flow_entry.ShortDebugString() << ".";
     }
   }

--- a/stratum/hal/lib/bcm/bcm_l3_manager.h
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.h
@@ -57,6 +57,21 @@ struct LpmOrHostActionParams {
       : class_id(-1), egress_intf_id(-1), is_intf_multipath(false) {}
 };
 
+// This struct encapsulates the key for a Mpls flow.
+struct MplsKey {
+  // The mpls label to match on.
+  uint32 mpls_label;
+  MplsKey() : mpls_label(-1) {}
+};
+
+struct MplsActionParams {
+  // Egress intf ID for the nexthop.
+  int egress_intf_id;
+  // A boolean determining whether the nexthop is an ECMP/WCMP group
+  bool is_intf_multipath;
+  MplsActionParams() : egress_intf_id(-1), is_intf_multipath(false) {}
+};
+
 // The "BcmL3Manager" class implements the L3 routing functionality.
 class BcmL3Manager {
  public:
@@ -166,6 +181,20 @@ class BcmL3Manager {
   // define the key for the flow (the egress_intf_id or class_id not needed).
   ::util::Status DeleteLpmOrHostFlow(const BcmFlowEntry& bcm_flow_entry);
 
+  // Inserts a MPLS LSR (transit) flow. The function programs the
+  // low level routes into the given unit based on the given BcmFlowEntry.
+  ::util::Status InsertMplsFlow(const BcmFlowEntry& bcm_flow_entry);
+
+  // Inserts a MPLS LSR (transit) flow. The function programs the
+  // low level routes into the given unit based on the given BcmFlowEntry. The
+  // fields populated in BcmFlowEntry are the same as the ones populated when
+  // adding the flow in InsertLpmOrHostFlow().
+  ::util::Status ModifyMplsFlow(const BcmFlowEntry& bcm_flow_entry);
+
+  // Inserts a MPLS LSR (transit) flow. The fields populated in BcmFlowEntry
+  // define the key for the flow (the egress_intf_id or class_id not needed).
+  ::util::Status DeleteMplsFlow(const BcmFlowEntry& bcm_flow_entry);
+
   // Helper to extract IPv4/IPv6 L3 LPM/Host flow keys given BcmFlowEntry.
   ::util::Status ExtractLpmOrHostKey(const BcmFlowEntry& bcm_flow_entry,
                                      LpmOrHostKey* key);
@@ -173,6 +202,14 @@ class BcmL3Manager {
   // Helper to extract IPv4/IPv6 L3 LPM/Host flow actions given BcmFlowEntry.
   ::util::Status ExtractLpmOrHostActionParams(
       const BcmFlowEntry& bcm_flow_entry, LpmOrHostActionParams* action_params);
+
+  // Helper to extract Mpls LSR (transit) flow keys given BcmFlowEntry.
+  ::util::Status ExtractMplsKey(const BcmFlowEntry& bcm_flow_entry,
+                                  MplsKey* key);
+
+  // Helper to extract Mpls LSR (transit) flow actions given BcmFlowEntry.
+  ::util::Status ExtractMplsActionParams(const BcmFlowEntry& bcm_flow_entry,
+                                   MplsActionParams* action_params);
 
   // A helper to find the sorted vector of the member egress intf ids of an
   // ECMP group. The output vector is going to have the following format:

--- a/stratum/hal/lib/bcm/bcm_l3_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_l3_manager_test.cc
@@ -57,6 +57,14 @@ class BcmL3ManagerTest : public ::testing::Test {
     port_nexthop_.set_src_mac(kSrcMac);
     port_nexthop_.set_dst_mac(kDstMac);
 
+    // TODO
+    port_mpls_nexthop_.set_type(BcmNonMultipathNexthop::NEXTHOP_TYPE_PORT);
+    port_mpls_nexthop_.set_unit(kUnit);
+    port_mpls_nexthop_.set_logical_port(kLogicalPort);
+    port_mpls_nexthop_.set_vlan(kVlan);
+    port_mpls_nexthop_.set_src_mac(kSrcMac);
+    port_mpls_nexthop_.set_dst_mac(kDstMac);
+
     trunk_nexthop_.set_type(BcmNonMultipathNexthop::NEXTHOP_TYPE_TRUNK);
     trunk_nexthop_.set_unit(kUnit);
     trunk_nexthop_.set_trunk_port(kTrunkPort);
@@ -136,6 +144,7 @@ class BcmL3ManagerTest : public ::testing::Test {
   BcmNonMultipathNexthop cpu_l2_copy_nexthop_;
   BcmNonMultipathNexthop cpu_normal_l3_nexthop_;
   BcmNonMultipathNexthop port_nexthop_;
+  BcmNonMultipathNexthop port_mpls_nexthop_;
   BcmNonMultipathNexthop trunk_nexthop_;
   BcmNonMultipathNexthop drop_nexthop_;
   BcmMultipathNexthop wcmp_nexthop1_;
@@ -255,6 +264,22 @@ TEST_F(BcmL3ManagerTest, FindOrCreateNonMultipathNexthopSuccessForRegularPort) {
       .WillOnce(Return(kEgressIntfId1));
 
   auto ret = bcm_l3_manager_->FindOrCreateNonMultipathNexthop(port_nexthop_);
+  ASSERT_TRUE(ret.ok());
+  EXPECT_EQ(kEgressIntfId1, ret.ValueOrDie());
+}
+
+// TODO
+TEST_F(BcmL3ManagerTest, FindOrCreateNonMultipathNexthopSuccessForMplsPort) {
+  // Expectations for the mock objects.
+  EXPECT_CALL(*bcm_sdk_mock_, FindOrCreateL3RouterIntf(kUnit, kSrcMac, kVlan))
+      .WillOnce(Return(kNewRouterIntfId));
+  EXPECT_CALL(*bcm_sdk_mock_,
+              FindOrCreateL3PortEgressIntf(kUnit, kDstMac, kLogicalPort, kVlan,
+                                           kNewRouterIntfId))
+      .WillOnce(Return(kEgressIntfId1));
+
+  auto ret =
+      bcm_l3_manager_->FindOrCreateNonMultipathNexthop(port_mpls_nexthop_);
   ASSERT_TRUE(ret.ok());
   EXPECT_EQ(kEgressIntfId1, ret.ValueOrDie());
 }
@@ -1045,6 +1070,44 @@ TEST_F(BcmL3ManagerTest,
   // Expectations for the mock objects.
   EXPECT_CALL(*bcm_sdk_mock_, AddL3RouteIpv4(kUnit, 80, 0xc0a00100, 0xffffff00,
                                              -1, 200256, true))
+      .WillOnce(Return(::util::OkStatus()));
+  EXPECT_CALL(*bcm_table_manager_mock_,
+              AddTableEntry(EqualsProto(p4_table_entry)))
+      .WillOnce(Return(::util::OkStatus()));
+
+  ASSERT_OK(bcm_l3_manager_->InsertTableEntry(p4_table_entry));
+}
+
+TEST_F(BcmL3ManagerTest,
+       InsertMplsFlowSuccessForIpv4LpmFlowAndMultipathNexthop) {
+  const std::string kBcmFlowEntryText = R"(
+      unit: 3
+      bcm_table_type: BCM_TABLE_MPLS
+      fields: {
+        type: MPLS_LABEL
+        value {
+          u32: 100
+        }
+      }
+      actions: {
+        type: OUTPUT_L3
+        params {
+          type: EGRESS_INTF_ID
+          value {
+            u32: 200256
+          }
+        }
+      }
+  )";
+
+  // Test BcmFlowEntry.
+  BcmFlowEntry bcm_flow_entry;
+  ASSERT_OK(ParseProtoFromString(kBcmFlowEntryText, &bcm_flow_entry));
+  ::p4::v1::TableEntry p4_table_entry =
+      ExpectFlowConversion(::p4::v1::Update::INSERT, bcm_flow_entry);
+
+  // Expectations for the mock objects.
+  EXPECT_CALL(*bcm_sdk_mock_, AddMplsRoute(kUnit, 100, 200256, true))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_table_manager_mock_,
               AddTableEntry(EqualsProto(p4_table_entry)))

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -533,6 +533,7 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
         case BcmFlowEntry::BCM_TABLE_IPV4_HOST:
         case BcmFlowEntry::BCM_TABLE_IPV6_LPM:
         case BcmFlowEntry::BCM_TABLE_IPV6_HOST:
+        case BcmFlowEntry::BCM_TABLE_MPLS:
           RETURN_IF_ERROR(bcm_l3_manager_->InsertTableEntry(entry));
           // BcmL3Manager updates the internal records in BcmTableManager.
           consumed = true;
@@ -578,6 +579,7 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
         case BcmFlowEntry::BCM_TABLE_IPV4_HOST:
         case BcmFlowEntry::BCM_TABLE_IPV6_LPM:
         case BcmFlowEntry::BCM_TABLE_IPV6_HOST:
+        case BcmFlowEntry::BCM_TABLE_MPLS:
           RETURN_IF_ERROR(bcm_l3_manager_->ModifyTableEntry(entry));
           consumed = true;
           break;
@@ -609,6 +611,7 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
         case BcmFlowEntry::BCM_TABLE_IPV4_HOST:
         case BcmFlowEntry::BCM_TABLE_IPV6_LPM:
         case BcmFlowEntry::BCM_TABLE_IPV6_HOST:
+        case BcmFlowEntry::BCM_TABLE_MPLS:
           RETURN_IF_ERROR(bcm_l3_manager_->DeleteTableEntry(entry));
           // BcmL3Manager updates the internal records in BcmTableManager.
           consumed = true;

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -552,6 +552,12 @@ std::unique_ptr<BcmNode> BcmNode::CreateInstance(
           RETURN_IF_ERROR(bcm_table_manager_->AddTableEntry(entry));
           consumed = true;
           break;
+        case BcmFlowEntry::BCM_TABLE_L2_VLAN:
+          RETURN_IF_ERROR(bcm_l2_manager_->InsertL2VlanEntry(bcm_flow_entry));
+          // Update the internal records in BcmTableManager.
+          RETURN_IF_ERROR(bcm_table_manager_->AddTableEntry(entry));
+          consumed = true;
+          break;
         case BcmFlowEntry::BCM_TABLE_MY_STATION:
           RETURN_IF_ERROR(
               bcm_l2_manager_->InsertMyStationEntry(bcm_flow_entry));

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -239,13 +239,18 @@ BcmNode::~BcmNode() {}
                  << entity.ShortDebugString() << ".";
         if (details != nullptr) details->push_back(status);
         break;
-      case ::p4::v1::Entity::kDirectMeterEntry:
-        // TODO(unknown): Implement this.
-        status = MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-                 << "Direct meter entries are not currently supported: "
-                 << entity.ShortDebugString() << ".";
-        if (details != nullptr) details->push_back(status);
+      case ::p4::v1::Entity::kDirectMeterEntry: {
+        ::p4::v1::ReadResponse resp;
+        std::vector<::p4::v1::DirectMeterEntry*> acl_directmeterentries;
+        RETURN_IF_ERROR(bcm_table_manager_->ReadDirectMeterTableEntries(
+            entity.direct_meter_entry().table_entry().table_id(), &resp));
+
+        if (!writer->Write(resp)) {
+          return MAKE_ERROR(ERR_INTERNAL)
+                 << "Write to stream for failed for node " << node_id_ << ".";
+        }
         break;
+      }
       case ::p4::v1::Entity::kCounterEntry:
         // TODO(unknown): Implement this.
         status = MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)

--- a/stratum/hal/lib/bcm/bcm_sdk_interface.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_interface.h
@@ -505,11 +505,12 @@ class BcmSdkInterface {
 
   // Adds a VLAN with a given ID if it does not exist (NOOP if the VLAN
   // already exists). If a new VLAN is created  all the ports including CPU
-  // will be added to the regular member ports and all the ports excluding CPU
-  // will be added to untagged member ports. Untagged member ports are referring
-  // to the ports where VLAN tags for all egress packets are stripped before
-  // sending the packet out.
-  virtual ::util::Status AddVlanIfNotFound(int unit, int vlan) = 0;
+  // will be added to the regular member ports and, if add_untagged_ports
+  // is true, all the ports excluding CPU will be added to untagged member
+  // ports. Untagged member ports are referring to the ports where VLAN
+  // tags for all egress packets are stripped before sending the packet out.
+  virtual ::util::Status AddVlanIfNotFound(int unit, int vlan,
+                                           bool add_untagged_ports = true) = 0;
 
   // Delete a VLAN given its ID if it exists (NOOP if the VLAN is already
   // deleted).

--- a/stratum/hal/lib/bcm/bcm_sdk_mock.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_mock.h
@@ -145,7 +145,8 @@ class BcmSdkMock : public BcmSdkInterface {
   MOCK_METHOD1(DeletePacketReplicationEntry,
                ::util::Status(const BcmPacketReplicationEntry& entry));
   MOCK_METHOD2(DeleteL2EntriesByVlan, ::util::Status(int unit, int vlan));
-  MOCK_METHOD2(AddVlanIfNotFound, ::util::Status(int unit, int vlan));
+  MOCK_METHOD3(AddVlanIfNotFound,
+               ::util::Status(int unit, int vlan, bool add_untagged_ports));
   MOCK_METHOD2(DeleteVlanIfFound, ::util::Status(int unit, int vlan));
   MOCK_METHOD6(ConfigureVlanBlock,
                ::util::Status(int unit, int vlan, bool block_broadcast,

--- a/stratum/hal/lib/bcm/bcm_sdk_mock.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_mock.h
@@ -56,19 +56,26 @@ class BcmSdkMock : public BcmSdkInterface {
                ::util::StatusOr<int>(int unit, uint64 router_mac, int vlan));
   MOCK_METHOD2(DeleteL3RouterIntf,
                ::util::Status(int unit, int router_intf_id));
+  MOCK_METHOD3(AttachMplsEncapTunnel,
+               ::util::Status(int unit, int router_intf_id,
+                              const BcmTunnelInit& tunnel_init));
+  MOCK_METHOD2(DetachMplsEncapTunnel,
+               ::util::Status(int unit, int router_intf_id));
   MOCK_METHOD1(FindOrCreateL3CpuEgressIntf, ::util::StatusOr<int>(int unit));
-  MOCK_METHOD5(FindOrCreateL3PortEgressIntf,
+  MOCK_METHOD6(FindOrCreateL3PortEgressIntf,
                ::util::StatusOr<int>(int unit, uint64 nexthop_mac, int port,
-                                     int vlan, int router_intf_id));
+                                     int vlan, int router_intf_id,
+                                     int mpls_label));
   MOCK_METHOD5(FindOrCreateL3TrunkEgressIntf,
                ::util::StatusOr<int>(int unit, uint64 nexthop_mac, int trunk,
                                      int vlan, int router_intf_id));
   MOCK_METHOD1(FindOrCreateL3DropIntf, ::util::StatusOr<int>(int unit));
   MOCK_METHOD2(ModifyL3CpuEgressIntf,
                ::util::Status(int unit, int egress_intf_id));
-  MOCK_METHOD6(ModifyL3PortEgressIntf,
+  MOCK_METHOD7(ModifyL3PortEgressIntf,
                ::util::Status(int unit, int egress_intf_id, uint64 nexthop_mac,
-                              int port, int vlan, int router_intf_id));
+                              int port, int vlan, int mpls_label,
+                              int router_intf_id));
   MOCK_METHOD6(ModifyL3TrunkEgressIntf,
                ::util::Status(int unit, int egress_intf_id, uint64 nexthop_mac,
                               int trunk, int vlan, int router_intf_id));
@@ -98,6 +105,9 @@ class BcmSdkMock : public BcmSdkInterface {
   MOCK_METHOD5(AddL3HostIpv6,
                ::util::Status(int unit, int vrf, const std::string& ipv6,
                               int class_id, int egress_intf_id));
+  MOCK_METHOD4(AddMplsRoute,
+               ::util::Status(int unit_, uint32 mpls_label, int egress_intf_id,
+                              bool is_intf_multipath));
   MOCK_METHOD7(ModifyL3RouteIpv4,
                ::util::Status(int unit, int vrf, uint32 subnet, uint32 mask,
                               int class_id, int egress_intf_id,
@@ -112,6 +122,9 @@ class BcmSdkMock : public BcmSdkInterface {
   MOCK_METHOD5(ModifyL3HostIpv6,
                ::util::Status(int unit, int vrf, const std::string& ipv6,
                               int class_id, int egress_intf_id));
+  MOCK_METHOD4(ModifyMplsRoute,
+               ::util::Status(int unit_, uint32 mpls_label, int egress_intf_id,
+                              bool is_intf_multipath));
   MOCK_METHOD4(DeleteL3RouteIpv4,
                ::util::Status(int unit, int vrf, uint32 subnet, uint32 mask));
   MOCK_METHOD4(DeleteL3RouteIpv6,
@@ -121,6 +134,7 @@ class BcmSdkMock : public BcmSdkInterface {
                ::util::Status(int unit, int vrf, uint32 ipv4));
   MOCK_METHOD3(DeleteL3HostIpv6,
                ::util::Status(int unit, int vrf, const std::string& ipv6));
+  MOCK_METHOD2(DeleteMplsRoute, ::util::Status(int unit_, uint32 mpls_label));
   MOCK_METHOD6(AddMyStationEntry,
                ::util::StatusOr<int>(int unit, int priority, int vlan,
                                      int vlan_mask, uint64 dst_mac,

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -95,6 +95,7 @@ void FillBcmTableEntryValue(const P4ActionFunction::P4ActionFields& source,
 void FillBcmField(BcmField::Type type, const MappedField& source,
                   BcmField* bcm_field) {
   bcm_field->set_type(type);
+  bcm_field->set_header_depth(source.header_depth());
   if (source.has_value()) {
     FillBcmTableEntryValue(source.value(), bcm_field->mutable_value());
   }

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -2329,7 +2329,8 @@ BcmTableManager::GetBcmMultipathNexthopInfo(uint32 group_id) const {
     const CommonFlowEntry& common_flow_entry) const {
   uint32 table_id = common_flow_entry.table_info().id();
   P4TableType table_type = common_flow_entry.table_info().type();
-
+  LOG(INFO) << "\n\n\ntable_type: " << table_type << "\n\n\n";
+  LOG(INFO) << "\n\n\nvlan_table_type:" << P4_TABLE_L2_VLAN << "\n\n\n";
   // We always expect the stage to be available for any table entry. Although
   // we do not use it in this function, we validate it.
   CHECK_RETURN_IF_FALSE(common_flow_entry.table_info().pipeline_stage() !=
@@ -2388,6 +2389,9 @@ BcmTableManager::GetBcmMultipathNexthopInfo(uint32 group_id) const {
       break;
     case P4_TABLE_MPLS:
       bcm_table_type = BcmFlowEntry::BCM_TABLE_MPLS;
+      break;
+    case P4_TABLE_L2_VLAN:
+      bcm_table_type = BcmFlowEntry::BCM_TABLE_L2_VLAN;
       break;
     default:
       break;

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -157,6 +157,8 @@ BcmField::Type GetBcmFieldType(P4FieldType p4_field_type) {
           {P4_FIELD_TYPE_ICMP_TYPE, BcmField::ICMP_TYPE_CODE},
           {P4_FIELD_TYPE_L3_CLASS_ID, BcmField::L3_DST_CLASS_ID},
           {P4_FIELD_TYPE_CLONE_PORT, BcmField::CLONE_PORT},
+          {P4_FIELD_TYPE_MPLS_LABEL, BcmField::MPLS_LABEL},
+          {P4_FIELD_TYPE_MPLS_BOS, BcmField::MPLS_BOS},
           // Currently unsupported field types below.
           {P4_FIELD_TYPE_IPV4_IHL, BcmField::UNKNOWN},
           {P4_FIELD_TYPE_IPV4_TOTAL_LENGTH, BcmField::UNKNOWN},
@@ -749,16 +751,25 @@ namespace {
         nexthop.src_mac() == 0) {
       VLOG(1) << "Detected a trap to CPU nexthop: "
               << nexthop.ShortDebugString() << ".";
-    } else if (nexthop.logical_port() == 0 && nexthop.src_mac() > 0 &&
-               nexthop.dst_mac() > 0) {
-      VLOG(1) << "Detected a nexthop to CPU with regular L3 routing: "
-              << nexthop.ShortDebugString() << ".";
+//    } else if (nexthop.logical_port() == 0 && nexthop.src_mac() > 0 &&
+//               nexthop.dst_mac() > 0) {
+//      VLOG(1) << "Detected a nexthop to CPU with regular L3 routing: "
+//              << nexthop.ShortDebugString() << ".";
 
-    } else if (nexthop.logical_port() > 0 && nexthop.src_mac() > 0 &&
+    } else if (nexthop.logical_port() >= 0 && nexthop.src_mac() > 0 &&
                nexthop.dst_mac() > 0) {
-      VLOG(1) << "Detected a nexthop to port with regular L3 routing: "
-              << nexthop.ShortDebugString() << ".";
-
+//      VLOG(1) << "Detected a nexthop to port with regular L3 routing: "
+//              << nexthop.ShortDebugString() << ".";
+      if (nexthop.has_tunnel_init()) {
+        VLOG(1) << "Detected a nexthop to port with tunnel encap routing: "
+                << nexthop.ShortDebugString() << ".";
+      } else if (!nexthop.has_tunnel_init() && nexthop.mpls_swap_label()) {
+        VLOG(1) << "Detected a nexthop to port with Mpls swap routing: "
+                << nexthop.ShortDebugString() << ".";
+      } else {
+        VLOG(1) << "Detected a nexthop to port with regular L3 routing: "
+                << nexthop.ShortDebugString() << ".";
+      }
     } else {
       return MAKE_ERROR(ERR_INVALID_PARAM)
              << "Detected invalid port nexthop: " << nexthop.ShortDebugString()
@@ -824,6 +835,9 @@ namespace {
         //    here as we cannot do rate limiting for such packets.
         // 3- If a regular port/trunk is given the src_mac and dst_mac both
         //    should be non-zero.
+        std::deque<uint32> mpls_labels;
+        std::deque<uint32> mpls_ttls;
+        uint16 ether_type = 0;
         for (const auto& field : function.modify_fields()) {
           switch (field.type()) {
             case P4_FIELD_TYPE_ETH_SRC:
@@ -831,6 +845,10 @@ namespace {
               break;
             case P4_FIELD_TYPE_ETH_DST:
               bcm_non_multipath_nexthop->set_dst_mac(field.u64());
+              break;
+            case P4_FIELD_TYPE_ETH_TYPE:
+              // TODO: accept as part of action, but ignore for now
+              ether_type = field.u32();
               break;
             case P4_FIELD_TYPE_EGRESS_PORT: {
               uint32 port_id = static_cast<uint32>(field.u32() + field.u64());
@@ -867,6 +885,20 @@ namespace {
               // TODO(unknown): Ignore class_id for now till we have a
               // resolution for b/73264766.
               break;
+            case P4_FIELD_TYPE_MPLS_LABEL:
+              // bcm_non_multipath_nexthop->set_mpls_label(field.u32());
+              mpls_labels.push_back(field.u32());
+              break;
+            case P4_FIELD_TYPE_MPLS_TTL:
+              // bcm_non_multipath_nexthop->set_mpls_ttl(field.u32());
+              mpls_ttls.push_back(field.u32());
+              break;
+            case P4_FIELD_TYPE_MPLS_BOS:
+              // TODO: accept as part of action, but ignore for now
+              break;
+            case P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS:
+              // TODO: accept as part of action, but ignore for now
+              break;
             default:
               return MAKE_ERROR(ERR_INVALID_PARAM)
                      << "Invalid or unsupported P4 field type to modify: "
@@ -876,6 +908,52 @@ namespace {
                      << action_profile_member.ShortDebugString() << ".";
           }
         }
+          bool is_tunnel_init = false;
+          for (const auto& header : function.modify_headers()) {
+            switch (header.header_type()) {
+            case P4HeaderType::P4_HEADER_MPLS:
+              // Check if the necessary parameters to create a header are present.
+              if (header.op_code() == P4HeaderOp::P4_HEADER_SET_VALID
+                  && mpls_labels.size() && mpls_ttls.size()) {
+                for (const auto& _ : mpls_labels) {
+                  auto label = bcm_non_multipath_nexthop->mutable_tunnel_init()
+                                  ->mutable_mpls_tunnel_init()
+                                  ->add_labels();
+                  label->set_mpls_label(mpls_labels.front());
+                  label->set_mpls_ttl(mpls_ttls.front());
+                  mpls_labels.pop_front();
+                  mpls_ttls.pop_front();
+                }
+                is_tunnel_init = true;
+              } else if (header.op_code() == P4HeaderOp::P4_HEADER_SET_INVALID) {
+                CHECK_RETURN_IF_FALSE(ether_type != 0)
+                    << "Expected EtherType to be present when decaping a header";
+              } else {
+                return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid P4HeaderOp code"
+                    << " or missing parameters :" << header.ShortDebugString();
+              }
+              break;
+            default:
+              return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid P4 header type to"
+                      << " modify: " << P4HeaderType_Name(header.header_type())
+                      << ". MappedAction is " << mapped_action.ShortDebugString()
+                      << ". ActionProfileMember is " << action_profile_member.ShortDebugString() << ".";
+            }
+          }
+          // Consume leftover Mpls headers
+          CHECK_RETURN_IF_FALSE(mpls_labels.size() <= 1) << "Found 2 unused Mpls labels";
+          CHECK_RETURN_IF_FALSE(mpls_ttls.size() <= 1) << "Found 2 unused Mpls ttls";
+          if (mpls_labels.size() == 1) {
+            bcm_non_multipath_nexthop->set_mpls_swap_label(mpls_labels[0]);
+            mpls_labels.pop_front();
+          }
+          if (mpls_ttls.size() == 1) {
+            bcm_non_multipath_nexthop->set_mpls_swap_ttl(mpls_ttls.front());
+            mpls_ttls.pop_front();
+          }
+          if (mpls_labels.size() > 0 && is_tunnel_init) {
+            LOG(WARNING) << "Found unused Mpls labels while having a tunnel init";
+          }
       } else if (function.primitives_size() == 1 &&
                  function.primitives(0).op_code() == P4_ACTION_OP_DROP) {
         bcm_non_multipath_nexthop->set_type(
@@ -2307,6 +2385,9 @@ BcmTableManager::GetBcmMultipathNexthopInfo(uint32 group_id) const {
       break;
     case P4_TABLE_L2_MY_STATION:
       bcm_table_type = BcmFlowEntry::BCM_TABLE_MY_STATION;
+      break;
+    case P4_TABLE_MPLS:
+      bcm_table_type = BcmFlowEntry::BCM_TABLE_MPLS;
       break;
     default:
       break;

--- a/stratum/hal/lib/bcm/bcm_table_manager.h
+++ b/stratum/hal/lib/bcm/bcm_table_manager.h
@@ -320,6 +320,11 @@ class BcmTableManager {
       const std::set<uint32>& table_ids, ::p4::v1::ReadResponse* resp,
       std::vector<::p4::v1::TableEntry*>* acl_flows) const;
 
+  // Reads the P4 DirectMeterEntries programmed in a given table
+  // (given by the table_id) on the node.
+  virtual ::util::Status ReadDirectMeterTableEntries(
+      const uint32 table_id, ::p4::v1::ReadResponse* resp) const;
+
   // Finds the and returns the stored P4 TableEntry that matches the
   // given entry.
   virtual ::util::StatusOr<::p4::v1::TableEntry> LookupTableEntry(

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -3028,47 +3028,50 @@ bcm_field_qualify_t HalAclStageToBcm(BcmAclStage stage) {
   return gtl::FindWithDefault(*bcm_stage_map, stage, bcmFieldQualifyCount);
 }
 
-// Returns the BCM type for given field or else enum count.
-bcm_field_qualify_t HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
+// Returns the BCM types for given field or else enum count.
+std::list<bcm_field_qualify_t> HalAclFieldToBcm(BcmAclStage stage,
+                                                BcmField::Type field) {
   // Default mappings for most ACL stages.
   static auto* default_field_map =
-      new absl::flat_hash_map<BcmField::Type, bcm_field_qualify_t,
+      new absl::flat_hash_map<BcmField::Type, std::list<bcm_field_qualify_t>,
                               EnumHash<BcmField::Type>>({
-          {BcmField::ETH_TYPE, bcmFieldQualifyEtherType},
-          {BcmField::IP_TYPE, bcmFieldQualifyIpType},
-          {BcmField::ETH_SRC, bcmFieldQualifySrcMac},
-          {BcmField::ETH_DST, bcmFieldQualifyDstMac},
-          {BcmField::VRF, bcmFieldQualifyVrf},
-          {BcmField::IN_PORT, bcmFieldQualifyInPort},
-          {BcmField::IN_PORT_BITMAP, bcmFieldQualifyInPorts},
-          {BcmField::OUT_PORT, bcmFieldQualifyDstPort},
-          {BcmField::VLAN_VID, bcmFieldQualifyOuterVlanId},
-          {BcmField::VLAN_PCP, bcmFieldQualifyOuterVlanPri},
-          {BcmField::IPV4_SRC, bcmFieldQualifySrcIp},
-          {BcmField::IPV4_DST, bcmFieldQualifyDstIp},
-          {BcmField::IPV6_SRC, bcmFieldQualifySrcIp6},
-          {BcmField::IPV6_DST, bcmFieldQualifyDstIp6},
-          {BcmField::IPV6_SRC_UPPER_64, bcmFieldQualifySrcIp6High},
-          {BcmField::IPV6_DST_UPPER_64, bcmFieldQualifyDstIp6High},
-          {BcmField::IP_PROTO_NEXT_HDR, bcmFieldQualifyIpProtocol},
-          {BcmField::IP_DSCP_TRAF_CLASS, bcmFieldQualifyDSCP},
-          {BcmField::IP_TTL_HOP_LIMIT, bcmFieldQualifyTtl},
-          {BcmField::VFP_DST_CLASS_ID, bcmFieldQualifyDstClassField},
-          {BcmField::L3_DST_CLASS_ID, bcmFieldQualifyDstClassL3},
-          {BcmField::L4_SRC, bcmFieldQualifyL4SrcPort},
-          {BcmField::L4_DST, bcmFieldQualifyL4DstPort},
-          {BcmField::TCP_FLAGS, bcmFieldQualifyTcpControl},
-          {BcmField::ICMP_TYPE_CODE, bcmFieldQualifyIcmpTypeCode},
+          {BcmField::ETH_TYPE, {bcmFieldQualifyEtherType}},
+          {BcmField::IP_TYPE, {bcmFieldQualifyIpType}},
+          {BcmField::ETH_SRC, {bcmFieldQualifySrcMac}},
+          {BcmField::ETH_DST, {bcmFieldQualifyDstMac}},
+          {BcmField::VRF, {bcmFieldQualifyVrf}},
+          {BcmField::IN_PORT, {bcmFieldQualifyInPort}},
+          {BcmField::IN_PORT_BITMAP, {bcmFieldQualifyInPorts}},
+          {BcmField::OUT_PORT, {bcmFieldQualifyDstPort}},
+          {BcmField::VLAN_VID,
+           {bcmFieldQualifyOuterVlanId, bcmFieldQualifyInnerVlanId}},
+          {BcmField::VLAN_PCP,
+           {bcmFieldQualifyOuterVlanPri, bcmFieldQualifyInnerVlanPri}},
+          {BcmField::IPV4_SRC, {bcmFieldQualifySrcIp}},
+          {BcmField::IPV4_DST, {bcmFieldQualifyDstIp}},
+          {BcmField::IPV6_SRC, {bcmFieldQualifySrcIp6}},
+          {BcmField::IPV6_DST, {bcmFieldQualifyDstIp6}},
+          {BcmField::IPV6_SRC_UPPER_64, {bcmFieldQualifySrcIp6High}},
+          {BcmField::IPV6_DST_UPPER_64, {bcmFieldQualifyDstIp6High}},
+          {BcmField::IP_PROTO_NEXT_HDR, {bcmFieldQualifyIpProtocol}},
+          {BcmField::IP_DSCP_TRAF_CLASS, {bcmFieldQualifyDSCP}},
+          {BcmField::IP_TTL_HOP_LIMIT, {bcmFieldQualifyTtl}},
+          {BcmField::VFP_DST_CLASS_ID, {bcmFieldQualifyDstClassField}},
+          {BcmField::L3_DST_CLASS_ID, {bcmFieldQualifyDstClassL3}},
+          {BcmField::L4_SRC, {bcmFieldQualifyL4SrcPort}},
+          {BcmField::L4_DST, {bcmFieldQualifyL4DstPort}},
+          {BcmField::TCP_FLAGS, {bcmFieldQualifyTcpControl}},
+          {BcmField::ICMP_TYPE_CODE, {bcmFieldQualifyIcmpTypeCode}},
       });
   // Stage specific field mappings.
   static auto* efp_field_map =
-      new absl::flat_hash_map<BcmField::Type, bcm_field_qualify_t,
+      new absl::flat_hash_map<BcmField::Type, std::list<bcm_field_qualify_t>,
                               EnumHash<BcmField::Type>>({
-          {BcmField::OUT_PORT, bcmFieldQualifyOutPort},
+          {BcmField::OUT_PORT, {bcmFieldQualifyOutPort}},
       });
   auto* stage_map = (stage == BCM_ACL_STAGE_EFP) ? efp_field_map : nullptr;
   auto default_qual =
-      gtl::FindWithDefault(*default_field_map, field, bcmFieldQualifyCount);
+      gtl::FindWithDefault(*default_field_map, field, {bcmFieldQualifyCount});
   if (stage_map) return gtl::FindWithDefault(*stage_map, field, default_qual);
   return default_qual;
 }
@@ -3097,14 +3100,16 @@ bcm_field_qualify_t HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
           unit, &group_config.qset, field.udf_chunk_id()));
       continue;
     }
-    bcm_field_qualify_t bcm_field =
+    std::list<bcm_field_qualify_t> bcm_fields =
         HalAclFieldToBcm(table.stage(), field.type());
-    if (bcm_field == bcmFieldQualifyCount) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Attempted to create ACL table with invalid predefined qualifier: "
-          << field.ShortDebugString() << ".";
+    for (const auto& bcm_field : bcm_fields) {
+      if (bcm_field == bcmFieldQualifyCount) {
+        RETURN_ERROR(ERR_INVALID_PARAM) << "Attempted to create ACL table with "
+                                           "invalid predefined qualifier: "
+                                        << field.ShortDebugString() << ".";
+      }
+      BCM_FIELD_QSET_ADD(group_config.qset, bcm_field);
     }
-    BCM_FIELD_QSET_ADD(group_config.qset, bcm_field);
   }
   // Allow SDK to find smallest possible table width for bank.
   group_config.mode = bcmFieldGroupModeAuto;
@@ -3394,12 +3399,30 @@ inline int bcm_add_field_u32(F func, int unit, int flow_id,
                                                        unit, entry, field));
       break;
     case BcmField::VLAN_VID:
-      RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_vlan_t>(
-          bcm_field_qualify_OuterVlanId, unit, entry, field));
+      if (field.header_depth() == 0) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_OuterVlanId, unit, entry, field));
+      } else if (field.header_depth() == 1) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_InnerVlanId, unit, entry, field));
+      } else {
+        LOG(ERROR) << "Attempted to translate unsupported BcmField::Type: "
+                   << BcmField::Type_Name(field.type()) << " with header_depth "
+                   << field.header_depth() << ".";
+      }
       break;
     case BcmField::VLAN_PCP:
-      RETURN_IF_BCM_ERROR(bcm_add_field_u32<uint8>(
-          bcm_field_qualify_OuterVlanPri, unit, entry, field));
+      if (field.header_depth() == 0) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<uint8>(
+            bcm_field_qualify_OuterVlanPri, unit, entry, field));
+      } else if (field.header_depth() == 1) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<uint8>(
+            bcm_field_qualify_InnerVlanPri, unit, entry, field));
+      } else {
+        LOG(ERROR) << "Attempted to translate unsupported BcmField::Type: "
+                   << BcmField::Type_Name(field.type()) << " with header_depth "
+                   << field.header_depth() << ".";
+      }
       break;
     case BcmField::IPV4_SRC:
       RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_ip_t>(bcm_field_qualify_SrcIp,
@@ -3848,7 +3871,12 @@ void FillAclPolicerConfig(const BcmMeterConfig& meter,
   table->clear_fields();
   for (int i = BcmField::UNKNOWN + 1; i <= BcmField::Type_MAX; ++i) {
     auto field = static_cast<BcmField::Type>(i);
-    if (BCM_FIELD_QSET_TEST(qset, HalAclFieldToBcm(table->stage(), field))) {
+    const std::list<bcm_field_qualify_t> bcm_acl_fields =
+        HalAclFieldToBcm(table->stage(), field);
+    if (std::all_of(bcm_acl_fields.cbegin(), bcm_acl_fields.cend(),
+                    [qset](bcm_field_qualify_t bcm_field) {
+                      return BCM_FIELD_QSET_TEST(qset, bcm_field);
+                    })) {
       table->add_fields()->set_type(field);
     }
   }
@@ -4116,12 +4144,32 @@ inline int bcm_get_field_u32(F func, int unit, int flow_id, uint32* value,
                                          &value, &mask);
       break;
     case BcmField::VLAN_VID:
-      retval = bcm_get_field_u32<bcm_vlan_t>(bcm_field_qualify_OuterVlanId_get,
-                                             unit, entry, &value, &mask);
+      if (field->header_depth() == 0) {
+        retval = bcm_get_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_OuterVlanId_get, unit, entry, &value, &mask);
+      } else if (field->header_depth() == 1) {
+        retval = bcm_get_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_InnerVlanId_get, unit, entry, &value, &mask);
+      } else {
+        LOG(ERROR) << "Could not retrieve BcmField::Type "
+                   << BcmField::Type_Name(field->type())
+                   << " with header depth " << field->header_depth();
+        return false;
+      }
       break;
     case BcmField::VLAN_PCP:
-      retval = bcm_get_field_u32<uint8>(bcm_field_qualify_OuterVlanPri_get,
-                                        unit, entry, &value, &mask);
+      if (field->header_depth() == 0) {
+        retval = bcm_get_field_u32<uint8>(bcm_field_qualify_OuterVlanPri_get,
+                                          unit, entry, &value, &mask);
+      } else if (field->header_depth() == 1) {
+        retval = bcm_get_field_u32<uint8>(bcm_field_qualify_InnerVlanPri_get,
+                                          unit, entry, &value, &mask);
+      } else {
+        LOG(ERROR) << "Could not retrieve BcmField::Type "
+                   << BcmField::Type_Name(field->type())
+                   << " with header depth " << field->header_depth();
+        return false;
+      }
       break;
     case BcmField::IPV4_SRC:
       retval = bcm_get_field_u32<bcm_ip_t>(bcm_field_qualify_SrcIp_get, unit,

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -181,6 +181,7 @@ DEFINE_int64(port_counters_interval_in_usec, 100 * 1000,
 DEFINE_int32(max_num_linkscan_writers, 10,
              "Max number of linkscan event Writers supported.");
 DECLARE_string(bcm_sdk_checkpoint_dir);
+DEFINE_string(bcm_sdk_rc_file,"rc.soc","Path to SDK6 rc file.");
 
 // TODO(unknown): There are many CHECK_RETURN_IF_FALSE in this file which will
 // need to be changed to return ERR_INTERNAL as opposed to ERR_INVALID_PARAM.
@@ -568,7 +569,8 @@ std::string PrintL3RouterIntf(const bcm_l3_intf_t& l3_intf) {
   buffer << "ttl: " << l3_intf.l3a_ttl << ", ";
   buffer << "mtu: " << l3_intf.l3a_mtu << ", ";
   buffer << "src_mac: " << BcmMacToStr(l3_intf.l3a_mac_addr) << ", ";
-  buffer << "router_intf_id: " << l3_intf.l3a_intf_id << ")";
+  buffer << "router_intf_id: " << l3_intf.l3a_intf_id << ", ";
+  buffer << "tunnel_idx: " << l3_intf.l3a_tunnel_idx << ")";
 
   return buffer.str();
 }
@@ -585,6 +587,15 @@ std::string PrintL3EgressIntf(const bcm_l3_egress_t& l3_egress,
   buffer << "vlan: " << l3_egress.vlan << ", ";
   buffer << "router_intf_id: " << l3_egress.intf << ", ";
   buffer << "dst_mac: " << BcmMacToStr(l3_egress.mac_addr) << ", ";
+  if (l3_egress.flags) {
+      buffer << "flags: " << l3_egress.flags << ", ";
+  }
+  if (l3_egress.mpls_label) {
+      buffer << "mpls_label: " << l3_egress.mpls_label << ", ";
+      buffer << "mpls_action: " << l3_egress.mpls_action << ", ";
+      buffer << "mpls_ttl: " << l3_egress.mpls_ttl << ", ";
+      buffer << "mpls_flags: " << l3_egress.mpls_flags << ", ";
+  }
   buffer << "egress_intf_id: " << egress_intf_id << ")";
 
   return buffer.str();
@@ -626,10 +637,60 @@ std::string PrintL3Host(const bcm_l3_host_t& host) {
   return buffer.str();
 }
 
+// Pretty prints an L3 MPLS route.
+std::string PrintL3MplsRoute(const bcm_mpls_tunnel_switch_t& tunnel_switch) {
+  std::stringstream buffer;
+  buffer << "L3 Mpls route (";
+  buffer << "label: " << tunnel_switch.label << ", ";
+  buffer << "egress interface: " << tunnel_switch.egress_if << ", ";
+  switch (tunnel_switch.action) {
+    case BCM_MPLS_SWITCH_ACTION_SWAP:
+      buffer << "action: SWAP";
+      break;
+    case BCM_MPLS_SWITCH_ACTION_PHP:
+      buffer << "action: PHP";
+      break;
+    case BCM_MPLS_SWITCH_ACTION_POP:
+      buffer << "action: POP";
+      break;
+    case BCM_MPLS_SWITCH_ACTION_POP_DIRECT:
+      buffer << "action: POP DIRECT";
+      break;
+    case BCM_MPLS_SWITCH_ACTION_NOP:
+      buffer << "action: NOP";
+      break;
+    default:
+      buffer << "action: Unknown (" << tunnel_switch.action << ")";
+      break;
+  }
+  buffer << ")";
+
+  return buffer.str();
+}
+
+std::string PrintL3MplsTunnelInit(
+    const std::vector<bcm_mpls_egress_label_t>& egress_labels) {
+  std::stringstream buffer;
+  buffer << "L3 Mpls tunnel initiator (";
+  for (const auto& label : egress_labels) {
+    buffer << "[ label: " << label.label << ", ";
+    buffer << "ttl: " << static_cast<uint16>(label.ttl) << ", ";
+    buffer << "flags: " << absl::StrFormat("%#x", label.flags) << " ]";
+  }
+
+  buffer << ")";
+
+  return buffer.str();
+}
+
 // Wrapper around SDK calls to see if the L3 intf object exists. If not, try to
 // create it.
+// TODO(max): try to integrate with L3_IIFs that want a MPLS tunnel initiator
+//    attached. This includes checking the tunnel init for MPLS label and ttl
+//    and potentially reusing the IFF. With ECMP groups there should be no need
+//    for IIF reuse, since they're shared at EGR intf level.
 int FindOrCreateL3RouterIntfHelper(int unit, bcm_l3_intf_t* l3_intf) {
-  int rv = bcm_l3_intf_find(unit, l3_intf);
+  int rv = BCM_E_NOT_FOUND;
   if (BCM_SUCCESS(rv)) {
     VLOG(1) << "L3 intf " << PrintL3RouterIntf(*l3_intf)
             << " already exists on unit " << unit << ".";
@@ -1241,6 +1302,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
     RETURN_IF_BCM_ERROR(bcm_init(unit));
     RETURN_IF_BCM_ERROR(bcm_l2_init(unit));
     RETURN_IF_BCM_ERROR(bcm_l3_init(unit));
+    RETURN_IF_BCM_ERROR(bcm_mpls_init(unit));
     RETURN_IF_BCM_ERROR(bcm_switch_control_set(unit, bcmSwitchL3EgressMode, 1));
     RETURN_IF_BCM_ERROR(
         bcm_switch_control_set(unit, bcmSwitchL3IngressInterfaceMapSet, 1));
@@ -1257,6 +1319,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
     RETURN_IF_BCM_ERROR(bcm_init(unit));
     RETURN_IF_BCM_ERROR(bcm_l2_init(unit));
     RETURN_IF_BCM_ERROR(bcm_l3_init(unit));
+    RETURN_IF_BCM_ERROR(bcm_mpls_init(unit));
     RETURN_IF_BCM_ERROR(bcm_switch_control_set(unit, bcmSwitchL3EgressMode, 1));
     RETURN_IF_BCM_ERROR(
         bcm_switch_control_set(unit, bcmSwitchL3IngressInterfaceMapSet, 1));
@@ -1584,6 +1647,47 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return l3_intf.l3a_intf_id;
 }
 
+::util::Status BcmSdkWrapper::AttachMplsEncapTunnel(
+    int unit, int router_intf_id, const BcmTunnelInit& tunnel_init) {
+  switch (tunnel_init.type_case()) {
+        case BcmTunnelInit::TypeCase::kMplsTunnelInit: {
+            std::vector<bcm_mpls_egress_label_t> egress_labels;
+            CHECK_RETURN_IF_FALSE(tunnel_init.mpls_tunnel_init().labels_size() > 0)
+                << "Expected at least one Mpls label in "
+                << tunnel_init.ShortDebugString();
+            for (auto const& label : tunnel_init.mpls_tunnel_init().labels()) {
+                bcm_mpls_egress_label_t egress_label;
+                bcm_mpls_egress_label_t_init(&egress_label);
+                egress_label.label = label.mpls_label();
+                egress_label.ttl = label.mpls_ttl();
+                egress_label.flags = BCM_MPLS_EGRESS_LABEL_TTL_SET;
+                egress_labels.push_back(egress_label);
+            }
+            // SDK6 semantics: front = innermost, back = outermost
+            std::reverse(egress_labels.begin(), egress_labels.end());
+            RETURN_IF_BCM_ERROR(bcm_mpls_tunnel_initiator_set(
+                unit, router_intf_id, egress_labels.size(), egress_labels.data()));
+
+            VLOG(1) << "Attached " << PrintL3MplsTunnelInit(egress_labels)
+                    << " to L3 router interface " << router_intf_id << " on unit "
+                    << unit << ".";
+            break;
+        }
+        default:
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unknown tunnel type in " << tunnel_init.ShortDebugString()
+               << " on unit " << unit << ".";
+  }
+  return ::util::OkStatus();
+}
+
+::util::Status BcmSdkWrapper::DetachMplsEncapTunnel(int unit,
+                                                    int router_intf_id) {
+  RETURN_IF_BCM_ERROR(bcm_mpls_tunnel_initiator_clear(unit, router_intf_id));
+
+  return ::util::OkStatus();
+}
+
 ::util::Status BcmSdkWrapper::DeleteL3RouterIntf(int unit, int router_intf_id) {
   bcm_l3_intf_t l3_intf;
   bcm_l3_intf_t_init(&l3_intf);
@@ -1613,7 +1717,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 }
 
 ::util::StatusOr<int> BcmSdkWrapper::FindOrCreateL3PortEgressIntf(
-    int unit, uint64 nexthop_mac, int port, int vlan, int router_intf_id) {
+    int unit, uint64 nexthop_mac, int port, int vlan, int router_intf_id, int mpls_label) {
   CHECK_RETURN_IF_FALSE(nexthop_mac);
   CHECK_RETURN_IF_FALSE(router_intf_id > 0);
   bcm_l3_egress_t l3_egress;
@@ -1623,6 +1727,10 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   l3_egress.module = 0;
   l3_egress.vlan = vlan > 0 ? vlan : BCM_VLAN_DEFAULT;
   l3_egress.intf = router_intf_id;
+  if (mpls_label > 0) {
+    l3_egress.mpls_label = mpls_label;
+    l3_egress.mpls_action = BCM_MPLS_EGRESS_ACTION_SWAP;
+  }
   l3_egress.flags |= BCM_L3_KEEP_VLAN;  // VLAN hashing enabled by default.
   int egress_intf_id = 0;
   RETURN_IF_BCM_ERROR(
@@ -1686,7 +1794,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
                                                      int egress_intf_id,
                                                      uint64 nexthop_mac,
                                                      int port, int vlan,
-                                                     int router_intf_id) {
+                                                     int mpls_label, int router_intf_id) {
   CHECK_RETURN_IF_FALSE(nexthop_mac);
   CHECK_RETURN_IF_FALSE(router_intf_id > 0);
   bcm_l3_egress_t l3_egress;
@@ -1696,6 +1804,10 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   l3_egress.module = 0;
   l3_egress.vlan = vlan > 0 ? vlan : BCM_VLAN_DEFAULT;
   l3_egress.intf = router_intf_id;
+  if (mpls_label > 0) {
+    l3_egress.mpls_label = mpls_label;
+    l3_egress.mpls_action = BCM_MPLS_EGRESS_ACTION_SWAP;
+  }
   l3_egress.flags |= BCM_L3_KEEP_VLAN;  // VLAN hashing enabled by default.
   RETURN_IF_BCM_ERROR(
       ModifyL3EgressIntfHelper(unit, egress_intf_id, &l3_egress));
@@ -1902,6 +2014,63 @@ void PopulateL3HostAction(int class_id, int egress_intf_id,
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::AddMplsRoute(int unit, uint32 mpls_label,
+                                           int egress_intf_id,
+                                           bool is_intf_multipath) {
+  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+
+  // We don't know if the wanted action is swap or pop from the match alone.
+  // Therefore we look at the nexthop and decide the action based on it.
+  bcm_mpls_switch_action_t action = BCM_MPLS_SWITCH_ACTION_INVALID;
+
+  if (is_intf_multipath) {
+    bcm_l3_egress_ecmp_t egress_intf;
+    egress_intf.ecmp_intf = egress_intf_id;
+    int ecmp_entries;
+    bcm_if_t entries[10];
+    RETURN_IF_BCM_ERROR(
+        bcm_l3_egress_ecmp_get(unit, &egress_intf, 10, entries, &ecmp_entries));
+    LOG(WARNING) << "Found ECMP group with " << ecmp_entries << " entries";
+    for (int i = 0; i < ecmp_entries; ++i) {
+      bcm_l3_egress_t egress;
+      RETURN_IF_BCM_ERROR(bcm_l3_egress_get(unit, entries[i], &egress));
+      LOG(WARNING) << "Entry: " << PrintL3EgressIntf(egress, entries[i]);
+      if (egress.mpls_label != BCM_MPLS_LABEL_INVALID) {
+        action = BCM_MPLS_SWITCH_ACTION_SWAP;
+      } else {
+        // FIXME: Should be BCM_MPLS_SWITCH_ACTION_POP_DIRECT.
+        // Bug in SDK6?
+        action = BCM_MPLS_SWITCH_ACTION_PHP;
+      }
+    }
+  } else {
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Non-multipath Mpls nexthops are not supported";
+  }
+
+  bcm_mpls_tunnel_switch_t tunnel_switch;
+  bcm_mpls_tunnel_switch_t_init(&tunnel_switch);
+  tunnel_switch.flags |= BCM_MPLS_SWITCH_TTL_DECREMENT;
+  // ingress match
+  tunnel_switch.label = mpls_label;
+  // By default SDK6 initializes the complete label range as "Port independent".
+  // This means that you can not match on the ingress port. This can be
+  // re-configured with the following registers:
+  // RETURN_IF_BCM_ERROR(WRITE_GLOBAL_MPLS_RANGE_1_UPPERr(unit, 0));
+  // RETURN_IF_BCM_ERROR(WRITE_GLOBAL_MPLS_RANGE_2_UPPERr(unit, 0));
+  tunnel_switch.port = BCM_GPORT_INVALID;
+  // egress options
+  tunnel_switch.action = action;
+  tunnel_switch.egress_if = egress_intf_id;
+
+  RETURN_IF_BCM_ERROR(bcm_mpls_tunnel_switch_add(unit, &tunnel_switch));
+
+  VLOG(1) << "Added MPLS L3 route " << PrintL3MplsRoute(tunnel_switch)
+          << " on unit " << unit << ".";
+
+  return ::util::OkStatus();
+}
+
 ::util::Status BcmSdkWrapper::AddL3HostIpv4(int unit, int vrf, uint32 ipv4,
                                             int class_id, int egress_intf_id) {
   CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
@@ -2017,6 +2186,60 @@ void PopulateL3HostAction(int class_id, int egress_intf_id,
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::ModifyMplsRoute(int unit, uint32 mpls_label,
+                                              int egress_intf_id,
+                                              bool is_intf_multipath) {
+  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+
+  bcm_mpls_tunnel_switch_t tunnel_switch;
+  bcm_mpls_tunnel_switch_t_init(&tunnel_switch);
+  // ingress match
+  tunnel_switch.label = mpls_label;
+  tunnel_switch.port = BCM_GPORT_INVALID;
+
+  // Get exists MPLS entry
+  RETURN_IF_BCM_ERROR(bcm_mpls_tunnel_switch_get(unit, &tunnel_switch));
+
+  // TODO(Max): This code is mostly copied from `AddMplsRoute`, need to be
+  // cleaned up later New action for this MPLS entry We don't know if the wanted
+  // action is swap or pop from the match alone. Therefore we look at the
+  // nexthop and decide the action based on it.
+  bcm_mpls_switch_action_t new_action = BCM_MPLS_SWITCH_ACTION_INVALID;
+
+  if (is_intf_multipath) {
+    bcm_l3_egress_ecmp_t egress_intf;
+    egress_intf.ecmp_intf = egress_intf_id;
+    int ecmp_entries;
+    bcm_if_t entries[10];
+    RETURN_IF_BCM_ERROR(
+        bcm_l3_egress_ecmp_get(unit, &egress_intf, 10, entries, &ecmp_entries));
+    LOG(WARNING) << "Found ECMP group with " << ecmp_entries << " entries";
+    for (int i = 0; i < ecmp_entries; ++i) {
+      bcm_l3_egress_t egress;
+      RETURN_IF_BCM_ERROR(bcm_l3_egress_get(unit, entries[i], &egress));
+      LOG(WARNING) << "Entry: " << PrintL3EgressIntf(egress, entries[i]);
+      if (egress.mpls_label != BCM_MPLS_LABEL_INVALID) {
+        new_action = BCM_MPLS_SWITCH_ACTION_SWAP;
+      } else {
+        // FIXME: Should be BCM_MPLS_SWITCH_ACTION_POP_DIRECT.
+        // Bug in SDK6?
+        new_action = BCM_MPLS_SWITCH_ACTION_PHP;
+      }
+    }
+  } else {
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Non-multipath Mpls nexthops are not supported";
+  }
+
+  // Update egress options and insert the entry
+  tunnel_switch.action = new_action;
+  tunnel_switch.egress_if = egress_intf_id;
+  tunnel_switch.flags = BCM_MPLS_SWITCH_REPLACE | BCM_MPLS_SWITCH_WITH_ID;
+  RETURN_IF_BCM_ERROR(bcm_mpls_tunnel_switch_add(unit, &tunnel_switch));
+
+  return ::util::OkStatus();
+}
+
 ::util::Status BcmSdkWrapper::DeleteL3RouteIpv4(int unit, int vrf,
                                                 uint32 subnet, uint32 mask) {
   bcm_l3_route_t route;
@@ -2073,13 +2296,27 @@ void PopulateL3HostAction(int class_id, int egress_intf_id,
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::DeleteMplsRoute(int unit, uint32 mpls_label) {
+  bcm_mpls_tunnel_switch_t tunnel_switch;
+  bcm_mpls_tunnel_switch_t_init(&tunnel_switch);
+  tunnel_switch.label = mpls_label;
+  tunnel_switch.port = BCM_GPORT_INVALID;
+  RETURN_IF_BCM_ERROR(bcm_mpls_tunnel_switch_delete(unit, &tunnel_switch));
+
+  VLOG(1) << "Deleted MPLS L3 host route "
+          << "TODO"
+          << " on unit " << unit << ".";
+
+  return ::util::OkStatus();
+}
+
 ::util::StatusOr<int> BcmSdkWrapper::AddMyStationEntry(int unit, int priority,
                                                        int vlan, int vlan_mask,
                                                        uint64 dst_mac,
                                                        uint64 dst_mac_mask) {
   bcm_l2_station_t l2_station;
   bcm_l2_station_t_init(&l2_station);
-  l2_station.flags = BCM_L2_STATION_IPV4 | BCM_L2_STATION_IPV6;
+  l2_station.flags = BCM_L2_STATION_IPV4 | BCM_L2_STATION_IPV6 | BCM_L2_STATION_MPLS;
   l2_station.priority = priority;
   if (vlan > 0) {
     // A specific VLAN is specified.

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
@@ -227,7 +227,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                         uint64 dst_mac,
                                         uint64 dst_mac_mask) override;
   ::util::Status DeleteL2EntriesByVlan(int unit, int vlan) override;
-  ::util::Status AddVlanIfNotFound(int unit, int vlan) override;
+  ::util::Status AddVlanIfNotFound(int unit, int vlan,
+                                   bool add_untagged_ports = true) override;
   ::util::Status DeleteVlanIfFound(int unit, int vlan) override;
   ::util::Status ConfigureVlanBlock(int unit, int vlan, bool block_broadcast,
                                     bool block_known_multicast,

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.h
@@ -153,10 +153,12 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::StatusOr<int> FindOrCreateL3RouterIntf(int unit, uint64 router_mac,
                                                  int vlan) override;
   ::util::Status DeleteL3RouterIntf(int unit, int router_intf_id) override;
+  ::util::Status AttachMplsEncapTunnel(int unit, int router_intf_id, const BcmTunnelInit& tunnel_init) override;
+  ::util::Status DetachMplsEncapTunnel(int unit, int router_intf_id) override;
   ::util::StatusOr<int> FindOrCreateL3CpuEgressIntf(int unit) override;
   ::util::StatusOr<int> FindOrCreateL3PortEgressIntf(
       int unit, uint64 nexthop_mac, int port, int vlan,
-      int router_intf_id) override;
+      int router_intf_id, int mpls_label) override;
   ::util::StatusOr<int> FindOrCreateL3TrunkEgressIntf(
       int unit, uint64 nexthop_mac, int trunk, int vlan,
       int router_intf_id) override;
@@ -164,7 +166,7 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status ModifyL3CpuEgressIntf(int unit, int egress_intf_id) override;
   ::util::Status ModifyL3PortEgressIntf(int unit, int egress_intf_id,
                                         uint64 nexthop_mac, int port, int vlan,
-                                        int router_intf_id) override;
+                                        int mpls_label,int router_intf_id) override;
 
   ::util::Status ModifyL3TrunkEgressIntf(int unit, int egress_intf_id,
                                          uint64 nexthop_mac, int trunk,
@@ -190,6 +192,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                int egress_intf_id) override;
   ::util::Status AddL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                int class_id, int egress_intf_id) override;
+  ::util::Status AddMplsRoute(int unit_, uint32 mpls_label, int egress_intf_id,
+                                bool is_intf_multipath) override;
   ::util::Status ModifyL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask, int class_id,
                                    int egress_intf_id,
@@ -202,6 +206,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                   int egress_intf_id) override;
   ::util::Status ModifyL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                   int class_id, int egress_intf_id) override;
+  ::util::Status ModifyMplsRoute(int unit_, uint32 mpls_label, int egress_intf_id,
+                                 bool is_intf_multipath) override;
   ::util::Status DeleteL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask) override;
   ::util::Status DeleteL3RouteIpv6(int unit, int vrf, const std::string& subnet,
@@ -209,6 +215,7 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status DeleteL3HostIpv4(int unit, int vrf, uint32 ipv4) override;
   ::util::Status DeleteL3HostIpv6(int unit, int vrf,
                                   const std::string& ipv6) override;
+  ::util::Status DeleteMplsRoute(int unit_, uint32 mpls_label) override;
   ::util::StatusOr<int> AddMyStationEntry(int unit, int priority, int vlan,
                                           int vlan_mask, uint64 dst_mac,
                                           uint64 dst_mac_mask) override;

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
@@ -2351,6 +2351,115 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return l3a_intf_id;
 }
 
+::util::StatusOr<int> BcmSdkWrapper::FindOrCreateL3MplsRouterIntf(int unit,
+                                                              uint64 router_mac,
+                                                              int vlan,
+                                                              uint32 mpls_label,
+                                                              uint32 mpls_ttl) {
+  bcmlt_entry_handle_t entry_hdl;
+  bcmlt_entry_info_t entry_info;
+  uint64_t max;
+  uint64_t min;
+  int mtu = 0;
+  {
+    // TODO(max): Do we need a separate tunnel MTU?
+    absl::ReaderMutexLock l(&data_lock_);
+    CHECK_RETURN_IF_FALSE(unit_to_mtu_.count(unit));
+    mtu = unit_to_mtu_[unit];
+  }
+  CHECK_RETURN_IF_FALSE(router_mac);
+  CHECK_RETURN_IF_FALSE(mpls_label);
+  CHECK_RETURN_IF_FALSE(mpls_ttl > 0 && mpls_ttl <= kuint8max);
+
+  // check if unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  RETURN_IF_BCM_ERROR(GetFieldMinMaxValue(unit, VLANs, VLAN_IDs, &min, &max));
+  if ((vlan > static_cast<int>(max)) ||
+      (vlan < static_cast<int>(min))) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid vlan (" << vlan << "), valid vlan range is "
+           << static_cast<int>(min) << " - "
+           << static_cast<int>(max) << ".";
+  }
+
+  // FIXME: the mpls label is currently not considered when checking for the
+  // interface existance. This could cause false positives.
+  L3Interfaces entry(router_mac, vlan);
+  auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
+  CHECK_RETURN_IF_FALSE(unit_to_l3_intf != nullptr)
+      << "Unit " << unit << "  is not found in l3_interface_ids. Have you "
+      << "called InitializeUnit for this unit before?";
+  l3_intf_t l3_interface = {0, router_mac, vlan, 0xff, mtu};
+  if (unit_to_l3_intf->count(entry)) {
+    auto it = unit_to_l3_intf->find(entry);
+    if (it != unit_to_l3_intf->end()) {
+      l3_interface.l3a_intf_id = it->second;
+      VLOG(1) << "L3 intf " << PrintL3RouterIntf(l3_interface)
+              << " already exists on unit " << unit << ".";
+      return it->second;
+    }
+  }
+
+  // Check resource limits.
+  if (unit_to_l3_intf->size() == unit_to_l3_intf_max_limit_[unit]) {
+    return MAKE_ERROR(ERR_INTERNAL) << "L3 interface table full.";
+  }
+
+  // entry id
+  std::set<int> l3_intf_ids = extract_values(*unit_to_l3_intf);
+  int l3a_intf_id = unit_to_l3_intf_min_limit_[unit];
+  if (!l3_intf_ids.empty()) {
+    l3a_intf_id = *l3_intf_ids.rbegin() + 1;
+  }
+
+  // Create mpls encap tunnel
+  // L3_EIF_ID + 4 == TNL_ENCAP_ID
+  // FIXME: better mapping
+  uint16 tnl_encap_id = l3a_intf_id + 4;
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_ENCAPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_ENCAP_IDs, tnl_encap_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, NUM_LABELSs, 1));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MAX_LABELSs, 2));
+  uint64 array_data[1] = {mpls_label};
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_array_add(entry_hdl, LABELs, 0, array_data, 1));
+  array_data[0] = mpls_ttl;
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_array_add(entry_hdl, LABEL_TTLs, 0, array_data, 1));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Create egress interface
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, L3_EIFs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, L3_EIF_IDs, l3a_intf_id));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, VLAN_IDs, (vlan > 0 ? vlan : 1)));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MAC_SAs, router_mac));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TTLs, 0xff));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, TNL_TYPEs, MPLSs));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_ENCAP_IDs, tnl_encap_id));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // update map
+  gtl::InsertOrDie(unit_to_l3_intf, entry, l3a_intf_id);
+  l3_interface.l3a_intf_id = l3a_intf_id;
+  VLOG(1) << "Created a new L3 mpls router intf: " << PrintL3RouterIntf(l3_interface)
+          << " on unit " << unit << ".";
+
+  // TODO(max): update mtu, L3_UC_TNL_MTU
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, L3_UC_TNL_MTUs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, L3_EIF_IDs, l3a_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, L3_MTUs, mtu));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  return l3a_intf_id;
+}
+
 ::util::Status BcmSdkWrapper::DeleteL3RouterIntf(int unit, int router_intf_id) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
@@ -2472,6 +2581,142 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   ConsumeSlot(l3_intfs, egress_intf_id);
   l3_intf_object_t l3_intf_o = {router_intf_id, nexthop_mac, vlan, port, 0};
   VLOG(1) << "Created a new L3 port egress intf: "
+          << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
+          << unit << ".";
+  return egress_intf_id;
+}
+
+::util::StatusOr<int> BcmSdkWrapper::FindOrCreateL3MplsEgressIntf(
+    int unit, uint64 nexthop_mac, int port, int router_intf_id) {
+  bcmlt_entry_handle_t entry_hdl;
+  int egress_intf_id = 0;
+  CHECK_RETURN_IF_FALSE(nexthop_mac);
+  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+
+  // Check if the unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  // Check if port is valid
+  RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
+
+  InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+  auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
+  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
+      << "Unit " << unit
+      << " not initialized yet. Call InitializeUnit first.";
+
+  // Check if router interface is valid
+  if (!FindIndexOrNull(*unit_to_l3_intf, router_intf_id)) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Router ID " << router_intf_id << " not found.";
+  }
+
+  // get next free slot
+  ASSIGN_OR_RETURN(egress_intf_id,
+      GetFreeSlot(l3_intfs, "L3 Port egress interface table is full."));
+
+  // Create MPLS dst mac entry
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DST_MACs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, DST_MACs, nexthop_mac));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Create next hop
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_ENCAP_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, NHOP_IDs, egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, L3_EIF_IDs, router_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // mark slot
+  ConsumeSlot(l3_intfs, egress_intf_id);
+  // TODO(max): print mpls label
+  l3_intf_object_t l3_intf_o = {router_intf_id, nexthop_mac, 0, port, 0};
+  VLOG(1) << "Created a new L3 mpls egress intf: "
+          << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
+          << unit << ".";
+  return egress_intf_id;
+}
+
+::util::StatusOr<int> BcmSdkWrapper::FindOrCreateL3MplsTransitEgressIntf(
+    int unit, uint64 nexthop_mac, int port, int router_intf_id, uint32 mpls_label) {
+  bcmlt_entry_handle_t entry_hdl;
+  int egress_intf_id = 0;
+  CHECK_RETURN_IF_FALSE(nexthop_mac);
+  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  CHECK_RETURN_IF_FALSE(mpls_label);
+
+  // Check if the unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  // Check if port is valid
+  RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
+
+  InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+  auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
+  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
+      << "Unit " << unit
+      << " not initialized yet. Call InitializeUnit first.";
+
+  // Check if router interface is valid
+  if (!FindIndexOrNull(*unit_to_l3_intf, router_intf_id)) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Router ID " << router_intf_id << " not found.";
+  }
+
+  // get next free slot
+  ASSIGN_OR_RETURN(egress_intf_id,
+      GetFreeSlot(l3_intfs, "L3 Port egress interface table is full."));
+
+  // Create MPLS dst mac entry
+  // TODO(max): better id mapping
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DST_MACs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, DST_MACs, nexthop_mac));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Create mpls transit entry
+  // TODO(max): better id mapping
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_TRANSITs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_TRANSIT_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, LABELs, mpls_label));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Create transit next hop
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_TRANSIT_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, NHOP_IDs, egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_TRANSIT_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, L3_EIF_IDs, router_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // mark slot
+  ConsumeSlot(l3_intfs, egress_intf_id);
+  // TODO(max): print mpls label
+  l3_intf_object_t l3_intf_o = {router_intf_id, nexthop_mac, 0, port, 0};
+  VLOG(1) << "Created a new L3 mpls transit egress intf: "
           << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
           << unit << ".";
   return egress_intf_id;
@@ -2716,6 +2961,80 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   l3_intf_o.trunk = 0;
 
   VLOG(1) << "Modified L3 port egress intf while keeping its ID the same: "
+          << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
+          << unit << ".";
+  return ::util::OkStatus();
+}
+
+::util::Status BcmSdkWrapper::ModifyL3MplsEgressIntf(int unit,
+                                                     int egress_intf_id,
+                                                     uint64 nexthop_mac,
+                                                     int port,
+                                                     int router_intf_id) {
+  bcmlt_entry_handle_t entry_hdl;
+  uint64_t max;
+  uint64_t min;
+  CHECK_RETURN_IF_FALSE(nexthop_mac);
+  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  // Check if unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  // Check if port is valid
+  RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
+
+  auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
+  InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr && unit_to_l3_intf != nullptr)
+      << "Unit " << unit
+      << " not initialized yet. Call InitializeUnit first.";
+  // Check if egress interface is valid
+  auto it = l3_egress_intf->find(egress_intf_id);
+  if (it != l3_egress_intf->end()) {
+    if (!it->second) {
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "L3 Egress interface "
+             << egress_intf_id << " is not created.";
+    }
+  } else {
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Invalid L3 Egress interface "
+           << egress_intf_id << ".";
+  }
+  // Check if router interface is valid
+  if (!FindIndexOrNull(*unit_to_l3_intf, router_intf_id)) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Router ID " << router_intf_id << " not found.";
+  }
+
+  // Update dst mac
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DST_MACs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TNL_MPLS_DST_MAC_IDs,
+                                            egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, DST_MACs, nexthop_mac));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_UPDATE,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // Update mpls next hop
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_ENCAP_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, NHOP_IDs, egress_intf_id));
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_field_add(entry_hdl, L3_EIF_IDs, router_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_UPDATE,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  // TODO(max): print mpls label
+  l3_intf_object_t l3_intf_o;
+  l3_intf_o.intf = router_intf_id;
+  l3_intf_o.mac_addr = nexthop_mac;
+  l3_intf_o.vlan = 0;
+  l3_intf_o.port = port;
+  l3_intf_o.trunk = 0;
+
+  VLOG(1) << "Modified L3 mpls egress intf while keeping its ID the same: "
           << PrintL3EgressIntf(l3_intf_o, egress_intf_id) << " on unit "
           << unit << ".";
   return ::util::OkStatus();
@@ -3264,6 +3583,121 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::AddMplsRoute(int unit, int port,
+    uint32 mpls_label, int egress_intf_id, bool is_intf_multipath) {
+  // Check if the unit is valid
+  RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
+  RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
+  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  CHECK_RETURN_IF_FALSE(mpls_label > 0);
+
+  // In SDKLT the MPLS action (POP, SWAP, L3_NHI) is part of the same table
+  // (TNL_MPLS_DECAP) that defines the flow match (port and label). But usually
+  // the actions are allocated before the matches, especially with actions groups.
+  // When a new MPLS route is requested, we therefore look at the next hop given,
+  // and try to deduct the intended action from it.
+  // If egress is an ECMP interface, we have to "pierce through" it to
+  // see what's the real next hop type.
+  uint64 nhop_to_check = egress_intf_id;
+
+  if (!is_intf_multipath) {
+    // Check if egress interface is valid
+    InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
+    CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+        << "Unit " << unit
+        << " not initialized yet. Call InitializeUnit first.";
+    auto exists = gtl::FindOrNull(*l3_egress_intf, egress_intf_id);
+    if (!exists || !*exists) {
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+          << "Invalid L3 Egress interface "
+          << egress_intf_id << ".";
+    }
+  } else {
+    // Check if ECMP egress interface is valid
+    InUseMap* ecmp_intfs = gtl::FindOrNull(l3_ecmp_egress_interface_ids_, unit);
+    CHECK_RETURN_IF_FALSE(ecmp_intfs != nullptr)
+        << "Unit " << unit
+        << " not initialized yet. Call InitializeUnit first.";
+    auto exists = gtl::FindOrNull(*ecmp_intfs, egress_intf_id);
+    if (!exists || !*exists) {
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+          << "Invalid L3 ECMP Egress interface "
+          << egress_intf_id << ".";
+    }
+
+    // Fetch first ECMP group member. We assume that an ECMP group only
+    // contains one type of next hops.
+    bcmlt_entry_handle_t entry_hdl;
+    bcmlt_entry_info_t entry_info;
+    RETURN_IF_BCM_ERROR(
+        bcmlt_entry_allocate(unit, ECMPs, &entry_hdl));
+    RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, ECMP_IDs, egress_intf_id));
+    RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_LOOKUP,
+                                          BCMLT_PRIORITY_NORMAL));
+    uint64 nhops[1] = {};
+    uint32 nhop_count = 0;
+    RETURN_IF_BCM_ERROR(bcmlt_entry_field_array_get(entry_hdl, NHOP_IDs, 0, nhops, 1, &nhop_count));
+    RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+    CHECK_RETURN_IF_FALSE(nhop_count != 0) << "Empty ECMP group.";
+    nhop_to_check = nhops[0];
+  }
+
+  // Check if egress interface is transit or normal (decap)
+  auto bos_action = INVALIDs;
+  auto non_bos_action = INVALIDs;
+  bcmlt_entry_handle_t entry_hdl;
+  bcmlt_entry_info_t entry_info;
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_allocate(unit, TNL_MPLS_TRANSIT_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, NHOP_IDs, nhop_to_check));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_commit(entry_hdl, BCMLT_OPCODE_LOOKUP,
+                                         BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_info_get(entry_hdl, &entry_info));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+  if (entry_info.status == SHR_E_NONE) {
+    // Transit (LSR) route
+    bos_action = is_intf_multipath ? SWAP_ECMPs : SWAP_NHIs;
+    non_bos_action = is_intf_multipath ? SWAP_ECMPs : SWAP_NHIs;
+    VLOG(1) << "Adding MPLS transit route for label " << mpls_label
+      << " from port " << port << " to egress interface " << egress_intf_id
+      << " on unit " << unit << ".";
+  }
+  RETURN_IF_BCM_ERROR(
+      bcmlt_entry_allocate(unit, L3_UC_NHOPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, NHOP_IDs, nhop_to_check));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_commit(entry_hdl, BCMLT_OPCODE_LOOKUP,
+                                         BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_info_get(entry_hdl, &entry_info));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+  if (entry_info.status == SHR_E_NONE) {
+    // Decap route
+    bos_action = is_intf_multipath ? L3_ECMPs : L3_NHIs;
+    non_bos_action = POPs;
+    VLOG(1) << "Adding MPLS decap route for label " << mpls_label
+      << " from port " << port << " to egress interface " << egress_intf_id
+      << " on unit " << unit << ".";
+  }
+
+  CHECK_RETURN_IF_FALSE(bos_action != INVALIDs && non_bos_action != INVALIDs)
+      << "Could not resolve type of next hop from egress interface "
+      << egress_intf_id << "on unit " << unit;
+
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DECAPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLS_LABELs, mpls_label));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, IPV4_PAYLOADs, 1));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, IPV4_PAYLOADs, 1));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, ECMP_IDs, egress_intf_id));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, BOS_ACTIONSs, bos_action));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, NON_BOS_ACTIONSs, non_bos_action));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_INSERT,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+    return ::util::OkStatus();
+}
+
 ::util::Status BcmSdkWrapper::AddL3HostIpv4(int unit, int vrf, uint32 ipv4,
                                             int class_id, int egress_intf_id) {
   bcmlt_entry_handle_t entry_hdl;
@@ -3572,6 +4006,12 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   return ::util::OkStatus();
 }
 
+::util::Status BcmSdkWrapper::ModifyMplsRoute(int unit, int port,
+    uint32 mpls_label, int egress_intf_id, bool is_intf_multipath) {
+  // TODO(max): implement
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << "not implemented";
+}
+
 ::util::Status BcmSdkWrapper::ModifyL3HostIpv4(int unit, int vrf, uint32 ipv4,
                                                int class_id,
                                                int egress_intf_id) {
@@ -3835,6 +4275,23 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 
   return ::util::OkStatus();
 }
+
+:util::Status BcmSdkWrapper::DeleteMplsRoute(int unit, int port,
+    uint32 mpls_label) {
+  bcmlt_entry_handle_t entry_hdl;
+  RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TNL_MPLS_DECAPs, &entry_hdl));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MPLS_LABELs, mpls_label));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, port));
+  RETURN_IF_BCM_ERROR(bcmlt_custom_entry_commit(entry_hdl, BCMLT_OPCODE_DELETE,
+                                                BCMLT_PRIORITY_NORMAL));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_free(entry_hdl));
+
+  VLOG(1) << "Deleted MPLS route for label " << mpls_label << " from port "
+      << port << " on unit " << unit << ".";
+
+  return ::util::OkStatus();
+};
 
 ::util::Status BcmSdkWrapper::DeleteL3HostIpv4(int unit, int vrf, uint32 ipv4) {
   uint64_t max;

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
@@ -196,7 +196,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                         uint64 dst_mac,
                                         uint64 dst_mac_mask) override;
   ::util::Status DeleteL2EntriesByVlan(int unit, int vlan) override;
-  ::util::Status AddVlanIfNotFound(int unit, int vlan) override;
+  ::util::Status AddVlanIfNotFound(int unit, int vlan,
+                                   bool add_untagged_ports = true) override;
   ::util::Status DeleteVlanIfFound(int unit, int vlan) override;
   ::util::Status ConfigureVlanBlock(int unit, int vlan, bool block_broadcast,
                                     bool block_known_multicast,

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
@@ -121,11 +121,12 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status SetMtu(int unit, int mtu) override LOCKS_EXCLUDED(data_lock_);
   ::util::StatusOr<int> FindOrCreateL3RouterIntf(int unit, uint64 router_mac,
                                                  int vlan) override;
+  ::util::Status AttachMplsEncapTunnel(int unit, int router_intf_id, const BcmTunnelInit& tunnel_init) override;
   ::util::Status DeleteL3RouterIntf(int unit, int router_intf_id) override;
   ::util::StatusOr<int> FindOrCreateL3CpuEgressIntf(int unit) override;
   ::util::StatusOr<int> FindOrCreateL3PortEgressIntf(
       int unit, uint64 nexthop_mac, int port, int vlan,
-      int router_intf_id) override;
+      int router_intf_id, int mpls_label) override;
   ::util::StatusOr<int> FindOrCreateL3TrunkEgressIntf(
       int unit, uint64 nexthop_mac, int trunk, int vlan,
       int router_intf_id) override;
@@ -133,8 +134,9 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status ModifyL3CpuEgressIntf(int unit, int egress_intf_id) override;
   ::util::Status ModifyL3PortEgressIntf(int unit, int egress_intf_id,
                                         uint64 nexthop_mac, int port, int vlan,
-                                        int router_intf_id) override;
-
+                                        int mpls_label,int router_intf_id) override;
+  ::util::Status ModifyL3MplsEgressIntf(int unit, int egress_intf_id, uint64 nexthop_mac,
+                                        int port, int router_intf_id) override;
   ::util::Status ModifyL3TrunkEgressIntf(int unit, int egress_intf_id,
                                          uint64 nexthop_mac, int trunk,
                                          int vlan, int router_intf_id) override;
@@ -159,6 +161,8 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                int egress_intf_id) override;
   ::util::Status AddL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                int class_id, int egress_intf_id) override;
+  ::util::Status AddMplsRoute(int unit_, int port,uint32 mpls_label,
+                              int egress_intf_id, bool is_intf_multipath) override;
   ::util::Status ModifyL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask, int class_id,
                                    int egress_intf_id,
@@ -171,6 +175,9 @@ class BcmSdkWrapper : public BcmSdkInterface {
                                   int egress_intf_id) override;
   ::util::Status ModifyL3HostIpv6(int unit, int vrf, const std::string& ipv6,
                                   int class_id, int egress_intf_id) override;
+  ::util::Status ModifyMplsRoute(int unit_, int port, uint32 mpls_label,
+                                   int egress_intf_id,
+                                   bool is_intf_multipath) override;
   ::util::Status DeleteL3RouteIpv4(int unit, int vrf, uint32 subnet,
                                    uint32 mask) override;
   ::util::Status DeleteL3RouteIpv6(int unit, int vrf, const std::string& subnet,
@@ -178,6 +185,7 @@ class BcmSdkWrapper : public BcmSdkInterface {
   ::util::Status DeleteL3HostIpv4(int unit, int vrf, uint32 ipv4) override;
   ::util::Status DeleteL3HostIpv6(int unit, int vrf,
                                   const std::string& ipv6) override;
+  ::util::Status DeleteMplsRoute(int unit_, int port, uint32 mpls_label) override;
   ::util::StatusOr<int> AddMyStationEntry(int unit, int priority, int vlan,
                                           int vlan_mask, uint64 dst_mac,
                                           uint64 dst_mac_mask) override;

--- a/stratum/hal/lib/p4/common_flow_entry.proto
+++ b/stratum/hal/lib/p4/common_flow_entry.proto
@@ -72,6 +72,7 @@ message MappedField {
   int32 bit_offset = 4;
   int32 bit_width = 5;
   P4HeaderType header_type = 6;
+  int32 header_depth = 7;
 }
 
 // This message supports action function mapping.  It applies to actions in

--- a/stratum/hal/lib/p4/common_flow_entry.proto
+++ b/stratum/hal/lib/p4/common_flow_entry.proto
@@ -121,8 +121,15 @@ message P4ActionFunction {
     repeated P4MeterColor meter_colors = 2;
   }
 
+  // TODO(max)
+  message P4ActionHeaders {
+    P4HeaderOp op_code = 1;
+    P4HeaderType header_type = 2;
+  }
+
   repeated P4ActionFields modify_fields = 1;
   repeated P4ActionPrimitive primitives = 2;
+  repeated P4ActionHeaders modify_headers = 3;
 }
 
 // A MappedAction represents the output of TableAction mapping from

--- a/stratum/hal/lib/p4/p4_table_map.proto
+++ b/stratum/hal/lib/p4/p4_table_map.proto
@@ -340,6 +340,7 @@ message P4ActionDescriptor {
     TunnelFieldValue ecn_value = 4;
     TunnelFieldValue dscp_value = 5;
     TunnelFieldValue ttl_value = 6;
+    bool is_mpls_tunnel = 7;
 
     oneof encap_or_decap {
       EncapProperties encap = 10;

--- a/stratum/hal/lib/p4/p4_table_map.proto
+++ b/stratum/hal/lib/p4/p4_table_map.proto
@@ -151,6 +151,10 @@ message P4FieldDescriptor {
     string table_name = 1;
   }
 
+  message P4HeaderLink {
+    string header_key = 1;
+  }
+
   // Mapping fields for match fields are:
   //  type - Identifies the field in an output flow entry.
   //  valid_conversions - Indicates how to derive the flow entry field value
@@ -179,6 +183,7 @@ message P4FieldDescriptor {
   P4HeaderType header_type = 7;
   repeated P4MetadataKey metadata_keys = 8;
   string value_set = 9;
+  P4HeaderLink header_link = 10;
 }
 
 // A P4ActionDescriptor defines how to map a P4 runtime action into a common

--- a/stratum/hal/lib/p4/p4_table_mapper.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper.cc
@@ -912,6 +912,33 @@ std::string P4TableMapper::GetMapperNameKey(
   for (const auto& color_action : action_descriptor.color_actions()) {
     FindAndAddMeterColors(color_action, mapped_action);
   }
+  // Handle tunnel_properties
+  if (action_descriptor.has_tunnel_properties()) {
+      LOG(WARNING) << "Found tunnel properties: "
+                   << action_descriptor.tunnel_properties().ShortDebugString();
+      auto header = P4HeaderType::P4_HEADER_UNKNOWN;
+      auto op = P4HeaderOp::P4_HEADER_NOP;
+      auto tunnel_properties = action_descriptor.tunnel_properties();
+
+      if (tunnel_properties.has_encap()) {
+        op = P4HeaderOp::P4_HEADER_SET_VALID;
+      } else if (tunnel_properties.has_decap()) {
+        op = P4HeaderOp::P4_HEADER_SET_INVALID;
+      }
+
+      if (tunnel_properties.is_mpls_tunnel()) {
+        header = P4HeaderType::P4_HEADER_MPLS;
+      } else if (tunnel_properties.is_gre_tunnel()) {
+        header = P4HeaderType::P4_HEADER_GRE;
+      }
+
+      if (op && header) {
+        P4ActionFunction::P4ActionHeaders* modify_header =
+            mapped_action->mutable_function()->add_modify_headers();
+        modify_header->set_op_code(op);
+        modify_header->set_header_type(header);
+      }
+  }
   return status;
 }
 

--- a/stratum/hal/lib/p4/p4_table_mapper.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper.cc
@@ -782,6 +782,60 @@ std::string P4TableMapper::GetMapperNameKey(
       table_p4_info.preamble().id(), action.action_id()));
 
   ::util::Status status = ProcessActionFunction(action, mapped_action);
+
+  APPEND_STATUS_IF_ERROR(status, ProcessTableActionRedirects(
+                                     table_p4_info, action, mapped_action));
+  return status;
+}
+
+::util::Status P4TableMapper::ProcessTableActionRedirects(
+    const ::p4::config::v1::Table& table_p4_info,
+    const ::p4::v1::Action& action, MappedAction* mapped_action) const {
+  if (action.action_id() == 0) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "P4 TableEntry action has no action_id.";
+  }
+
+  ::util::Status status = ::util::OkStatus();
+  auto desc_iter = global_id_table_map_.find(action.action_id());
+  if (desc_iter == global_id_table_map_.end()) {
+    ::util::Status action_error = MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+                                  << "P4 action ID in "
+                                  << action.ShortDebugString()
+                                  << " is unknown or invalid.";
+    APPEND_STATUS_IF_ERROR(status, action_error);
+    return status;
+  }
+  const auto& action_descriptor = desc_iter->second->action_descriptor();
+
+  // Action redirects migth also link to internal actions
+  // that contain instructions to define meter color conditions
+  for (const auto& redirect : action_descriptor.action_redirects()) {
+    for (const auto& link : redirect.internal_links()) {
+      // check if the table we are applying the internal action is in
+      // the applied_tables for the action
+      const auto applied_tables = link.applied_tables();
+      auto it =
+          std::find_if(applied_tables.begin(), applied_tables.end(),
+                       [&table_p4_info](const std::string& table_name) {
+                         return (table_name == table_p4_info.preamble().name());
+                       });
+      if (it != applied_tables.end()) {
+        auto* map_value = gtl::FindOrNull(p4_pipeline_config_.table_map(),
+                                          link.internal_action_name());
+        if (map_value) {
+          VLOG(1) << "Processing internal link " << link.internal_action_name()
+                  << " redirected from action " << action.action_id()
+                  << " valid for table " << table_p4_info.preamble().name();
+
+          for (const auto& color_action :
+               map_value->internal_action().color_actions()) {
+            FindAndAddMeterColors(color_action, mapped_action);
+          }
+        }
+      }
+    }
+  }
   return status;
 }
 
@@ -843,29 +897,34 @@ std::string P4TableMapper::GetMapperNameKey(
   // The action descriptor's color_actions contain instructions that are
   // conditional based on meter color.
   for (const auto& color_action : action_descriptor.color_actions()) {
-    for (const auto& color_op : color_action.ops()) {
-      for (int p = 0; p < color_op.primitives_size(); ++p) {
-        P4ActionOp primitive = color_op.primitives(p);
-        P4ActionFunction::P4ActionPrimitive* mapped_primitive =
-            mapped_action->mutable_function()->add_primitives();
-        mapped_primitive->set_op_code(primitive);
-        for (int c = 0; c < color_action.colors_size(); ++c) {
-          mapped_primitive->add_meter_colors(color_action.colors(c));
-        }
-      }
+    FindAndAddMeterColors(color_action, mapped_action);
+  }
+  return status;
+}
 
-      // TODO(unknown): Complete deprecation of destination_field_names.
-      if (color_op.destination_field_names_size() != 0 ||
-          !color_op.destination_field_name().empty()) {
-        // TODO(unknown): All of the existing P4 roles have color-qualified
-        // action primitives only. Add support here if this changes.
-        LOG(WARNING) << "Meter color action has unexpected destination field "
-                     << "assignments: " << color_op.ShortDebugString();
+void P4TableMapper::FindAndAddMeterColors(
+    const P4ActionDescriptor::P4MeterColorAction& color_action,
+    MappedAction* mapped_action) const {
+  for (const auto& color_op : color_action.ops()) {
+    for (int p = 0; p < color_op.primitives_size(); ++p) {
+      P4ActionOp primitive = color_op.primitives(p);
+      P4ActionFunction::P4ActionPrimitive* mapped_primitive =
+          mapped_action->mutable_function()->add_primitives();
+      mapped_primitive->set_op_code(primitive);
+      for (int c = 0; c < color_action.colors_size(); ++c) {
+        mapped_primitive->add_meter_colors(color_action.colors(c));
       }
     }
-  }
 
-  return status;
+    // TODO(unknown): Complete deprecation of destination_field_names.
+    if (color_op.destination_field_names_size() != 0 ||
+        !color_op.destination_field_name().empty()) {
+      // TODO(unknown): All of the existing P4 roles have color-qualified
+      // action primitives only. Add support here if this changes.
+      LOG(WARNING) << "Meter color action has unexpected destination field "
+                   << "assignments: " << color_op.ShortDebugString();
+    }
+  }
 }
 
 ::util::Status P4TableMapper::IsTableUpdateAllowed(

--- a/stratum/hal/lib/p4/p4_table_mapper.h
+++ b/stratum/hal/lib/p4/p4_table_mapper.h
@@ -467,11 +467,22 @@ class P4TableMapper {
       const ::p4::config::v1::ActionProfile& profile_p4_info,
       const ::p4::v1::Action& action, MappedAction* mapped_action) const;
 
+  // Processes the action redirects specified by the action for the table.
+  ::util::Status ProcessTableActionRedirects(
+      const ::p4::config::v1::Table& table_p4_info,
+      const ::p4::v1::Action& action, MappedAction* mapped_action) const;
+
   // Handles action function processing that is common to either a table entry
   // or an action profile update.  If successful, the output mapped_action will
   // be filled.
   ::util::Status ProcessActionFunction(const ::p4::v1::Action& action,
                                        MappedAction* mapped_action) const;
+
+  // Evaluates all of the P4MeterColorAction operations and fills
+  // the mapped_action with all the primitives defined in each operation
+  void FindAndAddMeterColors(
+      const P4ActionDescriptor::P4MeterColorAction& color_action,
+      MappedAction* mapped_action) const;
 
   // Evaluates the attributes in the table descriptor along with the current
   // state of static_table_updates_enabled_ to see if a mapping request is

--- a/stratum/lib/utils.h
+++ b/stratum/lib/utils.h
@@ -94,6 +94,20 @@ inline std::string PrintVector(const std::vector<T>& vec,
   return PrintArray<T>(vec.data(), vec.size(), sep);
 }
 
+template <typename T>
+inline std::string PrintIterable(const T& iterable, const std::string& sep) {
+  std::stringstream buffer;
+  std::string s = "";
+  buffer << "(";
+  for (auto const& elem : iterable) {
+    buffer << s << elem;
+    s = sep;
+  }
+  buffer << ")";
+
+  return buffer.str();
+}
+
 // Writes a proto message in binary format to the given file path.
 ::util::Status WriteProtoToBinFile(const ::google::protobuf::Message& message,
                                    const std::string& filename);

--- a/stratum/p4c_backends/fpm/bcm/bcm_target_info.cc
+++ b/stratum/p4c_backends/fpm/bcm/bcm_target_info.cc
@@ -16,6 +16,7 @@ bool BcmTargetInfo::IsPipelineStageFixed(
   switch (stage) {
     case P4Annotation::L2:
     case P4Annotation::L3_LPM:
+    case P4Annotation::L3_MPLS:
     case P4Annotation::ENCAP:
     case P4Annotation::DECAP:
       is_fixed = true;

--- a/stratum/p4c_backends/fpm/field_decoder.cc
+++ b/stratum/p4c_backends/fpm/field_decoder.cc
@@ -120,9 +120,10 @@ void FieldDecoder::ConvertHeaderFields(
         const std::string header_field_name =
             iter.first + "." + field_in_type.name();
         table_mapper_->AddField(header_field_name);
+
         UpdateFieldMapData(header_field_name, iter.second, field_in_type.name(),
                            annotated_types, field_in_type.bit_offset(),
-                           field_in_type.bit_width());
+                           field_in_type.bit_width(), iter.first);
         field_in_type.add_full_field_names(header_field_name);
         VLOG(1) << "Mapped header field name: " << header_field_name;
       }
@@ -247,7 +248,8 @@ bool FieldDecoder::DecodePathEndField(
 void FieldDecoder::UpdateFieldMapData(
     const std::string& fq_field_name, const std::string& header_type_name,
     const std::string& field_name, const AnnotatedFieldTypeMap& annotated_types,
-    uint32_t bit_offset, uint32_t bit_width) {
+    uint32_t bit_offset, uint32_t bit_width,
+    const std::string& parent_header_key) {
   AnnotatedFieldTypeMapKey key = std::make_pair(header_type_name, field_name);
   const auto& iter = annotated_types.find(key);
 
@@ -259,6 +261,8 @@ void FieldDecoder::UpdateFieldMapData(
   }
   table_mapper_->SetFieldAttributes(
       fq_field_name, field_type, P4_HEADER_UNKNOWN, bit_offset, bit_width);
+  // Add reference / link to the parent header
+  table_mapper_->SetFieldHeaderLink(fq_field_name, parent_header_key);
   if (header_type_name == GetP4ModelNames().local_metadata_type_name()) {
     table_mapper_->SetFieldLocalMetadataFlag(fq_field_name);
   }

--- a/stratum/p4c_backends/fpm/field_decoder.h
+++ b/stratum/p4c_backends/fpm/field_decoder.h
@@ -104,10 +104,11 @@ class FieldDecoder {
   // bit_offset and bit_width describe the field's position with its
   // surrounding header.
   void UpdateFieldMapData(const std::string& fq_field_name,
-                             const std::string& header_type_name,
-                             const std::string& field_name,
-                             const AnnotatedFieldTypeMap& annotated_types,
-                             uint32_t bit_offset, uint32_t bit_width);
+                          const std::string& header_type_name,
+                          const std::string& field_name,
+                          const AnnotatedFieldTypeMap& annotated_types,
+                          uint32_t bit_offset, uint32_t bit_width,
+                          const std::string& parent_header_key);
 
   // Determines whether the input field has an annotated field type.  If the
   // annotation exists, StoreFieldTypeAnnotation parses the field type and

--- a/stratum/p4c_backends/fpm/map_data/standard_parser_map.pb.txt
+++ b/stratum/p4c_backends/fpm/map_data/standard_parser_map.pb.txt
@@ -246,10 +246,51 @@ parser_states {
           next_state: "target_parse_arp"
         }
         cases {
+          keyset_values {
+            constant {
+              value: 0x8847
+              mask: 1
+            }
+          }
+          next_state: "target_parse_mpls"
+        }
+        cases {
           is_default: true
           next_state: "accept"
         }
       }
+    }
+  }
+}
+parser_states {
+  key: "target_parse_mpls"
+  value {
+    name: "target_parse_mpls"
+    extracted_header {
+      name: "MPLS Header"
+      header_type: P4_HEADER_MPLS
+      fields {
+        type: P4_FIELD_TYPE_MPLS_LABEL
+        bit_width: 20
+      }
+      fields {
+        type: P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS
+        bit_offset: 20
+        bit_width: 3
+      }
+      fields {
+        type: P4_FIELD_TYPE_MPLS_BOS
+        bit_offset: 23
+        bit_width: 1
+      }
+      fields {
+        type: P4_FIELD_TYPE_MPLS_TTL
+        bit_offset: 24
+        bit_width: 8
+      }
+    }
+    transition {
+      next_state: "accept"
     }
   }
 }

--- a/stratum/p4c_backends/fpm/parser_field_mapper.cc
+++ b/stratum/p4c_backends/fpm/parser_field_mapper.cc
@@ -422,9 +422,16 @@ int ParserFieldMapper::MatchTargetAndP4Fields(
   // outer header.  Non-extracted fields move to the pass3_fields_map_ map
   // for processing in Pass3 if they are still unresolved.
   int32 header_depth = 0;
-  if (in_tunnel) header_depth = 1;
   if (!mapped_fields.empty() || header_visited) {
-    for (const auto& header : p4_header.header_paths()) {
+    for (int i = 0; i < p4_header.header_paths().size(); ++i) {
+      const auto& header = p4_header.header_paths().Get(i);
+      if (in_tunnel) {
+        header_depth = 1;
+      } else if (IsHeaderArrayLast(header)) {
+        header_depth = i - 1;
+      } else {
+        header_depth = i;
+      }
       table_mapper_->SetHeaderAttributes(
           header, target_header.header_type(), header_depth);
     }

--- a/stratum/p4c_backends/fpm/table_map_generator.cc
+++ b/stratum/p4c_backends/fpm/table_map_generator.cc
@@ -79,6 +79,18 @@ void TableMapGenerator::SetFieldAttributes(
   }
 }
 
+void TableMapGenerator::SetFieldHeaderLink(
+    const std::string& field_name, const std::string& parent_header_key) {
+  hal::P4FieldDescriptor* field_descriptor =
+      FindMutableFieldDescriptorOrNull(field_name, generated_map_.get());
+  if (field_descriptor == nullptr) {
+    // TODO(unknown): Treat as internal compiler BUG exception?
+    LOG(ERROR) << "Unable to find field " << field_name << " to set attributes";
+    return;
+  }
+  field_descriptor->mutable_header_link()->set_header_key(parent_header_key);
+}
+
 void TableMapGenerator::SetFieldLocalMetadataFlag(
     const std::string& field_name) {
   hal::P4FieldDescriptor* field_descriptor =

--- a/stratum/p4c_backends/fpm/table_map_generator.h
+++ b/stratum/p4c_backends/fpm/table_map_generator.h
@@ -76,6 +76,8 @@ class TableMapGenerator {
                                   P4FieldType field_type,
                                   P4HeaderType header_type,
                                   uint32_t bit_offset, uint32_t bit_width);
+  virtual void SetFieldHeaderLink(const std::string& field_name,
+                                  const std::string& parent_header_key);
   virtual void SetFieldLocalMetadataFlag(const std::string& field_name);
   virtual void SetFieldValueSet(const std::string& field_name,
                                 const std::string& value_set_name,

--- a/stratum/p4c_backends/fpm/tunnel_type_mapper.cc
+++ b/stratum/p4c_backends/fpm/tunnel_type_mapper.cc
@@ -42,6 +42,7 @@ void TunnelTypeMapper::ProcessActionTunnel(
     hal::P4ActionDescriptor* action_descriptor) {
   // The per-action state needs to be reset.
   gre_header_op_ = P4_HEADER_NOP;
+  mpls_header_op_ = P4_HEADER_NOP;
   is_encap_ = false;
   is_decap_ = false;
   p4_tunnel_properties_.Clear();
@@ -50,10 +51,14 @@ void TunnelTypeMapper::ProcessActionTunnel(
   bool is_tunnel_action = false;
 
   for (const auto& tunnel_action : action_descriptor->tunnel_actions()) {
+    VLOG(1) << "Processing tunnel action: " << tunnel_action.ShortDebugString();
     bool found_encap_decap = FindInnerEncapHeader(tunnel_action);
     is_tunnel_action = is_tunnel_action || found_encap_decap;
     if (found_encap_decap) continue;
     found_encap_decap = FindGreHeader(tunnel_action);
+    is_tunnel_action = is_tunnel_action || found_encap_decap;
+    if (found_encap_decap) continue;
+    found_encap_decap = FindMplsHeader(tunnel_action);
     is_tunnel_action = is_tunnel_action || found_encap_decap;
     if (found_encap_decap) continue;
     found_encap_decap = FindInnerDecapHeader(tunnel_action);
@@ -99,6 +104,9 @@ void TunnelTypeMapper::ProcessActionTunnel(
   } else {
     // The action's tunnel_actions turned out to be irrelevant, so the
     // action_descriptor doesn't need them.
+    LOG(WARNING) << "action descriptor has tunnel actions, but could not "
+            << "construct valid P4TunnelProperties from: "
+            << action_descriptor->ShortDebugString() << ".";
     action_descriptor->clear_tunnel_actions();
   }
 }
@@ -168,6 +176,41 @@ bool TunnelTypeMapper::FindGreHeader(
   return is_gre;
 }
 
+// The input tunnel_action represents a MPLS tunnel when:
+//  - The header descriptor indicates the MPLS header type.
+//  - The header valid bit is set or cleared directly.  A header-to-header
+//    copy (P4_HEADER_COPY_VALID) makes no sense for a MPLS header.
+bool TunnelTypeMapper::FindMplsHeader(
+    const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action) {
+  bool is_mpls = false;
+  const auto& header_descriptor = FindHeaderDescriptorOrDie(
+      tunnel_action.header_name(), *p4_pipeline_config_);
+
+  if (header_descriptor.type() == P4_HEADER_MPLS) {
+    is_mpls = true;
+    if (tunnel_action.header_op() == P4_HEADER_SET_VALID ||
+        tunnel_action.header_op() == P4_HEADER_SET_INVALID) {
+      if (mpls_header_op_ != P4_HEADER_NOP &&
+          mpls_header_op_ != tunnel_action.header_op()) {
+        tunnel_error_message_ +=
+            "MPLS encap and decap cannot occur in the same action. ";
+        return true;
+      }
+      p4_tunnel_properties_.set_is_mpls_tunnel(true);
+      mpls_header_op_ = tunnel_action.header_op();
+      is_encap_ = tunnel_action.header_op() == P4_HEADER_SET_VALID;
+      is_decap_ = tunnel_action.header_op() == P4_HEADER_SET_INVALID;
+    } else {
+      // TODO(unknown): Are there any valid use cases for MPLS header copies?
+      tunnel_error_message_ +=
+          "MPLS header-to-header copy is an invalid tunnel operation. ";
+      return true;
+    }
+  }
+
+  return is_mpls;
+}
+
 // The input tunnel_action represents a tunnel decap when:
 //  - The header valid bit is invalidated.
 //  - The header descriptor indicates an inner header.
@@ -217,6 +260,25 @@ bool TunnelTypeMapper::CheckInnerHeaderType(P4HeaderType header_type) {
 
 void TunnelTypeMapper::ProcessTunnelAssignments(
     hal::P4ActionDescriptor* action_descriptor) {
+    // Process MPLS tunnel
+    if (mpls_header_op_ != P4_HEADER_NOP) {
+        // Inner headers are fixed to IPv4/v6 with BCM
+        if (is_encap_) {
+          p4_tunnel_properties_.mutable_encap()->set_encap_outer_header(
+              P4_HEADER_MPLS);
+          p4_tunnel_properties_.mutable_encap()->add_encap_inner_headers(
+              P4_HEADER_IPV4);
+          p4_tunnel_properties_.mutable_encap()->add_encap_inner_headers(
+              P4_HEADER_IPV6);
+        }
+        if (is_decap_) {
+          p4_tunnel_properties_.mutable_decap()->add_decap_inner_headers(
+              P4_HEADER_IPV4);
+          p4_tunnel_properties_.mutable_decap()->add_decap_inner_headers(
+              P4_HEADER_IPV6);
+        }
+        return;
+    }
   // The default assumption is that ECN, DSCP, and TTL get copied between
   // outer and inner headers.
   p4_tunnel_properties_.mutable_ecn_value()->set_copy(true);

--- a/stratum/p4c_backends/fpm/tunnel_type_mapper.h
+++ b/stratum/p4c_backends/fpm/tunnel_type_mapper.h
@@ -72,6 +72,8 @@ class TunnelTypeMapper {
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
   bool FindGreHeader(
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
+  bool FindMplsHeader(
+      const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
   bool FindInnerDecapHeader(
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
 
@@ -122,6 +124,7 @@ class TunnelTypeMapper {
   std::string action_name_;
   hal::P4ActionDescriptor::P4TunnelProperties p4_tunnel_properties_;
   P4HeaderOp gre_header_op_;
+  P4HeaderOp mpls_header_op_;
   bool is_encap_;
   bool is_decap_;
   std::vector<int> optimized_assignments_;

--- a/stratum/p4c_backends/fpm/utils.cc
+++ b/stratum/p4c_backends/fpm/utils.cc
@@ -280,6 +280,13 @@ std::string AddHeaderArrayLast(const std::string& header_name) {
       "$0.$1", header_name.c_str(), IR::Type_Stack::last.c_str());
 }
 
+bool IsHeaderArrayLast(const std::string& header_name) {
+  const std::string last = "last";
+  return header_name.size() >= last.size() &&
+         0 == header_name.compare(header_name.size() - last.size(), last.size(),
+                                  last);
+}
+
 bool IsParserEndState(const ParserState& state) {
   if (state.transition().next_state() == IR::ParserState::accept)
     return true;

--- a/stratum/p4c_backends/fpm/utils.h
+++ b/stratum/p4c_backends/fpm/utils.h
@@ -109,6 +109,9 @@ std::string AddHeaderArrayIndex(const std::string& header_name, int64 index);
 // output is "hdr.name.last".
 std::string AddHeaderArrayLast(const std::string& header_name);
 
+// Checks if the header name ends with the P4 parser "last" operator
+bool IsHeaderArrayLast(const std::string& header_name);
+
 // Returns true if the input ParserState specifies a transition to one of
 // P4's built-in terminating states, i.e. "accept" or "reject".
 bool IsParserEndState(const ParserState& state);

--- a/stratum/pipelines/main/field_map.pb.txt
+++ b/stratum/pipelines/main/field_map.pb.txt
@@ -73,3 +73,27 @@ field_addenda_map {
     type: P4_FIELD_TYPE_ENCAP_TUNNEL_ID
   }
 }
+field_addenda_map {
+  key: "hdr.mpls.label"
+  value {
+    type: P4_FIELD_TYPE_MPLS_LABEL
+  }
+}
+field_addenda_map {
+  key: "hdr.mpls.tc"
+  value {
+    type: P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS
+  }
+}
+field_addenda_map {
+  key: "hdr.mpls.bos"
+  value {
+    type: P4_FIELD_TYPE_MPLS_BOS
+  }
+}
+field_addenda_map {
+  key: "hdr.mpls.ttl"
+  value {
+    type: P4_FIELD_TYPE_MPLS_TTL
+  }
+}

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -366,6 +366,8 @@ control punt(inout parsed_packet_t hdr,
             local_metadata.icmp_code      : ternary;
             hdr.vlan_tag[0].vid           : ternary;
             hdr.vlan_tag[0].pcp           : ternary;
+            //hdr.vlan_tag[1].vid           : ternary;
+            //hdr.vlan_tag[1].pcp           : ternary;
             local_metadata.class_id       : ternary;
             local_metadata.vrf_id         : ternary;
         }

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -466,6 +466,7 @@ control ingress(inout parsed_packet_t hdr,
     @switchstack("pipeline_stage: L2")
     table my_station_table {
         key = {
+            hdr.vlan_tag[0].vid: ternary;
             hdr.ethernet.dst_addr: ternary;
         }
         actions = {

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -366,8 +366,8 @@ control punt(inout parsed_packet_t hdr,
             local_metadata.icmp_code      : ternary;
             hdr.vlan_tag[0].vid           : ternary;
             hdr.vlan_tag[0].pcp           : ternary;
-            //hdr.vlan_tag[1].vid           : ternary;
-            //hdr.vlan_tag[1].pcp           : ternary;
+            hdr.vlan_tag[1].vid           : ternary;
+            hdr.vlan_tag[1].pcp           : ternary;
             local_metadata.class_id       : ternary;
             local_metadata.vrf_id         : ternary;
         }

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -448,6 +448,8 @@ control l2_fwd(inout parsed_packet_t hdr,
     table l2_unicast_table {
         key = {
             hdr.ethernet.dst_addr: exact;
+            hdr.vlan_tag[0].vid: ternary;
+            standard_metadata.ingress_port: ternary;
         }
         actions = {
             set_egress_port;

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -519,6 +519,23 @@ control l2_fwd(inout parsed_packet_t hdr,
         standard_metadata.egress_spec = port;
     }
 
+    action push_vlan()
+    {
+        
+    }
+
+    @switchstack("pipeline_stage: L2_VLAN")
+    table l2_vlan_table{
+        actions = {
+            push_vlan;
+            NoAction;
+        }
+        key = {
+            standard_metadata.ingress_port: ternary;
+        }
+        const default_action = NoAction();
+    }
+
     @switchstack("pipeline_stage: L2")
     table l2_unicast_table {
         key = {
@@ -534,6 +551,7 @@ control l2_fwd(inout parsed_packet_t hdr,
     }
 
     apply {
+        l2_vlan_table.apply();
         l2_unicast_table.apply();
     }
 }

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -29,6 +29,7 @@ const bit<16> ETHERTYPE_IPV6 = 0x86dd;
 const bit<16> ETHERTYPE_ARP = 0x806;
 const bit<16> ETHERTYPE_ND = 0x6007;
 const bit<16> ETHERTYPE_LLDP = 0x88cc;
+const bit<16> ETHERTYPE_MPLS = 0x8847;
 
 const bit<8> IP_PROTOCOLS_TCP = 6;
 const bit<8> IP_PROTOCOLS_UDP = 17;
@@ -44,6 +45,13 @@ header ethernet_t {
     EthernetAddress dst_addr;
     EthernetAddress src_addr;
     bit<16>         ether_type;
+}
+
+header mpls_t {
+    bit<20> label;
+    bit<3> tc;
+    bit<1> bos;
+    bit<8> ttl;
 }
 
 header ipv4_base_t {
@@ -158,6 +166,8 @@ struct local_metadata_t {
 
 struct parsed_packet_t {
     ethernet_t          ethernet;
+    mpls_t              mpls;
+    mpls_t              inner_mpls;
     ipv4_base_t         ipv4_base;
     ipv6_base_t         ipv6_base;
     icmp_header_t       icmp_header;
@@ -196,6 +206,18 @@ parser pkt_parser(packet_in pk,
             ETHERTYPE_IPV4: parse_ipv4;
             ETHERTYPE_IPV6: parse_ipv6;
             ETHERTYPE_ARP: parse_arp;
+            ETHERTYPE_MPLS: parse_mpls;
+            default: accept;
+        }
+    }
+
+    state parse_mpls {
+        pk.extract(hdr.mpls);
+        // This is a hack to prevent the bf compiler from mapping the mpls ttl
+        // field onto the IP protocol field, which results in corrupted packets.
+        transition select(pk.lookahead<bit<4>>()) {
+            4: parse_ipv4;
+            6: parse_ipv6;
             default: accept;
         }
     }
@@ -263,6 +285,8 @@ control pkt_deparser(packet_out b, in parsed_packet_t hdr) {
         b.emit(hdr.packet_in);
         b.emit(hdr.ethernet);
         b.emit(hdr.vlan_tag);
+        b.emit(hdr.mpls);
+        b.emit(hdr.inner_mpls);
         b.emit(hdr.ipv4_base);
         b.emit(hdr.ipv6_base);
         b.emit(hdr.arp);
@@ -408,6 +432,18 @@ control l3_fwd(inout parsed_packet_t hdr,
         hdr.ethernet.dst_addr = dmac;
         hdr.ipv4_base.ttl = hdr.ipv4_base.ttl - 1;
     }
+    action encap_mpls(PortNum port, EthernetAddress smac, EthernetAddress dmac,
+                          bit<20> mpls_label, bit<8> mpls_ttl) {
+            standard_metadata.egress_spec = port;
+            hdr.ethernet.src_addr = smac;
+            hdr.ethernet.dst_addr = dmac;
+            hdr.ethernet.ether_type = ETHERTYPE_MPLS;
+            hdr.mpls.setValid();
+            hdr.mpls.label = mpls_label;
+            hdr.mpls.ttl = mpls_ttl;
+            hdr.mpls.bos = 1;
+            hdr.mpls.tc = 0;
+    }
 
     @max_group_size(8)
     action_selector(HashAlgorithm.crc16, 32w1024, 32w14) wcmp_action_profile;
@@ -424,6 +460,7 @@ control l3_fwd(inout parsed_packet_t hdr,
         }
         actions = {
             set_nexthop;
+            encap_mpls;
             NoAction;
             drop;
         }
@@ -431,8 +468,46 @@ control l3_fwd(inout parsed_packet_t hdr,
         implementation = wcmp_action_profile;
     }
 
+    @max_group_size(8)
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) mpls_ecmp_action_profile;
+
+    action swap_mpls(PortNum port, EthernetAddress smac, EthernetAddress dmac,
+                     bit<20> mpls_label) {
+        standard_metadata.egress_spec = port;
+        hdr.ethernet.src_addr = smac;
+        hdr.ethernet.dst_addr = dmac;
+        hdr.mpls.label = mpls_label;
+        hdr.mpls.ttl = hdr.mpls.ttl - 1;
+    }
+
+    action decap_mpls(PortNum port, EthernetAddress smac, EthernetAddress dmac) {
+        standard_metadata.egress_spec = port;
+        hdr.ethernet.src_addr = smac;
+        hdr.ethernet.dst_addr = dmac;
+        hdr.ethernet.ether_type = ETHERTYPE_IPV4;
+        hdr.mpls.setInvalid();
+    }
+
+    @switchstack("pipeline_stage: L3_MPLS")
+    table l3_mpls_table {
+        key = {
+            hdr.mpls.label                 : exact;
+            hdr.mpls.label                 : selector;
+        }
+        actions = {
+            swap_mpls;
+            decap_mpls;
+        }
+        implementation = mpls_ecmp_action_profile;
+        // implementation = wcmp_action_profile;
+    }
+
     apply {
-        l3_fwd_table.apply();
+        if (hdr.mpls.isValid()) {
+            l3_mpls_table.apply();
+        } else if (hdr.ipv4_base.isValid()) {
+            l3_fwd_table.apply();
+        }
     }
 }
 

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -476,6 +476,7 @@ control ingress(inout parsed_packet_t hdr,
         key = {
             hdr.vlan_tag[0].vid: ternary;
             hdr.ethernet.dst_addr: ternary;
+            standard_metadata.ingress_port: ternary;
         }
         actions = {
             set_l3_admit;

--- a/stratum/pipelines/main/table_map.pb.txt
+++ b/stratum/pipelines/main/table_map.pb.txt
@@ -15,6 +15,13 @@ table_addenda_map {
     addenda_names: "l2-vlan-fallback"
   }
 }
+
+table_addenda_map {
+  key: "ingress.l2_fwd.l2_vlan_table"
+  value {
+    type: P4_TABLE_L2_VLAN
+  }
+}
 table_addenda_map {
   key: "ingress.my_station_table"
   value {

--- a/stratum/pipelines/main/table_map.pb.txt
+++ b/stratum/pipelines/main/table_map.pb.txt
@@ -29,6 +29,25 @@ table_addenda_map {
   }
 }
 
+table_addenda_map {
+  key: "ingress.l3_fwd.l3_mpls_table"
+  value {
+    type: P4_TABLE_MPLS
+  }
+}
+action_addenda_map {
+  key: "ingress.l3_fwd.decap_mpls"
+  value {
+    addenda_names: "default-vlan-action-fallback"
+  }
+}
+action_addenda_map {
+  key: "ingress.l3_fwd.swap_mpls"
+  value {
+    addenda_names: "default-vlan-action-fallback"
+  }
+}
+
 # Defines an internal match on the default VLAN ID
 table_addenda {
   name: "l2-vlan-fallback"

--- a/stratum/public/proto/p4_annotation.proto
+++ b/stratum/public/proto/p4_annotation.proto
@@ -43,6 +43,7 @@ message P4Annotation {
     DECAP = 7;
     HIDDEN = 8;
     L3_MPLS = 9;
+    L2_VLAN = 10;
   }
 
   // Defines the hardware pipeline stage of an entity.

--- a/stratum/public/proto/p4_annotation.proto
+++ b/stratum/public/proto/p4_annotation.proto
@@ -42,6 +42,7 @@ message P4Annotation {
     ENCAP = 6;
     DECAP = 7;
     HIDDEN = 8;
+    L3_MPLS = 9;
   }
 
   // Defines the hardware pipeline stage of an entity.

--- a/stratum/public/proto/p4_table_defs.proto
+++ b/stratum/public/proto/p4_table_defs.proto
@@ -45,6 +45,7 @@ enum P4TableType {
   P4_TABLE_L2_MY_STATION = 4;  // The table that identifies whether a packet
                                // can be L3 routed based on (MAC, VLAN).
   P4_TABLE_L2_UNICAST = 5;     // The unicast logical table in L2 stage.
+  P4_TABLE_MPLS = 6;           // The MPLS transit table in L3 stage.
 }
 
 // This enum defines values to identify the table mapping output for match
@@ -141,6 +142,11 @@ enum P4FieldType {
   P4_FIELD_TYPE_DNS_AUTHORITY_RRS = 84;   // Number of NS RRs pointing towards authorities
   P4_FIELD_TYPE_DNS_ADDITIONAL_RRS = 85;  // Number of additional RRs
 
+  P4_FIELD_TYPE_MPLS_LABEL = 90;          // MPLS label
+  P4_FIELD_TYPE_MPLS_TRAFFIC_CLASS = 91;  // MPLS traffic class
+  P4_FIELD_TYPE_MPLS_BOS = 92;            // MPLS bottom of stack bit
+  P4_FIELD_TYPE_MPLS_TTL = 93;            // MPLS TTL
+
   // Field IDs over 1000 are reserved for adding more fields to existing
   // headers without renumbering.  Example: P4_FIELD_TYPE_GRE_SEQUENCE.
 }
@@ -164,6 +170,7 @@ enum P4HeaderType {
   P4_HEADER_ERSPAN = 13;
   P4_HEADER_DNS = 14;
   P4_HEADER_L4_PAYLOAD = 15;
+  P4_HEADER_MPLS = 16;
 }
 
 // This enum defines values to identify the mapping output for P4 actions.

--- a/stratum/public/proto/p4_table_defs.proto
+++ b/stratum/public/proto/p4_table_defs.proto
@@ -46,6 +46,7 @@ enum P4TableType {
                                // can be L3 routed based on (MAC, VLAN).
   P4_TABLE_L2_UNICAST = 5;     // The unicast logical table in L2 stage.
   P4_TABLE_MPLS = 6;           // The MPLS transit table in L3 stage.
+  P4_TABLE_L2_VLAN=7;
 }
 
 // This enum defines values to identify the table mapping output for match


### PR DESCRIPTION
## Description

Currently, stratum-bcm is not able to handle vlan tagged traffic unless a reactive approach is employed (by forwarding all traffic to the controller using, for example, the fwd application). The root cause of the problem is the fact that neither the VLAN is created anywhere in the codebase nor the respective port bitmaps are associated to the respective VLAN. This PR tries to solve the issue by creating (or removing) the VLANS on-demand whenever flow rules which reference a given VLAN are added (or removed) to/from the `my_station_table`. The VLAN id was already used by `BcmL2Manager::InsertMyStationEntry` but not exposed to the p4 pipeline.
Previously, the only way to achieve traffic forwarding would be to manually configure the VLANS in the bcm cli (e.g. for opennsa):

```
>> vlan create 10
>> vlan add 10 portBitMap=ce16,ce20
```

Superseeds: https://github.com/stratum/stratum/pull/782 (exactly the same code)

## How Has This Been Tested?

This was tested with the scenario illustrated below both with the Opennsa and SDKLT versions of stratum_bcm:

```
                 ┌──────────────────┐
                 │                  │
┌─────────┐      │                  │     ┌────────────┐
│    h1   │      │  stratum-bcm     │     │     h2     │
│         ├──────┤                  ├─────┤            │
└─────────┘      │                  │     └────────────┘
                 │                  │
10.66.5.2        └──────────────────┘      10.66.5.3

00:00:00:00:00:01                          00:00:00:00:00:02

 VLAN=10                                    VLAN=10
```

Using p4runtime-shell the following entries were created:

```
my_station_table:

H1 -> H2
t2=table_entry["ingress.my_station_table"](action="NoAction")
t2.match["hdr.ethernet.dst_addr"]="00:00:00:00:00:02"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.priority=50000
t2.insert()

H2 -> H1

t2=table_entry["ingress.my_station_table"](action="NoAction")
t2.match["hdr.ethernet.dst_addr"]="00:00:00:00:00:01"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.priority=50000
t2.insert()

punt/ACL table:

t=table_entry["ingress.punt.punt_table"](action="ingress.punt.set_egress_port")
t.match["hdr.ipv4_base.dst_addr"]="10.66.5.2"
t.match["hdr.vlan_tag[0].vid"]="10"
t.action["port"]="17"
t.priority=50000
t.insert()

t2=table_entry["ingress.punt.punt_table"](action="ingress.punt.set_egress_port")
t2.match["hdr.ipv4_base.dst_addr"]="10.66.5.3"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.action["port"]="102"
t2.priority=50000
t2.insert()
```

Traffic forwarding between both hosts was confirmed after installing the aforementioned rules. Removing the flows from `my_station_table` was also confirmed to remove the respective VLAN from the switch.

Regards
