### PR TITLE
Fix Tofino port shaping cleanup on ChassisConfig push

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -1158,8 +1158,6 @@ BfSdeWrapper::BfSdeWrapper()
 
   RETURN_IF_BFRT_ERROR(p4_pd_tm_set_port_shaping_rate(
       device, port, is_in_pps, burst_size, rate_per_second));
-  LOG(WARNING) << "Set port shaping on port " << port << " to burst "
-               << burst_size << ", rate " << rate_per_second;
 
   return ::util::OkStatus();
 }
@@ -1168,10 +1166,8 @@ BfSdeWrapper::BfSdeWrapper()
                                                TriState enable) {
   if (enable == TriState::TRI_STATE_TRUE) {
     RETURN_IF_BFRT_ERROR(p4_pd_tm_enable_port_shaping(device, port));
-    LOG(WARNING) << "Enabled port shaping on port " << port;
   } else if (enable == TriState::TRI_STATE_FALSE) {
     RETURN_IF_BFRT_ERROR(p4_pd_tm_disable_port_shaping(device, port));
-    LOG(WARNING) << "Disabled port shaping on port " << port;
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -1158,6 +1158,8 @@ BfSdeWrapper::BfSdeWrapper()
 
   RETURN_IF_BFRT_ERROR(p4_pd_tm_set_port_shaping_rate(
       device, port, is_in_pps, burst_size, rate_per_second));
+  LOG(WARNING) << "Set port shaping on port " << port << " to burst "
+               << burst_size << ", rate " << rate_per_second;
 
   return ::util::OkStatus();
 }
@@ -1166,8 +1168,10 @@ BfSdeWrapper::BfSdeWrapper()
                                                TriState enable) {
   if (enable == TriState::TRI_STATE_TRUE) {
     RETURN_IF_BFRT_ERROR(p4_pd_tm_enable_port_shaping(device, port));
+    LOG(WARNING) << "Enabled port shaping on port " << port;
   } else if (enable == TriState::TRI_STATE_FALSE) {
     RETURN_IF_BFRT_ERROR(p4_pd_tm_disable_port_shaping(device, port));
+    LOG(WARNING) << "Disabled port shaping on port " << port;
   }
 
   return ::util::OkStatus();


### PR DESCRIPTION
Currently, pushing a new chassis config without any port shaping does not delete a previous config, i.e. shaping stays enabled.
This PR addresses this by always disabling port shaping first, then potentially applying the new config afterwards. 
During a chassis config push, there will be a short period of time where the traffic rate could be higher than expected. Similar to how ports might flip up->down->up right now. Fixing this would require a more substantial rewrite of the `BfChassisManager`.