### PR TITLE
[stratum-bcm] Fix stacked headers on the ACL table

### DIFF
--- a/stratum/hal/lib/bcm/bcm.proto
+++ b/stratum/hal/lib/bcm/bcm.proto
@@ -314,6 +314,7 @@ message BcmField {
   // Type field is irrelevant to programming and verification but can be used
   // for bookkeeping.
   uint32 udf_chunk_id = 4;  // optional
+  uint32 header_depth = 5;  // optional
 }
 
 // BcmAction, as part of a flow entry, refers to the action that we take upon a

--- a/stratum/hal/lib/bcm/bcm_table_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager.cc
@@ -95,6 +95,7 @@ void FillBcmTableEntryValue(const P4ActionFunction::P4ActionFields& source,
 void FillBcmField(BcmField::Type type, const MappedField& source,
                   BcmField* bcm_field) {
   bcm_field->set_type(type);
+  bcm_field->set_header_depth(source.header_depth());
   if (source.has_value()) {
     FillBcmTableEntryValue(source.value(), bcm_field->mutable_value());
   }

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -3016,47 +3016,50 @@ bcm_field_qualify_t HalAclStageToBcm(BcmAclStage stage) {
   return gtl::FindWithDefault(*bcm_stage_map, stage, bcmFieldQualifyCount);
 }
 
-// Returns the BCM type for given field or else enum count.
-bcm_field_qualify_t HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
+// Returns the BCM types for given field or else enum count.
+std::list<bcm_field_qualify_t> HalAclFieldToBcm(BcmAclStage stage,
+                                                BcmField::Type field) {
   // Default mappings for most ACL stages.
   static auto* default_field_map =
-      new absl::flat_hash_map<BcmField::Type, bcm_field_qualify_t,
+      new absl::flat_hash_map<BcmField::Type, std::list<bcm_field_qualify_t>,
                               EnumHash<BcmField::Type>>({
-          {BcmField::ETH_TYPE, bcmFieldQualifyEtherType},
-          {BcmField::IP_TYPE, bcmFieldQualifyIpType},
-          {BcmField::ETH_SRC, bcmFieldQualifySrcMac},
-          {BcmField::ETH_DST, bcmFieldQualifyDstMac},
-          {BcmField::VRF, bcmFieldQualifyVrf},
-          {BcmField::IN_PORT, bcmFieldQualifyInPort},
-          {BcmField::IN_PORT_BITMAP, bcmFieldQualifyInPorts},
-          {BcmField::OUT_PORT, bcmFieldQualifyDstPort},
-          {BcmField::VLAN_VID, bcmFieldQualifyOuterVlanId},
-          {BcmField::VLAN_PCP, bcmFieldQualifyOuterVlanPri},
-          {BcmField::IPV4_SRC, bcmFieldQualifySrcIp},
-          {BcmField::IPV4_DST, bcmFieldQualifyDstIp},
-          {BcmField::IPV6_SRC, bcmFieldQualifySrcIp6},
-          {BcmField::IPV6_DST, bcmFieldQualifyDstIp6},
-          {BcmField::IPV6_SRC_UPPER_64, bcmFieldQualifySrcIp6High},
-          {BcmField::IPV6_DST_UPPER_64, bcmFieldQualifyDstIp6High},
-          {BcmField::IP_PROTO_NEXT_HDR, bcmFieldQualifyIpProtocol},
-          {BcmField::IP_DSCP_TRAF_CLASS, bcmFieldQualifyDSCP},
-          {BcmField::IP_TTL_HOP_LIMIT, bcmFieldQualifyTtl},
-          {BcmField::VFP_DST_CLASS_ID, bcmFieldQualifyDstClassField},
-          {BcmField::L3_DST_CLASS_ID, bcmFieldQualifyDstClassL3},
-          {BcmField::L4_SRC, bcmFieldQualifyL4SrcPort},
-          {BcmField::L4_DST, bcmFieldQualifyL4DstPort},
-          {BcmField::TCP_FLAGS, bcmFieldQualifyTcpControl},
-          {BcmField::ICMP_TYPE_CODE, bcmFieldQualifyIcmpTypeCode},
+          {BcmField::ETH_TYPE, {bcmFieldQualifyEtherType}},
+          {BcmField::IP_TYPE, {bcmFieldQualifyIpType}},
+          {BcmField::ETH_SRC, {bcmFieldQualifySrcMac}},
+          {BcmField::ETH_DST, {bcmFieldQualifyDstMac}},
+          {BcmField::VRF, {bcmFieldQualifyVrf}},
+          {BcmField::IN_PORT, {bcmFieldQualifyInPort}},
+          {BcmField::IN_PORT_BITMAP, {bcmFieldQualifyInPorts}},
+          {BcmField::OUT_PORT, {bcmFieldQualifyDstPort}},
+          {BcmField::VLAN_VID,
+           {bcmFieldQualifyOuterVlanId, bcmFieldQualifyInnerVlanId}},
+          {BcmField::VLAN_PCP,
+           {bcmFieldQualifyOuterVlanPri, bcmFieldQualifyInnerVlanPri}},
+          {BcmField::IPV4_SRC, {bcmFieldQualifySrcIp}},
+          {BcmField::IPV4_DST, {bcmFieldQualifyDstIp}},
+          {BcmField::IPV6_SRC, {bcmFieldQualifySrcIp6}},
+          {BcmField::IPV6_DST, {bcmFieldQualifyDstIp6}},
+          {BcmField::IPV6_SRC_UPPER_64, {bcmFieldQualifySrcIp6High}},
+          {BcmField::IPV6_DST_UPPER_64, {bcmFieldQualifyDstIp6High}},
+          {BcmField::IP_PROTO_NEXT_HDR, {bcmFieldQualifyIpProtocol}},
+          {BcmField::IP_DSCP_TRAF_CLASS, {bcmFieldQualifyDSCP}},
+          {BcmField::IP_TTL_HOP_LIMIT, {bcmFieldQualifyTtl}},
+          {BcmField::VFP_DST_CLASS_ID, {bcmFieldQualifyDstClassField}},
+          {BcmField::L3_DST_CLASS_ID, {bcmFieldQualifyDstClassL3}},
+          {BcmField::L4_SRC, {bcmFieldQualifyL4SrcPort}},
+          {BcmField::L4_DST, {bcmFieldQualifyL4DstPort}},
+          {BcmField::TCP_FLAGS, {bcmFieldQualifyTcpControl}},
+          {BcmField::ICMP_TYPE_CODE, {bcmFieldQualifyIcmpTypeCode}},
       });
   // Stage specific field mappings.
   static auto* efp_field_map =
-      new absl::flat_hash_map<BcmField::Type, bcm_field_qualify_t,
+      new absl::flat_hash_map<BcmField::Type, std::list<bcm_field_qualify_t>,
                               EnumHash<BcmField::Type>>({
-          {BcmField::OUT_PORT, bcmFieldQualifyOutPort},
+          {BcmField::OUT_PORT, {bcmFieldQualifyOutPort}},
       });
   auto* stage_map = (stage == BCM_ACL_STAGE_EFP) ? efp_field_map : nullptr;
   auto default_qual =
-      gtl::FindWithDefault(*default_field_map, field, bcmFieldQualifyCount);
+      gtl::FindWithDefault(*default_field_map, field, {bcmFieldQualifyCount});
   if (stage_map) return gtl::FindWithDefault(*stage_map, field, default_qual);
   return default_qual;
 }
@@ -3085,14 +3088,16 @@ bcm_field_qualify_t HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
           unit, &group_config.qset, field.udf_chunk_id()));
       continue;
     }
