### PR TITLE
Reject invalid `MeterConfig`s in Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -932,6 +932,7 @@ BfrtTableManager::ReadDirectCounterEntry(
   CHECK_RETURN_IF_FALSE(meter_entry.meter_id() != 0)
       << "Missing meter id in MeterEntry " << meter_entry.ShortDebugString()
       << ".";
+  RETURN_IF_ERROR(IsValidMeterConfig(meter_entry.config()));
 
   bool meter_units_in_packets;  // or bytes
   {

--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -117,6 +117,32 @@ std::string ByteStringToP4RuntimeByteString(std::string bytes) {
   return bytes;
 }
 
+::util::Status IsValidMeterConfig(const ::p4::v1::MeterConfig& meter_config) {
+  if (meter_config.cir() > meter_config.pir()) {
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Meter configuration " << meter_config.ShortDebugString()
+        << " is invalid: committed rate cannot be greater than peak rate.";
+  }
+  if (meter_config.cburst() > meter_config.pburst()) {
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Meter configuration " << meter_config.ShortDebugString()
+        << " is invalid: committed burst size cannot be greater than peak burst"
+        << " size.";
+  }
+  if (meter_config.cburst() == 0) {
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Meter configuration " << meter_config.ShortDebugString()
+        << " is invalid: committed burst size cannot be zero.";
+  }
+  if (meter_config.pburst() == 0) {
+    RETURN_ERROR(ERR_INVALID_PARAM)
+        << "Meter configuration " << meter_config.ShortDebugString()
+        << " is invalid: peak burst size cannot be zero.";
+  }
+
+  return ::util::OkStatus();
+}
+
 std::string P4RuntimeGrpcStatusToString(const ::grpc::Status& status) {
   std::stringstream ss;
   if (!status.error_details().empty()) {

--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -123,12 +123,6 @@ std::string ByteStringToP4RuntimeByteString(std::string bytes) {
         << "Meter configuration " << meter_config.ShortDebugString()
         << " is invalid: committed rate cannot be greater than peak rate.";
   }
-  if (meter_config.cburst() > meter_config.pburst()) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Meter configuration " << meter_config.ShortDebugString()
-        << " is invalid: committed burst size cannot be greater than peak burst"
-        << " size.";
-  }
   if (meter_config.cburst() == 0) {
     RETURN_ERROR(ERR_INVALID_PARAM)
         << "Meter configuration " << meter_config.ShortDebugString()

--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -118,21 +118,22 @@ std::string ByteStringToP4RuntimeByteString(std::string bytes) {
 }
 
 ::util::Status IsValidMeterConfig(const ::p4::v1::MeterConfig& meter_config) {
-  if (meter_config.cir() > meter_config.pir()) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Meter configuration " << meter_config.ShortDebugString()
-        << " is invalid: committed rate cannot be greater than peak rate.";
-  }
-  if (meter_config.cburst() == 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Meter configuration " << meter_config.ShortDebugString()
-        << " is invalid: committed burst size cannot be zero.";
-  }
-  if (meter_config.pburst() == 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Meter configuration " << meter_config.ShortDebugString()
-        << " is invalid: peak burst size cannot be zero.";
-  }
+  CHECK_RETURN_IF_FALSE(meter_config.cir() >= 0)
+      << "Meter configuration " << meter_config.ShortDebugString()
+      << " is invalid: committed rate cannot be less than zero.";
+  CHECK_RETURN_IF_FALSE(meter_config.pir() >= 0)
+      << "Meter configuration " << meter_config.ShortDebugString()
+      << " is invalid: peak rate cannot be less than zero.";
+  CHECK_RETURN_IF_FALSE(meter_config.cburst() > 0)
+      << "Meter configuration " << meter_config.ShortDebugString()
+      << " is invalid: committed burst size cannot be less than or equal to"
+      << " zero.";
+  CHECK_RETURN_IF_FALSE(meter_config.pburst() > 0)
+      << "Meter configuration " << meter_config.ShortDebugString()
+      << " is invalid: peak burst size cannot be less than or equal to zero.";
+  CHECK_RETURN_IF_FALSE(meter_config.pir() >= meter_config.cir())
+      << "Meter configuration " << meter_config.ShortDebugString()
+      << " is invalid: committed rate cannot be greater than peak rate.";
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/p4/utils.h
+++ b/stratum/hal/lib/p4/utils.h
@@ -52,6 +52,10 @@ std::string P4RuntimeByteStringToPaddedByteString(std::string byte_string,
 // Converts a byte string to a canonical P4Runtime byte string.
 std::string ByteStringToP4RuntimeByteString(std::string bytes);
 
+// Validates that the P4 MeterConfig is a valid trTCM according to RFC 2698.
+// See: https://datatracker.ietf.org/doc/html/rfc2698
+::util::Status IsValidMeterConfig(const ::p4::v1::MeterConfig& meter_config);
+
 // Helper to convert a gRPC status with error details to a string. Assumes
 // ::grpc::Status includes a binary error detail which is encoding a serialized
 // version of ::google::rpc::Status proto in which the details are captured

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -116,14 +116,6 @@ TEST(ValidMeterConfigTest, RejectsInvalidMeterConfigs) {
   )PROTO";
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfig3, &config));
   EXPECT_FALSE(IsValidMeterConfig(config).ok());
-  constexpr char kInvalidMeterConfig4[] = R"PROTO(
-    cir: 300
-    pir: 400
-    cburst: 200
-    pburst: 100
-  )PROTO";
-  CHECK_OK(ParseProtoFromString(kInvalidMeterConfig4, &config));
-  EXPECT_FALSE(IsValidMeterConfig(config).ok());
   constexpr char kValidMeterConfig[] = R"PROTO(
     cir: 1000
     pir: 2000

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -89,6 +89,51 @@ TEST(ByteStringTest, ByteStringToP4RuntimeByteStringCorrect) {
                                         "\x00\x00\x00\x00\xab", 5)));
 }
 
