### PR TITLE
Check meter config only if we are trying to set the meter

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -932,7 +932,6 @@ BfrtTableManager::ReadDirectCounterEntry(
   CHECK_RETURN_IF_FALSE(meter_entry.meter_id() != 0)
       << "Missing meter id in MeterEntry " << meter_entry.ShortDebugString()
       << ".";
-  RETURN_IF_ERROR(IsValidMeterConfig(meter_entry.config()));
 
   bool meter_units_in_packets;  // or bytes
   {
@@ -960,6 +959,7 @@ BfrtTableManager::ReadDirectCounterEntry(
     meter_index = meter_entry.index().index();
   }
   if (meter_entry.has_config()) {
+    RETURN_IF_ERROR(IsValidMeterConfig(meter_entry.config()));
     RETURN_IF_ERROR(bf_sde_interface_->WriteIndirectMeter(
         device_, session, meter_id, meter_index, meter_units_in_packets,
         meter_entry.config().cir(), meter_entry.config().cburst(),


### PR DESCRIPTION
We don't check the meter config when we are trying to reset the meter, which contains an empty meter config in the write request.