### PR TITLE
Add support for OpenConfig `/interfaces/interface[name=*]/state/id` path

### DIFF
--- a/stratum/docs/gnmi/README.md
+++ b/stratum/docs/gnmi/README.md
@@ -45,6 +45,7 @@ Service and tree initialization
  When the service is initialized, it creates a `GnmiPublisher`, and the `GnmiPublisher` instantiates the `YangParseTree`.
  When the tree is initialized, it generates default nodes for wildcard paths such as:
 
+  - `/interfaces/interface[name=*]/state/id`
   - `/interfaces/interface[name=*]/state/ifindex`
   - `/interfaces/interface[name=*]/state/name`
   - `/interfaces/interface/...`

--- a/stratum/docs/gnmi/supported-paths.md
+++ b/stratum/docs/gnmi/supported-paths.md
@@ -20,6 +20,12 @@ Supported gNMI paths
  - Get type: ALL, STATE
  - Set mode: Not valid
 
+`/interfaces/interface[name=*]/state/id`
+
+ - Subscription mode: ONCE, POLL
+ - Get type: ALL, STATE
+ - Set mode: Not valid
+
 `/interfaces/interface[name=*]/state/ifindex`
 
  - Subscription mode: ONCE, POLL
@@ -200,6 +206,12 @@ Supported gNMI paths
 `/interfaces/interface[name=port name]/state/loopback-mode`
 
  - Subscription mode: ONCE, POLL, SAMPLE, ON_CHANGE
+ - Get type: ALL, STATE
+ - Set mode: Not valid
+
+`/interfaces/interface[name=port name]/state/id`
+
+ - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
 

