### PR TITLE
Move QoS singleton port lookup into `BfChassisManager`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -1349,12 +1349,7 @@ namespace {
       case TofinoConfig::TofinoQosConfig::PpgConfig::kSdkPort:
         sdk_port = ppg_config.sdk_port();
         break;
-      case TofinoConfig::TofinoQosConfig::PpgConfig::kPort: {
-        ASSIGN_OR_RETURN(
-            sdk_port,
-            GetPortIdFromPortKey(device, PortKey(0, ppg_config.port(), 0)));
-        break;
-      }
+      case TofinoConfig::TofinoQosConfig::PpgConfig::kPort:
       default:
         RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port type in PpgConfig "
                                         << ppg_config.ShortDebugString() << ".";
@@ -1387,12 +1382,7 @@ namespace {
       case TofinoConfig::TofinoQosConfig::QueueConfig::kSdkPort:
         sdk_port = queue_config.sdk_port();
         break;
-      case TofinoConfig::TofinoQosConfig::QueueConfig::kPort: {
-        ASSIGN_OR_RETURN(
-            sdk_port,
-            GetPortIdFromPortKey(device, PortKey(0, queue_config.port(), 0)));
-        break;
-      }
+      case TofinoConfig::TofinoQosConfig::QueueConfig::kPort:
       default:
         RETURN_ERROR(ERR_INVALID_PARAM)
             << "Unsupported port type in QueueConfig "


### PR DESCRIPTION
The sdk wrapper has no knowledge about singleton ports, thus can not look up the correct dev port for them. This change fixes a bug where the singleton port ID is confused with the front panel number, leading to dev port lookup errors and failing a ChassisConfig push.