### PR TITLE
Add SHA hash for all Bazel http_archive deps

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -58,6 +58,7 @@ def stratum_deps():
             remote = "https://github.com/p4lang/p4c",
             commit = "43568b75796d68a6424ad22eebeee62f46ccd3fe",
             build_file = "@//bazel:external/p4c.BUILD",
+            sha256 = "6f0c38ccc82a3876403843c67d2994bd66115c569d1ef11cbf8e23a0281266da",
         )
 
     if "judy" not in native.existing_rules():
@@ -91,6 +92,7 @@ def stratum_deps():
             name = "com_github_p4lang_PI",
             remote = "https://github.com/p4lang/PI.git",
             commit = "a5fd855d4b3293e23816ef6154e83dc6621aed6a",
+            sha256 = "7df38438f94d64c5005b890210d3f1b40e2402870295e21d44cceac67ebd1a1b",
         )
 
     for sde_ver in BF_SDE_PI_VER:
@@ -110,6 +112,7 @@ def stratum_deps():
             name = "com_github_p4lang_PI_np4",
             remote = "https://github.com/craigsdell/PI.git",
             commit = "12be7a96f3d903afdd6cc3095f7d4003242af60b",
+            sha256 = "696bd1f01133e85cc83125ac747f53f67a519208cab3c7ddaa1d131ee0cea65c",
         )
 
     if "com_github_openconfig_gnmi_proto" not in native.existing_rules():
@@ -158,6 +161,7 @@ def stratum_deps():
             remote = "https://github.com/openconfig/public",
             commit = "624655d053ad1fdda62901c7e2055c22cd5d6a05",
             build_file = "@//bazel:external/ocpublic.BUILD",
+            sha256 = "d9529e43065491b61ce5fdeaf38c0db10a8407cb9f1c4cd23563e5bbe28871f5",
         )
 
     if "com_github_openconfig_hercules" not in native.existing_rules():
@@ -166,6 +170,7 @@ def stratum_deps():
             remote = "https://github.com/openconfig/hercules",
             commit = "ca3575e85500fa089dfe0b8cd3ea71943267102e",
             build_file = "@//bazel:external/hercules.BUILD",
+            sha256 = "48cc536bc95f363f54aa32ececc24d03e0ab7d97972ab33cf67e63e430883bf8",
         )
 
     if "com_github_yang_models_yang" not in native.existing_rules():
@@ -174,6 +179,7 @@ def stratum_deps():
             remote = "https://github.com/YangModels/yang",
             commit = "ed2ce1028ff57d667764dbdbe3c37328820f0e50",
             build_file = "@//bazel:external/yang.BUILD",
+            sha256 = "53ba8dd265bff6d3cff108ea44493b3e7cf52c62bc089839e96d4329d2874d95",
         )
 
     if "com_github_nlohmann_json" not in native.existing_rules():
@@ -236,6 +242,7 @@ def stratum_deps():
             name = "com_googlesource_code_re2",
             remote = "https://github.com/google/re2",
             commit = "be0e1305d264b2cbe1d35db66b8c5107fc2a727e",
+            sha256 = "4f94f422c14aea5419970f4399ac15b2148bc2e90c8566b9de45c6cf3ff6ce53",
         )
 
     if "com_github_systemd_systemd" not in native.existing_rules():
@@ -244,6 +251,7 @@ def stratum_deps():
             remote = "https://github.com/systemd/systemd",
             commit = "06e93130b4045db1c75f8de506d2447642de74cf",
             build_file = "@//bazel:external/systemd.BUILD",
+            sha256 = "1a02064429ca3995558abd118d3dda06571169b7a6d5e2f3289935967c929a45",
         )
 
     if "com_github_nelhage_rules_boost" not in native.existing_rules():

--- a/bazel/rules/proto_gen.bzl
+++ b/bazel/rules/proto_gen.bzl
@@ -60,4 +60,5 @@ def proto_gen_deps():
             remote = "https://github.com/openconfig/ygot",
             commit = "68346f97239f91ac9fb1f419586f58d6c39f5500",
             build_file = "@//bazel:external/ygot_proto.BUILD",
+            sha256 = "db40653f99d878ab698ea32fdbaa1d9c166281df547c823b896bfbdfc0624c8e",
         )

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -16,6 +16,7 @@ def _build_http_archive(
     patches = [],
     patch_args = [],
     patch_cmds = [],
+    sha256 = None,
     ):
   if not remote.startswith("https://github.com"):
     # This is only currently support for github repos
