### PR TITLE
Update Abseil to `20211102.0`

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -207,9 +207,9 @@ def stratum_deps():
     if "com_google_absl" not in native.existing_rules():
         http_archive(
             name = "com_google_absl",
-            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.tar.gz"],
-            strip_prefix = "abseil-cpp-20210324.2",
-            sha256 = "59b862f50e710277f8ede96f083a5bb8d7c9595376146838b9580be90374ee1f",
+            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
+            strip_prefix = "abseil-cpp-20211102.0",
+            sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
         )
 
     if "com_github_google_glog" not in native.existing_rules():


### PR DESCRIPTION
https://github.com/abseil/abseil-cpp/releases/tag/20211102.0

Now depends on `bazelbuild/platforms`,  but some other dependency already pulls that in and we have no direct dep:

```
bazel query --keep_going "rdeps(..., @platforms//..., 1)" --output package --noimplicit_deps
@bazel_tools//platforms
@com_google_absl//absl/time/internal/cctz
@com_google_googletest//
@io_bazel_rules_go_compat//platforms
@platforms//cpu
@platforms//os
```

