### PR TITLE
Push tools image to Aether harbor registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,12 @@ docker_login: &docker_login
   run:
     name: Docker login
     command: echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
+
+harbor_login: &harbor_login
+  run:
+    name: Harbor login
+    command: echo $AETHER_HARBOR_PWD | docker login -u $AETHER_HARBOR_LOGIN --password-stdin registry.aetherproject.org
+
 docker_build: &docker_build
   run:
     name: Build Docker image
@@ -67,10 +73,17 @@ docker_build: &docker_build
         --label build-timestamp=$(date +%FT%T%z) \
         --label build-machine=circle-ci \
         .
+      docker tag $DOCKER_IMG registry.aetherproject.org/$HARBOR_IMG
+
 docker_push: &docker_push
   run:
     name: Push Docker image
     command: docker push $DOCKER_IMG
+
+harbor_push: &harbor_push
+  run:
+    name: Push Docker image to harbor
+    command: docker push registry.aetherproject.org/$HARBOR_IMG
 
 jobs:
 
@@ -267,6 +280,7 @@ jobs:
       - DOCKER_SCOPE: stratum/tools
       - DOCKER_FILE: Dockerfile.stratum_tools
       - DOCKER_IMG: stratumproject/stratum-tools
+      - HARBOR_IMG: tost/stratum-tools
       - CC: clang
       - CXX: clang++
     steps:
@@ -280,12 +294,14 @@ jobs:
             bazel build --config=release //stratum/tools:stratum_tools_deb
             cp bazel-bin/stratum/tools/stratum_tools_deb.deb $DOCKER_SCOPE
       - *docker_login
+      - *harbor_login
       - *docker_build
       - run:
           name: Test stratum-tools Docker image
           command: |
             docker run $DOCKER_IMG
       - *docker_push
+      - *harbor_push
       - *clean_bazel_cache
       - *save_bazel_cache
 


### PR DESCRIPTION
With the docker.io rate limits and the depreciation of the bf-pipeline-builder image, I decided to upload the `stratum-tools` image to the Aether registry as well. It can be found here: https://registry.aetherproject.org/harbor/projects/4/repositories/stratum-tools. ONF projects should use that image going forward.

Pros of pushing the image from here (circleci):
- Full control over build flags and tags
- Easy to change, update and maintain in one atomic commit

Cons:
- Increased risk of credential leak (will be addressed in the future with project specific credentials)
- Two names for the same image `tost/stratum-tools` and `stratumproject/stratum-tools`

Any other concerns?