### PR TITLE
Make Stratum-bfrt the runtime default

### DIFF
--- a/stratum/docs/setup_guide_barefoot_tofino_onos.md
+++ b/stratum/docs/setup_guide_barefoot_tofino_onos.md
@@ -224,5 +224,6 @@ In case of problems with these instructions, feel free to create an issue or PR.
 - ["Trellis+Stratum example" (Untested)](/tools/mininet/examples/trellis)
 - [ONL building](https://opennetlinux.org/doc-building.html)
 - [stratum-bf Docker](https://registry.hub.docker.com/r/stratumproject/stratum-bf)
+- [stratum-bfrt Docker](https://registry.hub.docker.com/r/stratumproject/stratum-bfrt)
 - [ONOS CLI](https://wiki.onosproject.org/display/ONOS/Appendix+A+%3A+CLI+commands)
 - ["Using ONOS to control Stratum-enabled Intel/Barefoot Tofino-based switches"](https://wiki.onosproject.org/pages/viewpage.action?pageId=16122978)

--- a/stratum/hal/bin/barefoot/README.build.md
+++ b/stratum/hal/bin/barefoot/README.build.md
@@ -175,7 +175,7 @@ If you want to create a Docker image from the Debian package,
 ```bash
 export SDE_VERSION=9.3.2
 export STRATUM_TARGET=stratum_bfrt
-docker build -t stratumproject/stratum-bf:$SDE_VERSION \
+docker build -t stratumproject/stratum-bfrt:$SDE_VERSION \
   --build-arg STRATUM_TARGET="$STRATUM_TARGET" \
   -f stratum/hal/bin/barefoot/docker/Dockerfile \
   bazel-bin/stratum/hal/bin/barefoot
@@ -196,7 +196,7 @@ docker save [Image Name] -o [Tarball Name]
 
 For example,
 ```bash
-docker save stratumproject/stratum-bf:9.3.2 -o stratum-bf-9.3.2-docker.tar
+docker save stratumproject/stratum-bfrt:9.3.2 -o stratum-bfrt-9.3.2-docker.tar
 ```
 
 ### Method 4: Build the SDE and Stratum locally

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -22,11 +22,11 @@ You can pull a nightly version of this container image from
 [Dockerhub](https://hub.docker.com/repository/docker/stratumproject/stratum-bf/tags)
 
 ```bash
-$ docker pull stratumproject/stratum-bf:[SDE version]
+$ docker pull stratumproject/stratum-bfrt:[SDE version]
 ```
 
 For example, the container with BF SDE 9.3.2: <br/>
-`stratumproject/stratum-bf:9.3.2`
+`stratumproject/stratum-bfrt:9.3.2`
 
 These containers include kernel modules for OpenNetworkLinux.
 
@@ -60,8 +60,8 @@ docker save [Image Name] -o [Tarball Name]
 
 For example,
 ```bash
-docker pull stratumproject/stratum-bf:9.3.2
-docker save stratumproject/stratum-bf:9.3.2 -o stratum-bf-9.3.2-docker.tar
+docker pull stratumproject/stratum-bfrt:9.3.2
+docker save stratumproject/stratum-bfrt:9.3.2 -o stratum-bfrt-9.3.2-docker.tar
 ```
 
 Then, deploy the tarball to the device via scp, rsync, http, USB stick, etc.
@@ -77,7 +77,7 @@ docker images
 For example,
 
 ```bash
-docker load -i stratum-bf-9.3.2-docker.tar
+docker load -i stratum-bfrt-9.3.2-docker.tar
 ```
 
 ### Set up huge pages
@@ -118,7 +118,7 @@ For more details on additional options that can be passed to
 CHASSIS_CONFIG    # Override the default chassis config file.
 LOG_DIR           # The directory for logging, default: `/var/log/`.
 SDE_VERSION       # The SDE version
-DOCKER_IMAGE      # The container image name, default: stratumproject/stratum-bf
+DOCKER_IMAGE      # The container image name, default: stratumproject/stratum-bfrt
 DOCKER_IMAGE_TAG  # The container image tag, default: $SDE_VERSION
 PLATFORM          # Use specific platform port map
 ```

--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -5,7 +5,7 @@ set -e
 
 LOG_DIR=${LOG_DIR:-/var/log}
 SDE_VERSION=${SDE_VERSION:-9.3.2}
-DOCKER_IMAGE=${DOCKER_IMAGE:-stratumproject/stratum-bf}
+DOCKER_IMAGE=${DOCKER_IMAGE:-stratumproject/stratum-bfrt}
 DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-$SDE_VERSION}
 
 # Try to load the platform string if not already set.

--- a/stratum/tools/stratum_replay/README.md
+++ b/stratum/tools/stratum_replay/README.md
@@ -40,7 +40,7 @@ container we should access.
 
 ```
 $ docker ps | grep stratum-bf
-4c615277261d  stratumproject/stratum-bf:9.3.2-4.14.49-OpenNetworkLinux  "/usr/bin/stratum-st…"  5 days ago  Up 5 days
+4c615277261d  stratumproject/stratum-bfrt:9.3.2-4.14.49-OpenNetworkLinux  "/usr/bin/stratum-st…"  5 days ago  Up 5 days
 ```
 
 The `4c615277261d` is the container ID we need.


### PR DESCRIPTION
This PR makes Stratum-bfrt the default selection at runtime over Stratum-bf.

Followup to #776, which made it the compile-time default.