### PR TITLE
Collate lint and style checks into single CI task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,23 +289,25 @@ jobs:
       - *clean_bazel_cache
       - *save_bazel_cache
 
-  cpp-format-check:
+  lint-and-style-check:
     docker:
       - image: stratumproject/build:build
     steps:
       - checkout
+      # We always continue with all steps, even on failures, to get the most
+      # information per CI run.
       - run:
+          when: always
           name: Run clang-format script
           command: .circleci/check-cpp-format.sh
-
-  cpp-lint-check:
-    docker:
-      - image: stratumproject/build:build
-    steps:
-      - checkout
       - run:
+          when: always
           name: Run cpplint
           command: cpplint --recursive --exclude=stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc stratum
+      - run:
+          when: always
+          name: Run buildifier script
+          command: .circleci/check-bazel-format.sh
 
   license-check:
     docker:
@@ -316,15 +318,6 @@ jobs:
           name: Run reuse
           command: reuse lint
 
-  bazel-style-check:
-    docker:
-      - image: stratumproject/build:build
-    steps:
-      - checkout
-      - run:
-          name: Run buildifier script
-          command: .circleci/check-bazel-format.sh
-
 workflows:
   version: 2
   build_and_test:
@@ -332,10 +325,8 @@ workflows:
       - unit_tests
       - cdlang_tests
       - coverage
-      - cpp-format-check
-      - cpp-lint-check
+      - lint-and-style-check
       - license-check
-      - bazel-style-check
   docker-publish:
     jobs:
       - publish-docker-build:


### PR DESCRIPTION
This speeds up CI by eliminating the overhead of setting up a new container per check. We ensure that all steps are always run to get the most information per run.