### PR TITLE
Remove Google specific defines

### DIFF
--- a/stratum/glue/gtl/stl_util.h
+++ b/stratum/glue/gtl/stl_util.h
@@ -49,18 +49,6 @@ inline const T* vector_as_array(const std::vector<T, Allocator>* v) {
   return v->data();
 }
 
-// Like str->resize(new_size), except any new characters added to "*str" as a
-// result of resizing may be left uninitialized, rather than being filled with
-// '0' bytes. Typically used when code is then going to overwrite the backing
-// store of the string with known data. Uses a Google extension to ::string.
-inline void STLStringResizeUninitialized(std::string* s, size_t new_size) {
-#if __google_stl_resize_uninitialized_string
-  s->resize_uninitialized(new_size);
-#else
-  s->resize(new_size);
-#endif
-}
-
 // Calls delete (non-array version) on the SECOND item (pointer) in each pair in
 // the range [begin, end).
 //

--- a/stratum/glue/init_google.h
+++ b/stratum/glue/init_google.h
@@ -5,20 +5,9 @@
 #ifndef STRATUM_GLUE_INIT_GOOGLE_H_
 #define STRATUM_GLUE_INIT_GOOGLE_H_
 
-// TODO(boc): google only: this is not required for open source
-// #include "base/init_google.h"  // IWYU pragma: export
-
-// InitGoogle is not defined in portable base, so we instead emulate its
-// behavior.
-#if !GOOGLE_BASE_HAS_INITGOOGLE
-
 #include "gflags/gflags.h"
 #include "stratum/glue/logging.h"
 #include "stratum/glue/stamping.h"
-
-// TODO(unknown) need to define transformation or comment this out on
-// Google's side
-using gflags::ParseCommandLineFlags;
 
 inline void InitGoogle(const char* usage, int* argc, char*** argv,
                        bool remove_flags) {
@@ -38,9 +27,7 @@ inline void InitGoogle(const char* usage, int* argc, char*** argv,
                                                 ::gflags::SET_FLAGS_DEFAULT)
              .empty());
   ::gflags::SetVersionString(stratum::kBuildScmRevision);
-  ParseCommandLineFlags(argc, argv, remove_flags);
+  ::gflags::ParseCommandLineFlags(argc, argv, remove_flags);
 }
-
-#endif  // !GOOGLE_BASE_HAS_INITGOOGLE
 
 #endif  // STRATUM_GLUE_INIT_GOOGLE_H_


### PR DESCRIPTION
These cause compiler warnings and serve no purpose anymore. `STLStringResizeUninitialized` is removed, as there are no usages anywhere. Should it be required at a later point, we can fall back to Abseils internal version of it: https://github.com/abseil/abseil-cpp/blob/aad2c8a3966424bbaa2f26027d104d17f9c1c1ae/absl/strings/internal/resize_uninitialized.h#L61-L68