### PR TITLE
Move `cpplint` check to script

### DIFF
--- a/.circleci/check-bazel-format.sh
+++ b/.circleci/check-bazel-format.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-#
 # Copyright 2021-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
-#
+
 set -ex
 
 # Files in this branch that are different from main.

--- a/.circleci/check-cpp-format.sh
+++ b/.circleci/check-cpp-format.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-#
 # Copyright 2020-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
-#
+
 set -ex
 
 # Files in this branch that are different from main.

--- a/.circleci/check-cpplint.sh
+++ b/.circleci/check-cpplint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright 2020-present Open Networking Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+cpplint --recursive --exclude=stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc stratum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ jobs:
       - *clean_bazel_cache
       - *save_bazel_cache
 
-  lint-and-style-check:
+  lint-and-style-checks:
     docker:
       - image: stratumproject/build:build
     steps:
@@ -325,8 +325,8 @@ jobs:
           command: .circleci/check-cpp-format.sh
       - run:
           when: always
-          name: Run cpplint
-          command: cpplint --recursive --exclude=stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc stratum
+          name: Run cpplint script
+          command: .circleci/check-cpplint.sh
       - run:
           when: always
           name: Run buildifier script
@@ -359,7 +359,7 @@ workflows:
       - unit_tests
       - cdlang_tests
       - coverage
-      - lint-and-style-check
+      - lint-and-style-checks
       - license-check
       - markdown-lint-check
   docker-publish:

--- a/.circleci/lint-markdown.sh
+++ b/.circleci/lint-markdown.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 # Copyright 2021-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.circleci/workspace_status.sh
+++ b/.circleci/workspace_status.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 # Copyright 2020-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Makes it easier to run `cpplint` locally. No need to copy the exact invocation out of the CI config file.