### PR TITLE
Add missing signal.h includes

### DIFF
--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <csignal>
 #include <iomanip>
 #include <sstream>  // IWYU pragma: keep
 #include <string>

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <csignal>
 #include <iomanip>
 #include <sstream>  // IWYU pragma: keep
 #include <string>

--- a/stratum/hal/lib/common/admin_service.cc
+++ b/stratum/hal/lib/common/admin_service.cc
@@ -4,6 +4,7 @@
 
 #include "stratum/hal/lib/common/admin_service.h"
 
+#include <csignal>
 #include <string>
 
 #include "absl/memory/memory.h"


### PR DESCRIPTION
Required for failing tests in #850 

Not sure why compilation failures are happening now... possibly due to a dropped include in newer versions of gRPC

cc: @koconnor29