@@ -39,22 +40,43 @@ def _build_http_archive(
 
   # Generate http_archive rule
   if build_file:
-    http_archive(
-      name = name,
-      urls = urls,
-      strip_prefix = prefix,
-      build_file = build_file,
-      patches = patches,
-      patch_args = patch_args,
-    )
+    if sha256:
+      http_archive(
+        name = name,
+        urls = urls,
+        strip_prefix = prefix,
+        build_file = build_file,
+        patches = patches,
+        patch_args = patch_args,
+        sha256 = sha256,
+      )
+    else:
+      http_archive(
+        name = name,
+        urls = urls,
+        strip_prefix = prefix,
+        build_file = build_file,
+        patches = patches,
+        patch_args = patch_args,
+    )      
   else:
-    http_archive(
-      name = name,
-      urls = urls,
-      strip_prefix = prefix,
-      patches = patches,
-      patch_args = patch_args,
-    )
+    if sha256:
+      http_archive(
+        name = name,
+        urls = urls,
+        strip_prefix = prefix,
+        patches = patches,
+        patch_args = patch_args,
+        sha256 = sha256,
+      )
+    else:
+      http_archive(
+        name = name,
+        urls = urls,
+        strip_prefix = prefix,
+        patches = patches,
+        patch_args = patch_args,
+      )
   return True
 
 def _build_git_repository(
@@ -110,6 +132,7 @@ def remote_workspace(
     patches = [],
     patch_args = [],
     patch_cmds = [],
+    sha256 = None,
     ):
   ref_count = 0
   if branch:
@@ -135,7 +158,7 @@ def remote_workspace(
 
   # Prefer http_archive
   if not use_git and _build_http_archive(
-      name, remote, branch, commit, tag, build_file, patches, patch_args, patch_cmds):
+      name, remote, branch, commit, tag, build_file, patches, patch_args, patch_cmds, sha256):
     return
 
   # Fall back to git_repository

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -2,139 +2,154 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 _strict = False
 
 def _build_http_archive(
-    name,
-    remote,
-    branch = None,
-    commit = None,
-    tag = None,
-    build_file = None,
-    patches = [],
-    patch_args = [],
-    patch_cmds = [],
-    sha256 = None,
-    ):
-  if not remote.startswith("https://github.com"):
-    # This is only currently support for github repos
-    return False
+        name,
+        remote,
+        branch = None,
+        commit = None,
+        tag = None,
+        build_file = None,
+        patches = [],
+        patch_args = [],
+        patch_cmds = [],
+        sha256 = None):
+    if not remote.startswith("https://github.com"):
+        # This is only currently support for github repos
+        return False
 
-  # Fix remote suffix
-  if remote.endswith(".git"):
-    remote = remote[:-4]
-  elif remote.endswith("/"):
-    remote = remote[:-1]
+    # Fix remote suffix
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+    elif remote.endswith("/"):
+        remote = remote[:-1]
 
-  # Tranform repo URL to archive URL
-  repo_name = remote.split("/")[-1]
-  if tag:
-    urls = ["%s/archive/v%s.zip" % (remote, tag)]
-    prefix = repo_name + "-" + tag
-  if commit or branch:
-    ref = commit if commit else branch
-    urls = ["%s/archive/%s.zip" % (remote, ref)]
-    prefix = repo_name + "-" + ref
+    # Tranform repo URL to archive URL
+    repo_name = remote.split("/")[-1]
+    if tag:
+        urls = ["%s/archive/v%s.zip" % (remote, tag)]
+        prefix = repo_name + "-" + tag
+    if commit or branch:
+        ref = commit if commit else branch
+        urls = ["%s/archive/%s.zip" % (remote, ref)]
+        prefix = repo_name + "-" + ref
 
-  # Generate http_archive rule
-  http_archive(
-    name = name,
-    urls = urls,
-    strip_prefix = prefix,
-    build_file = build_file,
-    patches = patches,
-    patch_args = patch_args,
-    sha256 = sha256,
-  )
-  return True
+    # Generate http_archive rule
+    http_archive(
+        name = name,
+        urls = urls,
+        strip_prefix = prefix,
+        build_file = build_file,
+        patches = patches,
+        patch_args = patch_args,
+        sha256 = sha256,
+    )
+    return True
 
 def _build_git_repository(
-    name,
-    remote,
-    branch = None,
-    commit = None,
-    tag = None,
-    build_file = None,
-    patches = [],
-    patch_args = [],
-    patch_cmds = [],
-    ):
+        name,
+        remote,
+        branch = None,
+        commit = None,
+        tag = None,
+        build_file = None,
+        patches = [],
+        patch_args = [],
+        patch_cmds = []):
+    # Strip trailing / from remote
+    if remote.endswith("/"):
+        remote = remote[:-1]
 
