### PR TITLE
Build Stratum-bmv2 images with clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,8 @@ jobs:
       - DOCKER_SCOPE: .
       - DOCKER_FILE: tools/mininet/Dockerfile
       - DOCKER_IMG: opennetworking/mn-stratum
+      - CC: clang
+      - CXX: clang++
     steps:
       - setup_remote_docker
       - checkout


### PR DESCRIPTION
This PR changes the compiler used to build Stratum-bmv2 images to `clang`, like for most other images.