### PR TITLE
Add comment about BCM SDK header include order

### DIFF
--- a/stratum/hal/lib/bcm/sdk/bcm_diag_shell.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_diag_shell.cc
@@ -26,8 +26,11 @@
 #include <string>
 
 extern "C" {
+// The include order here is significant. First, we undefine symbols clashing
+// with the SDK.
 #include "stratum/hal/lib/bcm/sdk_build_undef.h"  // NOLINT
-#include "sdk_build_flags.h"                      // NOLINT
+// Then we add the defines from the SDK.
+#include "sdk_build_flags.h"  // NOLINT
 // TODO(bocon) we might be able to prune some of these includes
 #include "appl/diag/bslmgmt.h"
 #include "appl/diag/opennsa_diag.h"

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -32,8 +32,11 @@
 #include <utility>
 
 extern "C" {
+// The include order here is significant. First, we undefine symbols clashing
+// with the SDK.
 #include "stratum/hal/lib/bcm/sdk_build_undef.h"  // NOLINT
-#include "sdk_build_flags.h"                      // NOLINT
+// Then we add the defines from the SDK.
+#include "sdk_build_flags.h"  // NOLINT
 // TODO(bocon) we might be able to prune some of these includes
 #include "appl/diag/bslmgmt.h"
 #include "appl/diag/opennsa_diag.h"


### PR DESCRIPTION
This should make things more clear and prevents the linter from re-ordering includes.