-  # Strip trailing / from remote
-  if remote.endswith("/"):
-    remote = remote[:-1]
-
-  # Generate the git_repository rule
-  if build_file:
-    new_git_repository(
-      name = name,
-      remote = remote,
-      branch = branch,
-      commit = commit,
-      tag = tag,
-      patches = patches,
-      patch_args = patch_args,
-      build_file = build_file,
-      patch_cmds = patch_cmds,
-    )
-  else:
-    git_repository(
-      name = name,
-      remote = remote,
-      branch = branch,
-      commit = commit,
-      tag = tag,
-      patches = patches,
-      patch_args = patch_args,
-      patch_cmds = patch_cmds,
-    )
-  return True
+    # Generate the git_repository rule
+    if build_file:
+        new_git_repository(
+            name = name,
+            remote = remote,
+            branch = branch,
+            commit = commit,
+            tag = tag,
+            patches = patches,
+            patch_args = patch_args,
+            build_file = build_file,
+            patch_cmds = patch_cmds,
+        )
+    else:
+        git_repository(
+            name = name,
+            remote = remote,
+            branch = branch,
+            commit = commit,
+            tag = tag,
+            patches = patches,
+            patch_args = patch_args,
+            patch_cmds = patch_cmds,
+        )
+    return True
 
 def remote_workspace(
-    name,
-    remote,
-    branch = None,
-    commit = None,
-    tag = None,
-    build_file = None,
-    use_git = False,
-    patches = [],
-    patch_args = [],
-    patch_cmds = [],
-    sha256 = None,
+        name,
+        remote,
+        branch = None,
+        commit = None,
+        tag = None,
+        build_file = None,
+        use_git = False,
+        patches = [],
+        patch_args = [],
+        patch_cmds = [],
+        sha256 = None):
+    ref_count = 0
+    if branch:
+        ref_count += 1
+    if commit:
+        ref_count += 1
+    if tag:
+        ref_count += 1
+
+    if ref_count == 0:
+        fail("one of branch, commit or tag must be set for " + name)
+    elif ref_count > 1:
+        fail("only one of branch, commit, or tag can be set for " + name)
+
+    if commit and len(commit) != 40:
+        fail("You must use the full commit hash for " + name)
+        use_git = True
+        print("using git for ", name, remote)
+
+    if _strict and branch:
+        print("Warning: external workspace, %s, " % name +
+              "should refer to a specific tag or commit (currently: %s)" % branch)
+
+    # Prefer http_archive
+    if not use_git and _build_http_archive(
+        name,
+        remote,
+        branch,
+        commit,
+        tag,
+        build_file,
+        patches,
+        patch_args,
+        patch_cmds,
+        sha256,
     ):
-  ref_count = 0
-  if branch:
-    ref_count += 1
-  if commit:
-    ref_count += 1
-  if tag:
-    ref_count += 1
+        return
 
-  if ref_count == 0:
-    fail("one of branch, commit or tag must be set for " + name)
-  elif ref_count > 1:
-    fail("only one of branch, commit, or tag can be set for " + name)
+    # Fall back to git_repository
+    if _build_git_repository(
+        name,
+        remote,
+        branch,
+        commit,
+        tag,
+        build_file,
+        patches,
+        patch_args,
+        patch_cmds,
+    ):
+        return
 
-  if commit and len(commit) != 40:
-    fail("You must use the full commit hash for " + name)
-    use_git = True
-    print("using git for ", name, remote)
-
-  if _strict and branch:
-    print("Warning: external workspace, %s, " % name +
-          "should refer to a specific tag or commit (currently: %s)" % branch)
-
-  # Prefer http_archive
-  if not use_git and _build_http_archive(
-      name, remote, branch, commit, tag, build_file, patches, patch_args, patch_cmds, sha256):
-    return
-
-  # Fall back to git_repository
-  if _build_git_repository(
-      name, remote, branch, commit, tag, build_file, patches, patch_args, patch_cmds):
-    return
-
-  fail("could not generate remote workspace for " + name)
+    fail("could not generate remote workspace for " + name)

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -39,44 +39,15 @@ def _build_http_archive(
     prefix = repo_name + "-" + ref
 
   # Generate http_archive rule
-  if build_file:
-    if sha256:
-      http_archive(
-        name = name,
-        urls = urls,
-        strip_prefix = prefix,
-        build_file = build_file,
-        patches = patches,
-        patch_args = patch_args,
-        sha256 = sha256,
-      )
-    else:
-      http_archive(
-        name = name,
-        urls = urls,
-        strip_prefix = prefix,
-        build_file = build_file,
-        patches = patches,
-        patch_args = patch_args,
-    )      
-  else:
-    if sha256:
-      http_archive(
-        name = name,
-        urls = urls,
-        strip_prefix = prefix,
-        patches = patches,
-        patch_args = patch_args,
-        sha256 = sha256,
-      )
-    else:
-      http_archive(
-        name = name,
-        urls = urls,
-        strip_prefix = prefix,
-        patches = patches,
-        patch_args = patch_args,
-      )
+  http_archive(
+    name = name,
+    urls = urls,
+    strip_prefix = prefix,
+    build_file = build_file,
+    patches = patches,
+    patch_args = patch_args,
+    sha256 = sha256,
+  )
   return True
 
 def _build_git_repository(


### PR DESCRIPTION
Caching is improved when Bazel knows the SHAs of
remote repositories.

The remote_workspace macro is usually backed by a
 http_archive. We should pass the SHA along to the
macro when we know it, so that it can be included in
the generated http_archive rule and passed to Bazel.

Adds hashes to

1. com_github_p4lang_PI
2. com_github_p4lang_PI_np4
3. com_github_openconfig_hercules
4. com_github_openconfig_ygot_proto
5. com_github_openconfig_public
6. com_github_yang_models_yang
7. com_googlesource_code_re2
8. com_github_systemd_systemd
9. com_github_p4lang_p4c

Fixes #845