### PR TITLE
[stratum-bcm] Fix meter color conditions and reference pipeline

### DIFF
--- a/stratum/hal/lib/p4/p4_table_mapper.h
+++ b/stratum/hal/lib/p4/p4_table_mapper.h
@@ -467,6 +467,11 @@ class P4TableMapper {
       const ::p4::config::v1::ActionProfile& profile_p4_info,
       const ::p4::v1::Action& action, MappedAction* mapped_action) const;
 
+  // Processes the action redirects specified by the action for the table.
+  ::util::Status ProcessTableActionRedirects(
+      const ::p4::config::v1::Table& table_p4_info,
+      const ::p4::v1::Action& action, MappedAction* mapped_action) const;
+
   // Handles action function processing that is common to either a table entry
   // or an action profile update.  If successful, the output mapped_action will
   // be filled.

--- a/stratum/hal/lib/p4/p4_table_mapper.h
+++ b/stratum/hal/lib/p4/p4_table_mapper.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_H_
 
@@ -11,10 +10,11 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/p4/common_flow_entry.pb.h"
@@ -24,7 +24,6 @@
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace hal {


### PR DESCRIPTION
## Description

According to the p4c-fpm compiler implementation, for `color_actions` to be recognized they must:

- follow a table hit on the ACL table: https://github.com/stratum/stratum/blob/b78cd64155a96ef1db6b548556bdc1c83bfe27fa/stratum/p4c_backends/fpm/table_hit_inspector.cc#L120-L121
- the local metadata color member must be an enum and not to some randomly defined `bit<2>` field as of today: https://github.com/stratum/stratum/blob/334ec403c47bd2338d9ca6204f52f72c1a2a8989/stratum/p4c_backends/fpm/meter_color_mapper.cc#L284
- the global color comparison must specifically be made against a member called `MeterColor_t` https://github.com/stratum/stratum/blob/334ec403c47bd2338d9ca6204f52f72c1a2a8989/stratum/p4c_backends/fpm/meter_color_mapper.cc#L310

Unfortunately, even after fixing the reference pipeline to include a default meter `color_action`:

```p4
if (punt_table.apply().hit) {
    if (local_metadata.color != MeterColor_t.COLOR_GREEN) {
        mark_to_drop(standard_metadata);
    }
}
```

stratum-bcm is still not able to associate the action to the ACL flow entries. This happens because in the generated protobuf (switch binary) color-based actions are represented as Action Redirects. E.g. for the `ingress.punt.set_egress_port` ACL action, an action redirect is defined that points to `__ingress.punt.set_egress_port__Meter1`, this last containing the `color_action`. 

```
table_map {
  key: "ingress.punt.set_egress_port"
  value {
    action_descriptor {
      type: P4_ACTION_TYPE_FUNCTION
      assignments {
        assigned_value {
          source_field_name: "standard_metadata.egress_spec"
        }
        destination_field_name: "local_metadata.egress_spec_at_punt_match"
      }
      assignments {
        assigned_value {
          parameter_name: "port"
        }
        destination_field_name: "standard_metadata.egress_spec"
      }
      action_redirects {
        internal_links {
          internal_action_name: "__ingress.punt.set_egress_port__Meter1"
          applied_tables: "ingress.punt.punt_table"
        }
      }
    }
  }
}
table_map {
  key: "__ingress.punt.set_egress_port__Meter1"
  value {
    internal_action {
      type: P4_ACTION_TYPE_FUNCTION
      assignments {
        assigned_value {
          source_field_name: "standard_metadata.egress_spec"
        }
        destination_field_name: "local_metadata.egress_spec_at_punt_match"
      }
      assignments {
        assigned_value {
          parameter_name: "port"
        }
        destination_field_name: "standard_metadata.egress_spec"
      }
      color_actions {
        colors: P4_METER_YELLOW
        colors: P4_METER_RED
        ops {
          primitives: P4_ACTION_OP_DROP
        }
      }
    }
  }
}
```
For the `meter_color` action to be applied, stratum needs to also process the action redirects when processing a given action. That's all this PR does:
- It adds `ProcessTableActionRedirects` to p4_table_mapper
- It fixes the reference pipeline to include a working example of `color_action` on the ACL table

## How Has This Been Tested?

This was tested with the scenario illustrated below both with the Opennsa and SDKLT versions of stratum_bcm. It also includes the patch from https://github.com/stratum/stratum/pull/783 to fix vlan traffic forwarding (although unrelated to this patch).

```
                 ┌──────────────────┐
                 │                  │
┌─────────┐      │                  │     ┌────────────┐
│    h1   │      │  stratum-bcm     │     │     h2     │
│         ├──────┤                  ├─────┤            │
└─────────┘      │                  │     └────────────┘
                 │                  │
10.66.5.2        └──────────────────┘      10.66.5.3

00:00:00:00:00:01                          00:00:00:00:00:02

 (VLAN=10)                                    (VLAN=10)
```

Using p4runtime-shell the following entries were created:

```
punt/ACL table flows:

t=table_entry["ingress.punt.punt_table"](action="ingress.punt.set_egress_port")
t.match["hdr.ipv4_base.dst_addr"]="10.66.5.2"
t.match["hdr.vlan_tag[0].vid"]="10"
t.action["port"]="17"
t.priority=50000
t.insert()

t2=table_entry["ingress.punt.punt_table"](action="ingress.punt.set_egress_port")
t2.match["hdr.ipv4_base.dst_addr"]="10.66.5.3"
t2.match["hdr.vlan_tag[0].vid"]="10"
t2.action["port"]="102"
t2.priority=50000
t2.insert()

Direct Meter installation (modify action)

ce = DirectMeterEntry('ingress.punt.ingress_port_meter')
ce.table_entry.match['hdr.ipv4_base.dst_addr'] = '10.66.5.2'
ce.table_entry.match["hdr.vlan_tag[0].vid"]="10"
ce.table_entry.priority = 50000
ce.cir = 200
ce.cburst = 200
ce.pir = 300
ce.pburst = 300
ce.modify()

ce = DirectMeterEntry('ingress.punt.ingress_port_meter')
ce.table_entry.match['hdr.ipv4_base.dst_addr'] = '10.66.5.3'
ce.table_entry.match["hdr.vlan_tag[0].vid"]="10"
ce.table_entry.priority = 50000
ce.cir = 200
ce.cburst = 200
ce.pir = 300
ce.pburst = 300
ce.modify()

```

We've checked that each punt_table flow rule also configures the respective `drop` action associated to colors, i.e., this block of code is reached:

https://github.com/stratum/stratum/blob/334ec403c47bd2338d9ca6204f52f72c1a2a8989/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc#L3574-L3584

Best regards