+TEST(ValidMeterConfigTest, RejectsInvalidMeterConfigs) {
+  EXPECT_FALSE(IsValidMeterConfig({}).ok());
+  ::p4::v1::MeterConfig config;
+  constexpr char kInvalidMeterConfig1[] = R"PROTO(
+    cir: 0
+    pir: 0
+    cburst: 0
+    pburst: 0
+  )PROTO";
+  CHECK_OK(ParseProtoFromString(kInvalidMeterConfig1, &config));
+  EXPECT_FALSE(IsValidMeterConfig(config).ok());
+  constexpr char kInvalidMeterConfig2[] = R"PROTO(
+    cir: 100
+    pir: 200
+    cburst: 0
+    pburst: 0
+  )PROTO";
+  CHECK_OK(ParseProtoFromString(kInvalidMeterConfig2, &config));
+  EXPECT_FALSE(IsValidMeterConfig(config).ok());
+  constexpr char kInvalidMeterConfig3[] = R"PROTO(
+    cir: 500
+    pir: 400
+    cburst: 100
+    pburst: 100
+  )PROTO";
+  CHECK_OK(ParseProtoFromString(kInvalidMeterConfig3, &config));
+  EXPECT_FALSE(IsValidMeterConfig(config).ok());
+  constexpr char kInvalidMeterConfig4[] = R"PROTO(
+    cir: 300
+    pir: 400
+    cburst: 200
+    pburst: 100
+  )PROTO";
+  CHECK_OK(ParseProtoFromString(kInvalidMeterConfig4, &config));
+  EXPECT_FALSE(IsValidMeterConfig(config).ok());
+  constexpr char kValidMeterConfig[] = R"PROTO(
+    cir: 1000
+    pir: 2000
+    cburst: 4000
+    pburst: 8000
+  )PROTO";
+  CHECK_OK(ParseProtoFromString(kValidMeterConfig, &config));
+  EXPECT_OK(IsValidMeterConfig(config));
+}
+
 // This test fixture provides a common P4PipelineConfig for these tests.
 class TableMapValueTest : public testing::Test {
  protected:


### PR DESCRIPTION
P4RT meters are trTCM according to [RFC 2698](https://datatracker.ietf.org/doc/html/rfc2698).
Not all P4 `MeterConfig`s possible are actually valid. We don't want to solely rely on the SDE to reject those, therefore we introduce logic in Stratum to catch them early and with helpful error messages.