### PR TITLE
Make egress queue of clone sessions configurable in Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -305,12 +305,14 @@ class BfSdeInterface {
   // Inserts a clone session ($mirror.cfg table).
   virtual ::util::Status InsertCloneSession(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 session_id, int egress_port, int cos, int max_pkt_len) = 0;
+      uint32 session_id, int egress_port, int egress_queue, int cos,
+      int max_pkt_len) = 0;
 
   // Modifies a clone session ($mirror.cfg table).
   virtual ::util::Status ModifyCloneSession(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 session_id, int egress_port, int cos, int max_pkt_len) = 0;
+      uint32 session_id, int egress_port, int egress_queue, int cos,
+      int max_pkt_len) = 0;
 
   // Deletes a clone session ($mirror.cfg table).
   virtual ::util::Status DeleteCloneSession(

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -155,18 +155,18 @@ class BfSdeMock : public BfSdeInterface {
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 group_id, std::vector<uint32>* group_ids,
                      std::vector<std::vector<uint32>>* mc_node_ids));
-  MOCK_METHOD6(
+  MOCK_METHOD7(
       InsertCloneSession,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
-                     uint32 session_id, int egress_port, int cos,
-                     int max_pkt_len));
-  MOCK_METHOD6(
+                     uint32 session_id, int egress_port, int egress_queue,
+                     int cos, int max_pkt_len));
+  MOCK_METHOD7(
       ModifyCloneSession,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
-                     uint32 session_id, int egress_port, int cos,
-                     int max_pkt_len));
+                     uint32 session_id, int egress_port, int egress_queue,
+                     int cos, int max_pkt_len));
   MOCK_METHOD3(GetNodesInMulticastGroup,
                ::util::StatusOr<std::vector<uint32>>(
                    int device,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -2399,7 +2399,8 @@ namespace {
 
 ::util::Status BfSdeWrapper::WriteCloneSession(
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-    uint32 session_id, int egress_port, int cos, int max_pkt_len, bool insert) {
+    uint32 session_id, int egress_port, int egress_queue, int cos,
+    int max_pkt_len, bool insert) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
   CHECK_RETURN_IF_FALSE(real_session);
 
@@ -2425,6 +2426,9 @@ namespace {
   // Data: $ucast_egress_port_valid
   RETURN_IF_ERROR(
       SetFieldBool(table_data.get(), "$ucast_egress_port_valid", true));
+  // Data: $egress_port_queue
+  RETURN_IF_ERROR(
+      SetField(table_data.get(), "$egress_port_queue", egress_queue));
   // Data: $ingress_cos
   RETURN_IF_ERROR(SetField(table_data.get(), "$ingress_cos", cos));
   // Data: $max_pkt_len
@@ -2444,18 +2448,20 @@ namespace {
 
 ::util::Status BfSdeWrapper::InsertCloneSession(
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-    uint32 session_id, int egress_port, int cos, int max_pkt_len) {
+    uint32 session_id, int egress_port, int egress_queue, int cos,
+    int max_pkt_len) {
   ::absl::ReaderMutexLock l(&data_lock_);
-  return WriteCloneSession(device, session, session_id, egress_port, cos,
-                           max_pkt_len, true);
+  return WriteCloneSession(device, session, session_id, egress_port,
+                           egress_queue, cos, max_pkt_len, true);
 }
 
 ::util::Status BfSdeWrapper::ModifyCloneSession(
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-    uint32 session_id, int egress_port, int cos, int max_pkt_len) {
+    uint32 session_id, int egress_port, int egress_queue, int cos,
+    int max_pkt_len) {
   ::absl::ReaderMutexLock l(&data_lock_);
-  return WriteCloneSession(device, session, session_id, egress_port, cos,
-                           max_pkt_len, false);
+  return WriteCloneSession(device, session, session_id, egress_port,
+                           egress_queue, cos, max_pkt_len, false);
 }
 
 ::util::Status BfSdeWrapper::DeleteCloneSession(

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -225,12 +225,12 @@ class BfSdeWrapper : public BfSdeInterface {
       LOCKS_EXCLUDED(data_lock_);
   ::util::Status InsertCloneSession(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 session_id, int egress_port, int cos, int max_pkt_len) override
-      LOCKS_EXCLUDED(data_lock_);
+      uint32 session_id, int egress_port, int egress_queue, int cos,
+      int max_pkt_len) override LOCKS_EXCLUDED(data_lock_);
   ::util::Status ModifyCloneSession(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 session_id, int egress_port, int cos, int max_pkt_len) override
-      LOCKS_EXCLUDED(data_lock_);
+      uint32 session_id, int egress_port, int egress_queue, int cos,
+      int max_pkt_len) override LOCKS_EXCLUDED(data_lock_);
   ::util::Status DeleteCloneSession(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 session_id) override LOCKS_EXCLUDED(data_lock_);
@@ -435,8 +435,8 @@ class BfSdeWrapper : public BfSdeInterface {
   // Common code for clone session handling.
   ::util::Status WriteCloneSession(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 session_id, int egress_port, int cos, int max_pkt_len, bool insert)
-      SHARED_LOCKS_REQUIRED(data_lock_);
+      uint32 session_id, int egress_port, int egress_queue, int cos,
+      int max_pkt_len, bool insert) SHARED_LOCKS_REQUIRED(data_lock_);
 
   // Common code for action profile member handling.
   ::util::Status WriteActionProfileMember(

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
@@ -250,7 +250,7 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
           << "Instances on Replicas are not supported: "
           << replica.ShortDebugString() << ".";
       RETURN_IF_ERROR(bf_sde_interface_->InsertCloneSession(
-          device_, session, entry.session_id(), replica.egress_port(),
+          device_, session, entry.session_id(), replica.egress_port(), 0,
           entry.class_of_service(), entry.packet_length_bytes()));
       break;
     }
@@ -266,7 +266,7 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
           << "Instances on Replicas are not supported: "
           << replica.ShortDebugString() << ".";
       RETURN_IF_ERROR(bf_sde_interface_->ModifyCloneSession(
-          device_, session, entry.session_id(), replica.egress_port(),
+          device_, session, entry.session_id(), replica.egress_port(), 0,
           entry.class_of_service(), entry.packet_length_bytes()));
       break;
     }

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
@@ -349,7 +349,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
 
   EXPECT_CALL(*bf_sde_wrapper_mock_,
-              InsertCloneSession(kDevice1, _, kSessionId, kEgressPort, kCos,
+              InsertCloneSession(kDevice1, _, kSessionId, kEgressPort, 0, kCos,
                                  kPacketLength))
       .WillOnce(Return(::util::OkStatus()));
 
@@ -515,7 +515,7 @@ TEST_F(BfrtPreManagerTest, ModifyCloneSessionSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
 
   EXPECT_CALL(*bf_sde_wrapper_mock_,
-              ModifyCloneSession(kDevice1, _, kSessionId, kEgressPort, kCos,
+              ModifyCloneSession(kDevice1, _, kSessionId, kEgressPort, 0, kCos,
                                  kPacketLength))
       .WillOnce(Return(::util::OkStatus()));
 


### PR DESCRIPTION
While the SDE seems to set the default egress queue to `0`, we don't want to get surprised in the future, so we explicitly set it now. By exposing the queue parameter in the SDE wrapper API, we can easily make it user configurable in the future.

Admittedly, the second part if a bit of a YAGNI violation...

While P4Runtime has no mechanism to pass in the egress queue today, if needed we could use the MSB of the `uint32` session ID for it.