### PR TITLE
[stratum-bcm] Support the P4 DirectMeterEntryRead operation

### DIFF
--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -239,13 +239,18 @@ BcmNode::~BcmNode() {}
                  << entity.ShortDebugString() << ".";
         if (details != nullptr) details->push_back(status);
         break;
-      case ::p4::v1::Entity::kDirectMeterEntry:
-        // TODO(unknown): Implement this.
-        status = MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-                 << "Direct meter entries are not currently supported: "
-                 << entity.ShortDebugString() << ".";
-        if (details != nullptr) details->push_back(status);
+      case ::p4::v1::Entity::kDirectMeterEntry: {
+        ::p4::v1::ReadResponse resp;
+        std::vector<::p4::v1::DirectMeterEntry*> acl_directmeterentries;
+        RETURN_IF_ERROR(bcm_table_manager_->ReadDirectMeterTableEntries(
+            entity.direct_meter_entry().table_entry().table_id(), &resp));
+
+        if (!writer->Write(resp)) {
+          return MAKE_ERROR(ERR_INTERNAL)
+                 << "Write to stream for failed for node " << node_id_ << ".";
+        }
         break;
+      }
       case ::p4::v1::Entity::kCounterEntry:
         // TODO(unknown): Implement this.
         status = MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)

--- a/stratum/hal/lib/bcm/bcm_table_manager.h
+++ b/stratum/hal/lib/bcm/bcm_table_manager.h
@@ -320,6 +320,11 @@ class BcmTableManager {
       const std::set<uint32>& table_ids, ::p4::v1::ReadResponse* resp,
       std::vector<::p4::v1::TableEntry*>* acl_flows) const;
 
+  // Reads the P4 DirectMeterEntries programmed in a given table
+  // (given by the table_id) on the node.
+  virtual ::util::Status ReadDirectMeterTableEntries(
+      const uint32 table_id, ::p4::v1::ReadResponse* resp) const;
+
   // Finds the and returns the stored P4 TableEntry that matches the
   // given entry.
   virtual ::util::StatusOr<::p4::v1::TableEntry> LookupTableEntry(


### PR DESCRIPTION
## Description

This PR implements the `DirectMeterEntryRead` operation, required for the controller to read the direct meter resources. Since the meter_config is already on the ACL table entries implementing this message is as simple as copying the values from there to the DirectMeter mutablecConfig. Comparing stratum-bcm to stratum-bmv2 we found that the table entry action and meter_config are not part of the response. So, we are explicitly removing those fields from the response.
I am a bit unsure if this approach is 100% correct so your feedback is appreciated. Btw, DirectCounterRead operations are currently broken in stratum-bcm and should follow a similar approach to this one (I'll look into that later).

## Todo:

- [ ] Unit Tests
- [ ] Describe the runtime validation approach