--- a/stratum/hal/lib/common/yang_parse_tree_paths.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_paths.cc
@@ -965,6 +965,19 @@ void SetUpInterfacesInterfaceStateName(const std::string& name,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// /interfaces/interface[name=<name>]/state/id
+void SetUpInterfacesInterfaceStateId(uint32 id, TreeNode* node) {
+  auto on_change_functor = UnsupportedFunc();
+  auto on_poll_functor = [id](const GnmiEvent& event, const ::gnmi::Path& path,
+                              GnmiSubscribeStream* stream) {
+    return SendResponse(GetResponse(path, id), stream);
+  };
+  node->SetOnTimerHandler(on_poll_functor)
+      ->SetOnPollHandler(on_poll_functor)
+      ->SetOnChangeHandler(on_change_functor);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // /interfaces/interface[name=<name>]/state/oper-status
 void SetUpInterfacesInterfaceStateOperStatus(uint64 node_id, uint32 port_id,
                                              TreeNode* node,
@@ -3347,6 +3360,9 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("name")());
   SetUpInterfacesInterfaceStateName(name, node);
+  node =
+      tree->AddNode(GetPath("interfaces")("interface", name)("state")("id")());
+  SetUpInterfacesInterfaceStateId(port_id, node);
 
   node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("oper-status")());
@@ -3846,6 +3862,40 @@ void YangParseTreePaths::AddSubtreeSystem(YangParseTree* tree) {
 }
 
 void YangParseTreePaths::AddSubtreeAllInterfaces(YangParseTree* tree) {
+  // Add support for "/interfaces/interface[name=*]/state/id".
+  tree->AddNode(GetPath("interfaces")("interface", "*")("state")("id")())
+      ->SetOnChangeRegistration(
+          [tree](const EventHandlerRecordPtr& record)
+              EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_) {
+                // Subscribing to a wildcard node means that all matching nodes
+                // have to be registered for received events.
+                auto status = tree->PerformActionForAllNonWildcardNodes(
+                    GetPath("interfaces")("interface")(),
+                    GetPath("state")("id")(), [&record](const TreeNode& node) {
+                      return node.DoOnChangeRegistration(record);
+                    });
+                return status;
+              })
+      ->SetOnChangeHandler(
+          [tree](const GnmiEvent& event, const ::gnmi::Path& path,
+                 GnmiSubscribeStream* stream) { return ::util::OkStatus(); })
+      ->SetOnPollHandler(
+          [tree](const GnmiEvent& event, const ::gnmi::Path& path,
+                 GnmiSubscribeStream* stream)
+              EXCLUSIVE_LOCKS_REQUIRED(tree->root_access_lock_) {
+                // Polling a wildcard node means that all matching nodes have to
+                // be polled.
+                auto status = tree->PerformActionForAllNonWildcardNodes(
+                    GetPath("interfaces")("interface")(),
+                    GetPath("state")("id")(),
+                    [&event, &stream](const TreeNode& leaf) {
+                      return (leaf.GetOnPollHandler())(event, stream);
+                    });
+                // Notify the client that all nodes have been processed.
+                APPEND_STATUS_IF_ERROR(
+                    status, YangParseTreePaths::SendEndOfSeriesMessage(stream));
+                return status;
+              });
   // Add support for "/interfaces/interface[name=*]/state/ifindex".
   tree->AddNode(GetPath("interfaces")("interface", "*")("state")("ifindex")())
       ->SetOnChangeRegistration(

--- a/stratum/hal/lib/common/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/common/yang_parse_tree_test.cc
@@ -192,7 +192,8 @@ class YangParseTreeTest : public ::testing::Test {
                                  const OnEventAction& action,
                                  const GnmiEvent& event,
                                  ::gnmi::SubscribeResponse* resp) {
-    // After tree creation only two leafs are defined:
+    // After tree creation only three leafs are defined:
+    // /interfaces/interface[name=*]/state/id
     // /interfaces/interface[name=*]/state/ifindex
     // /interfaces/interface[name=*]/state/name
 
@@ -376,7 +377,8 @@ class YangParseTreeTest : public ::testing::Test {
                               const OnSetAction& action,
                               const ::google::protobuf::Message& val,
                               SetRequest* req, GnmiEventPtr* notification) {
-    // After tree creation only two leafs are defined:
+    // After tree creation only three leafs are defined:
+    // /interfaces/interface[name=*]/state/id
     // /interfaces/interface[name=*]/state/ifindex
     // /interfaces/interface[name=*]/state/name
 
@@ -649,7 +651,8 @@ TEST_F(YangParseTreeTest, FindRoot) {
 }
 
 TEST_F(YangParseTreeTest, PerformActionForAllNodesNonePresent) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -672,7 +675,8 @@ TEST_F(YangParseTreeTest, PerformActionForAllNodesNonePresent) {
 
 // Check if the action is executed for all qualified leafs.
 TEST_F(YangParseTreeTest, PerformActionForAllNodesOnePresent) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -804,7 +808,8 @@ TEST_F(YangParseTreeTest, SendNotificationPass) {
 
 // Check if the action is executed for all qualified leafs.
 TEST_F(YangParseTreeTest, GetDataFromSwitchInterfaceDataConvertedCorrectly) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -974,7 +979,8 @@ TEST_F(YangParseTreeTest, InterfacesInterfaceStateAdminStatusOnChangeSuccess) {
 
 // Check if the action is executed correctly.
 TEST_F(YangParseTreeTest, InterfacesInterfaceStateNameOnPollSuccess) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -1003,6 +1009,40 @@ TEST_F(YangParseTreeTest, InterfacesInterfaceStateNameOnPollSuccess) {
   // Check that the result of the call is what is expected.
   ASSERT_EQ(resp.update().update_size(), 1);
   EXPECT_EQ(resp.update().update(0).val().string_val(), "interface-1");
+}
+
+// Check if the action is executed correctly.
+TEST_F(YangParseTreeTest, InterfacesInterfaceStateIdOnPollSuccess) {
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
+  // /interfaces/interface[name=*]/state/ifindex
+  // /interfaces/interface[name=*]/state/name
+
+  // The test requires one interface branch to be added.
+  AddSubtreeInterface("interface-1");
+
+  // Mock gRPC stream that copies parameter of Write() to 'resp'. The contents
+  // of the 'resp' variable is then checked.
+  SubscribeReaderWriterMock stream;
+  ::gnmi::SubscribeResponse resp;
+  EXPECT_CALL(stream, Write(_, _))
+      .WillOnce(
+          DoAll(WithArgs<0>(Invoke(
+                    [&resp](const ::gnmi::SubscribeResponse& r) { resp = r; })),
+                Return(true)));
+
+  // Find the 'name' leaf.
+  auto* node = GetRoot().FindNodeOrNull(
+      GetPath("interfaces")("interface", "interface-1")("state")("id")());
+  ASSERT_NE(node, nullptr);
+
+  // Get its OnPoll() handler and call it.
+  const auto& handler = node->GetOnPollHandler();
+  EXPECT_OK(handler(PollEvent(), &stream));
+
+  // Check that the result of the call is what is expected.
+  ASSERT_EQ(resp.update().update_size(), 1);
+  EXPECT_EQ(resp.update().update(0).val().uint_val(), kInterface1PortId);
 }
 
 // Check if the 'state/ifindex' OnPoll action is works correctly.
@@ -2995,7 +3035,8 @@ TEST_F(YangParseTreeTest,
 // Check if all expected handlers are registered
 TEST_F(YangParseTreeTest,
        ExpectedRegistrationsTakePlaceInterfacesInterfaceElipsis) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -3057,7 +3098,8 @@ TEST_F(YangParseTreeTest,
 // Check if all expected handlers are registered
 TEST_F(YangParseTreeTest,
        ExpectedRegistrationsTakePlaceComponentsComponetChassisAlarms) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only three leafs are defined:
+  // /interfaces/interface[name=*]/state/id
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 


### PR DESCRIPTION
This PR exposes the ChassisConfig SingletonPort IDs under the [P4RT Openconfig](http://ops.openconfig.net/branches/models/master/docs/openconfig-p4rt.html#interfaces-interface-state-id) path `/interfaces/interface[name=*]/state/id`. Once P4RT port translation is implemented, this path contains the port IDs to use in flow programming.