### PR TITLE
Reject action profile members with weights in Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -1097,6 +1097,12 @@ BfrtTableManager::ReadDirectCounterEntry(
         member.watch_kind_case() ==
         ::p4::v1::ActionProfileGroup::Member::WATCH_KIND_NOT_SET)
         << "Watch ports are not supported.";
+    CHECK_RETURN_IF_FALSE(member.weight() != 0)
+        << "Zero member weights are not allowed.";
+    if (member.weight() != 1) {
+      RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
+          << "Member weights greater than 1 are not supported.";
+    }
     member_ids.push_back(member.member_id());
     member_status.push_back(true);  // Activate the member.
   }


### PR DESCRIPTION
The implementation does not support weighted members, therefore should not accept them.