-    bcm_field_qualify_t bcm_field =
+    std::list<bcm_field_qualify_t> bcm_fields =
         HalAclFieldToBcm(table.stage(), field.type());
-    if (bcm_field == bcmFieldQualifyCount) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Attempted to create ACL table with invalid predefined qualifier: "
-          << field.ShortDebugString() << ".";
+    for (const auto& bcm_field : bcm_fields) {
+      if (bcm_field == bcmFieldQualifyCount) {
+        RETURN_ERROR(ERR_INVALID_PARAM) << "Attempted to create ACL table with "
+                                           "invalid predefined qualifier: "
+                                        << field.ShortDebugString() << ".";
+      }
+      BCM_FIELD_QSET_ADD(group_config.qset, bcm_field);
     }
-    BCM_FIELD_QSET_ADD(group_config.qset, bcm_field);
   }
   // Allow SDK to find smallest possible table width for bank.
   group_config.mode = bcmFieldGroupModeAuto;
@@ -3382,12 +3387,30 @@ inline int bcm_add_field_u32(F func, int unit, int flow_id,
                                                        unit, entry, field));
       break;
     case BcmField::VLAN_VID:
-      RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_vlan_t>(
-          bcm_field_qualify_OuterVlanId, unit, entry, field));
+      if (field.header_depth() == 0) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_OuterVlanId, unit, entry, field));
+      } else if (field.header_depth() == 1) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_InnerVlanId, unit, entry, field));
+      } else {
+        LOG(ERROR) << "Attempted to translate unsupported BcmField::Type: "
+                   << BcmField::Type_Name(field.type()) << " with header_depth "
+                   << field.header_depth() << ".";
+      }
       break;
     case BcmField::VLAN_PCP:
