### PR TITLE
Only link against `bfshell_plugin.so` and enable `pi` for SDE 9.7.0 build

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -13,7 +13,7 @@ package(
 cc_library(
     name = "bfsde",
     srcs = glob([
-        "barefoot-bin/lib/bfshell_plugin*",
+        "barefoot-bin/lib/bfshell_plugin*.so*",
         "barefoot-bin/lib/libavago.so*",
         "barefoot-bin/lib/libbf_switchd_lib.a*",
         "barefoot-bin/lib/libbfsys.so*",

--- a/stratum/hal/bin/barefoot/build-bf-sde.sh
+++ b/stratum/hal/bin/barefoot/build-bf-sde.sh
@@ -158,7 +158,7 @@ if [[ $SDE_VERSION == "9.7.0" ]]; then
     sed -i 's/add_subdirectory(kdrv)/#add_subdirectory(kdrv)/g' $SDE/pkgsrc/bf-drivers/CMakeLists.txt
     # Build BF SDE
     ./p4studio dependencies install --source-packages bridge,libcli,thrift --jobs $JOBS
-    ./p4studio configure bfrt '^pi' '^tofino2h' '^thrift-driver' '^p4rt' tofino asic '^tofino2m' '^tofino2' '^grpc' $BSP_CMD
+    ./p4studio configure bfrt pi '^tofino2h' '^thrift-driver' '^p4rt' tofino asic '^tofino2m' '^tofino2' '^grpc' $BSP_CMD
     ./p4studio build --jobs $JOBS
     popd
 else


### PR DESCRIPTION
`"barefoot-bin/lib/bfshell_plugin*",` can include some unexpected files when building with older version of SDEs which cause the build failed.

```
ERROR: /root/.cache/bazel/_bazel_root/1b07b1db06ec9ee22c71eac6f0bd4549/external/local_barefoot_bin/BUILD:13:11: in srcs attribute of cc_library rule @local_barefoot_bin//:bfsde: source file '@local_barefoot_bin//:barefoot-bin/lib/bfshell_plugin_bf_rt.la' is misplaced here (expected .cc, .cpp, .cxx, .c++, .C, .cu, .cl, .c, .h, .hh, .hpp, .ipp, .hxx, .h++, .inc, .inl, .tlh, .tli, .H, .tcc, .S, .s, .asm, .a, .lib, .pic.a, .lo, .lo.lib, .pic.lo, .so, .dylib, .dll, .o, .obj or .pic.o). Since this rule was created by the macro 'cc_library', the error might have been caused by the macro implementation
```