-      RETURN_IF_BCM_ERROR(bcm_add_field_u32<uint8>(
-          bcm_field_qualify_OuterVlanPri, unit, entry, field));
+      if (field.header_depth() == 0) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<uint8>(
+            bcm_field_qualify_OuterVlanPri, unit, entry, field));
+      } else if (field.header_depth() == 1) {
+        RETURN_IF_BCM_ERROR(bcm_add_field_u32<uint8>(
+            bcm_field_qualify_InnerVlanPri, unit, entry, field));
+      } else {
+        LOG(ERROR) << "Attempted to translate unsupported BcmField::Type: "
+                   << BcmField::Type_Name(field.type()) << " with header_depth "
+                   << field.header_depth() << ".";
+      }
       break;
     case BcmField::IPV4_SRC:
       RETURN_IF_BCM_ERROR(bcm_add_field_u32<bcm_ip_t>(bcm_field_qualify_SrcIp,
@@ -3836,7 +3859,12 @@ void FillAclPolicerConfig(const BcmMeterConfig& meter,
   table->clear_fields();
   for (int i = BcmField::UNKNOWN + 1; i <= BcmField::Type_MAX; ++i) {
     auto field = static_cast<BcmField::Type>(i);
-    if (BCM_FIELD_QSET_TEST(qset, HalAclFieldToBcm(table->stage(), field))) {
+    const std::list<bcm_field_qualify_t> bcm_acl_fields =
+        HalAclFieldToBcm(table->stage(), field);
+    if (std::all_of(bcm_acl_fields.cbegin(), bcm_acl_fields.cend(),
+                    [qset](bcm_field_qualify_t bcm_field) {
+                      return BCM_FIELD_QSET_TEST(qset, bcm_field);
+                    })) {
       table->add_fields()->set_type(field);
     }
   }
@@ -4104,12 +4132,32 @@ inline int bcm_get_field_u32(F func, int unit, int flow_id, uint32* value,
                                          &value, &mask);
       break;
     case BcmField::VLAN_VID:
-      retval = bcm_get_field_u32<bcm_vlan_t>(bcm_field_qualify_OuterVlanId_get,
-                                             unit, entry, &value, &mask);
+      if (field->header_depth() == 0) {
+        retval = bcm_get_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_OuterVlanId_get, unit, entry, &value, &mask);
+      } else if (field->header_depth() == 1) {
+        retval = bcm_get_field_u32<bcm_vlan_t>(
+            bcm_field_qualify_InnerVlanId_get, unit, entry, &value, &mask);
+      } else {
+        LOG(ERROR) << "Could not retrieve BcmField::Type "
+                   << BcmField::Type_Name(field->type())
+                   << " with header depth " << field->header_depth();
+        return false;
+      }
       break;
     case BcmField::VLAN_PCP:
-      retval = bcm_get_field_u32<uint8>(bcm_field_qualify_OuterVlanPri_get,
-                                        unit, entry, &value, &mask);
+      if (field->header_depth() == 0) {
+        retval = bcm_get_field_u32<uint8>(bcm_field_qualify_OuterVlanPri_get,
+                                          unit, entry, &value, &mask);
+      } else if (field->header_depth() == 1) {
+        retval = bcm_get_field_u32<uint8>(bcm_field_qualify_InnerVlanPri_get,
+                                          unit, entry, &value, &mask);
+      } else {
+        LOG(ERROR) << "Could not retrieve BcmField::Type "
+                   << BcmField::Type_Name(field->type())
+                   << " with header depth " << field->header_depth();
+        return false;
+      }
       break;
     case BcmField::IPV4_SRC:
       retval = bcm_get_field_u32<bcm_ip_t>(bcm_field_qualify_SrcIp_get, unit,

--- a/stratum/hal/lib/p4/common_flow_entry.proto
+++ b/stratum/hal/lib/p4/common_flow_entry.proto
@@ -72,6 +72,7 @@ message MappedField {
   int32 bit_offset = 4;
   int32 bit_width = 5;
   P4HeaderType header_type = 6;
+  int32 header_depth = 7;
 }
 
 // This message supports action function mapping.  It applies to actions in

--- a/stratum/hal/lib/p4/p4_table_map.proto
+++ b/stratum/hal/lib/p4/p4_table_map.proto
@@ -151,6 +151,10 @@ message P4FieldDescriptor {
     string table_name = 1;
   }
 
+  message P4HeaderLink {
+    string header_key = 1;
+  }
+
   // Mapping fields for match fields are:
   //  type - Identifies the field in an output flow entry.
   //  valid_conversions - Indicates how to derive the flow entry field value
@@ -179,6 +183,7 @@ message P4FieldDescriptor {
   P4HeaderType header_type = 7;
   repeated P4MetadataKey metadata_keys = 8;
   string value_set = 9;
+  P4HeaderLink header_link = 10;
 }
 
 // A P4ActionDescriptor defines how to map a P4 runtime action into a common

--- a/stratum/p4c_backends/fpm/field_decoder.cc
+++ b/stratum/p4c_backends/fpm/field_decoder.cc
@@ -120,9 +120,10 @@ void FieldDecoder::ConvertHeaderFields(
         const std::string header_field_name =
             iter.first + "." + field_in_type.name();
         table_mapper_->AddField(header_field_name);
+
         UpdateFieldMapData(header_field_name, iter.second, field_in_type.name(),
                            annotated_types, field_in_type.bit_offset(),
-                           field_in_type.bit_width());
+                           field_in_type.bit_width(), iter.first);
         field_in_type.add_full_field_names(header_field_name);
         VLOG(1) << "Mapped header field name: " << header_field_name;
       }
@@ -247,7 +248,8 @@ bool FieldDecoder::DecodePathEndField(
 void FieldDecoder::UpdateFieldMapData(
     const std::string& fq_field_name, const std::string& header_type_name,
     const std::string& field_name, const AnnotatedFieldTypeMap& annotated_types,
-    uint32_t bit_offset, uint32_t bit_width) {
+    uint32_t bit_offset, uint32_t bit_width,
+    const std::string& parent_header_key) {
   AnnotatedFieldTypeMapKey key = std::make_pair(header_type_name, field_name);
   const auto& iter = annotated_types.find(key);
 
@@ -259,6 +261,8 @@ void FieldDecoder::UpdateFieldMapData(
   }
   table_mapper_->SetFieldAttributes(
       fq_field_name, field_type, P4_HEADER_UNKNOWN, bit_offset, bit_width);
+  // Add reference / link to the parent header
+  table_mapper_->SetFieldHeaderLink(fq_field_name, parent_header_key);
   if (header_type_name == GetP4ModelNames().local_metadata_type_name()) {
     table_mapper_->SetFieldLocalMetadataFlag(fq_field_name);
   }

--- a/stratum/p4c_backends/fpm/field_decoder.h
+++ b/stratum/p4c_backends/fpm/field_decoder.h
@@ -104,10 +104,11 @@ class FieldDecoder {
   // bit_offset and bit_width describe the field's position with its
   // surrounding header.
   void UpdateFieldMapData(const std::string& fq_field_name,
-                             const std::string& header_type_name,
-                             const std::string& field_name,
-                             const AnnotatedFieldTypeMap& annotated_types,
-                             uint32_t bit_offset, uint32_t bit_width);
+                          const std::string& header_type_name,
+                          const std::string& field_name,
+                          const AnnotatedFieldTypeMap& annotated_types,
+                          uint32_t bit_offset, uint32_t bit_width,
+                          const std::string& parent_header_key);
 
   // Determines whether the input field has an annotated field type.  If the
   // annotation exists, StoreFieldTypeAnnotation parses the field type and

--- a/stratum/p4c_backends/fpm/parser_field_mapper.cc
+++ b/stratum/p4c_backends/fpm/parser_field_mapper.cc
@@ -422,9 +422,16 @@ int ParserFieldMapper::MatchTargetAndP4Fields(
   // outer header.  Non-extracted fields move to the pass3_fields_map_ map
   // for processing in Pass3 if they are still unresolved.
   int32 header_depth = 0;
-  if (in_tunnel) header_depth = 1;
   if (!mapped_fields.empty() || header_visited) {
-    for (const auto& header : p4_header.header_paths()) {
+    for (int i = 0; i < p4_header.header_paths().size(); ++i) {
+      const auto& header = p4_header.header_paths().Get(i);
+      if (in_tunnel) {
+        header_depth = 1;
+      } else if (IsHeaderArrayLast(header)) {
+        header_depth = i - 1;
+      } else {
+        header_depth = i;
+      }
       table_mapper_->SetHeaderAttributes(
           header, target_header.header_type(), header_depth);
     }

--- a/stratum/p4c_backends/fpm/table_map_generator.cc
+++ b/stratum/p4c_backends/fpm/table_map_generator.cc
@@ -79,6 +79,18 @@ void TableMapGenerator::SetFieldAttributes(
   }
 }
 
+void TableMapGenerator::SetFieldHeaderLink(
+    const std::string& field_name, const std::string& parent_header_key) {
+  hal::P4FieldDescriptor* field_descriptor =
+      FindMutableFieldDescriptorOrNull(field_name, generated_map_.get());
+  if (field_descriptor == nullptr) {
+    // TODO(unknown): Treat as internal compiler BUG exception?
+    LOG(ERROR) << "Unable to find field " << field_name << " to set attributes";
+    return;
+  }
+  field_descriptor->mutable_header_link()->set_header_key(parent_header_key);
+}
+
 void TableMapGenerator::SetFieldLocalMetadataFlag(
     const std::string& field_name) {
   hal::P4FieldDescriptor* field_descriptor =

--- a/stratum/p4c_backends/fpm/table_map_generator.h
+++ b/stratum/p4c_backends/fpm/table_map_generator.h
@@ -76,6 +76,8 @@ class TableMapGenerator {
                                   P4FieldType field_type,
                                   P4HeaderType header_type,
                                   uint32_t bit_offset, uint32_t bit_width);
+  virtual void SetFieldHeaderLink(const std::string& field_name,
+                                  const std::string& parent_header_key);
   virtual void SetFieldLocalMetadataFlag(const std::string& field_name);
   virtual void SetFieldValueSet(const std::string& field_name,
                                 const std::string& value_set_name,

--- a/stratum/p4c_backends/fpm/utils.cc
+++ b/stratum/p4c_backends/fpm/utils.cc
@@ -280,6 +280,13 @@ std::string AddHeaderArrayLast(const std::string& header_name) {
       "$0.$1", header_name.c_str(), IR::Type_Stack::last.c_str());
 }
 
+bool IsHeaderArrayLast(const std::string& header_name) {
+  const std::string last = "last";
+  return header_name.size() >= last.size() &&
+         0 == header_name.compare(header_name.size() - last.size(), last.size(),
+                                  last);
+}
+
 bool IsParserEndState(const ParserState& state) {
   if (state.transition().next_state() == IR::ParserState::accept)
     return true;

--- a/stratum/p4c_backends/fpm/utils.h
+++ b/stratum/p4c_backends/fpm/utils.h
@@ -109,6 +109,9 @@ std::string AddHeaderArrayIndex(const std::string& header_name, int64 index);
 // output is "hdr.name.last".
 std::string AddHeaderArrayLast(const std::string& header_name);
 
+// Checks if the header name ends with the P4 parser "last" operator
+bool IsHeaderArrayLast(const std::string& header_name);
+
 // Returns true if the input ParserState specifies a transition to one of
 // P4's built-in terminating states, i.e. "accept" or "reject".
 bool IsParserEndState(const ParserState& state);

--- a/stratum/pipelines/main/main.p4
+++ b/stratum/pipelines/main/main.p4
@@ -366,6 +366,8 @@ control punt(inout parsed_packet_t hdr,
             local_metadata.icmp_code      : ternary;
             hdr.vlan_tag[0].vid           : ternary;
             hdr.vlan_tag[0].pcp           : ternary;
+            //hdr.vlan_tag[1].vid           : ternary;
+            //hdr.vlan_tag[1].pcp           : ternary;
             local_metadata.class_id       : ternary;
             local_metadata.vrf_id         : ternary;
         }


### PR DESCRIPTION
## Description

This is a WIP implementation targeted at fixing header stacking on the stratum-bcm ACL/punt table. Currently, the `header_depth` field is only being set in case the header is a tunnel. For stacked headers (e.g. vlan double tag) this field is not being set. Furthermore, extracted match fields do not hold a reference to the parent header making it impossible to know to which depth in the stack they refer to.

So, this PR makes sure `header_depth` is set for stacked headers and that a link to the parent header (`header_link`) is saved on the switch protobuf binary. See the textual representation below:

```
table_map {
  key: "hdr.vlan_tag[0]"
  value {
    header_descriptor {
      type: P4_HEADER_VLAN
    }
  }
}
...
table_map {
  key: "hdr.vlan_tag[0].vid"
  value {
    field_descriptor {
      type: P4_FIELD_TYPE_VLAN_VID
      valid_conversions {
        match_type: TERNARY
        conversion: P4_CONVERT_TO_U32_AND_MASK
      }
      bit_offset: 4
      bit_width: 12
      header_type: P4_HEADER_VLAN
      header_link {
        header_key: "hdr.vlan_tag[0]"
      }
    }
  }
}
...
table_map {
  key: "hdr.vlan_tag[1]"
  value {
    header_descriptor {
      type: P4_HEADER_VLAN
      depth: 1
    }
  }
}
...
table_map {
  key: "hdr.vlan_tag[1].vid"
  value {
    field_descriptor {
      type: P4_FIELD_TYPE_VLAN_VID
      valid_conversions {
        match_type: TERNARY
        conversion: P4_CONVERT_TO_U32_AND_MASK
      }
      bit_offset: 4
      bit_width: 12
      header_type: P4_HEADER_VLAN
      header_link {
        header_key: "hdr.vlan_tag[1]"
      }
    }
  }
}
```

This allow us to propagate the `header_depth` up until the `BcmField` construction. For QinQ, the `BcmField::Type` is always `BcmField::VLAN_VID` regardless of the `header_depth`. If we want to have different treatment for single-tagged packets vs double-tagged packets we need a way to differentiate them. The header depth of the parent header (i.e. the vlan header holding the VLAN_VID) seems the logical way to do it.

Some things are missing in the implementation (see list below). Either way, some early feedback is appreciated.

Todo:

- [ ] Handle Tests
- [ ] SDKLT implementation
- [ ] Documentation
