### PR TITLE
Format and check all Bazel `BUILD` files

### DIFF
--- a/.circleci/check-bazel-format.sh
+++ b/.circleci/check-bazel-format.sh
@@ -7,6 +7,9 @@ set -ex
 # Files in this branch that are different from main.
 CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/main -- 'BUILD' '*.BUILD' '*.bzl')
 
+# All Bazel BUILD files.
+BUILD_FILES=$(git ls-files "*BUILD")
+
 # List of files that are already formatted.
 read -r -d '\0' KNOWN_FILES << EOF
 bazel/BUILD
@@ -81,7 +84,7 @@ stratum/tools/stratum_replay/BUILD
 \0
 EOF
 
-echo -e "$KNOWN_FILES\n$CHANGED_FILES" | sort -u | xargs -t buildifier -lint=fix -mode=fix
+echo -e "$KNOWN_FILES\n$CHANGED_FILES\n$BUILD_FILES" | sort -u | xargs -t buildifier -lint=fix -mode=fix
 
 # Report which files need to be fixed.
 git update-index --refresh

--- a/bazel/external/gnmi.BUILD
+++ b/bazel/external/gnmi.BUILD
@@ -1,12 +1,12 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
+licenses(["notice"])  # Apache v2
+
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 proto_library(
@@ -19,14 +19,14 @@ proto_library(
     srcs = ["gnmi/gnmi.proto"],
     deps = [
         ":gnmi_ext_proto",
-        "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:descriptor_proto",
     ],
 )
 
 cc_proto_library(
     name = "gnmi_ext_cc_proto",
-    deps = [":gnmi_ext_proto"]
+    deps = [":gnmi_ext_proto"],
 )
 
 cc_proto_library(
@@ -37,6 +37,6 @@ cc_proto_library(
 cc_grpc_library(
     name = "gnmi_cc_grpc",
     srcs = [":gnmi_proto"],
+    grpc_only = True,
     deps = [":gnmi_cc_proto"],
-    grpc_only = True
 )

--- a/bazel/external/gnoi.BUILD
+++ b/bazel/external/gnoi.BUILD
@@ -1,27 +1,27 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
+licenses(["notice"])  # Apache v2
+
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "types_proto",
     srcs = ["gnoi/types/types.proto"],
     deps = [
-        "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:descriptor_proto",
     ],
 )
 
 cc_proto_library(
     name = "types_cc_proto",
-    deps = [":types_proto"]
+    deps = [":types_proto"],
 )
 
 proto_library(
@@ -43,43 +43,43 @@ proto_library(
 
 cc_proto_library(
     name = "diag_cc_proto",
-    deps = [":diag_proto"]
+    deps = [":diag_proto"],
 )
 
 cc_grpc_library(
     name = "diag_cc_grpc",
     srcs = [":diag_proto"],
-    deps = [":diag_cc_proto"],
     grpc_only = True,
+    deps = [":diag_cc_proto"],
 )
 
 proto_library(
     name = "system_proto",
     srcs = ["gnoi/system/system.proto"],
     deps = [
-      ":types_proto",
-      ":common_proto"
+        ":common_proto",
+        ":types_proto",
     ],
 )
 
 cc_proto_library(
     name = "system_cc_proto",
-    deps = [":system_proto"]
+    deps = [":system_proto"],
 )
 
 cc_grpc_library(
     name = "system_cc_grpc",
     srcs = [":system_proto"],
-    deps = [":system_cc_proto"],
     grpc_only = True,
+    deps = [":system_cc_proto"],
 )
 
 proto_library(
     name = "file_proto",
     srcs = ["gnoi/file/file.proto"],
     deps = [
-      ":types_proto",
-      ":common_proto"
+        ":common_proto",
+        ":types_proto",
     ],
 )
 
@@ -91,16 +91,16 @@ cc_proto_library(
 cc_grpc_library(
     name = "file_cc_grpc",
     srcs = [":file_proto"],
-    deps = [":file_cc_proto"],
     grpc_only = True,
+    deps = [":file_cc_proto"],
 )
 
 proto_library(
     name = "cert_proto",
     srcs = ["gnoi/cert/cert.proto"],
     deps = [
-      ":types_proto",
-      ":common_proto",
+        ":common_proto",
+        ":types_proto",
     ],
 )
 
@@ -112,6 +112,6 @@ cc_proto_library(
 cc_grpc_library(
     name = "cert_cc_grpc",
     srcs = [":cert_proto"],
-    deps = [":cert_cc_proto"],
     grpc_only = True,
+    deps = [":cert_cc_proto"],
 )

--- a/bazel/external/hercules.BUILD
+++ b/bazel/external/hercules.BUILD
@@ -1,44 +1,45 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@com_github_stratum_stratum//bazel/rules:yang_to_proto_rule.bzl", "yang_to_proto")
+
 licenses(["notice"])  # Apache v2
 
-load("@com_github_stratum_stratum//bazel/rules:yang_to_proto_rule.bzl", "yang_to_proto")
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "hercules_yang_models",
     srcs = [
-        "yang/openconfig-hercules-platform-linecard.yang",
-        "yang/openconfig-hercules-qos.yang",
-        "yang/openconfig-hercules-platform.yang",
-        "yang/openconfig-hercules-platform-chassis.yang",
-        "yang/openconfig-hercules-platform-port.yang",
         "yang/openconfig-hercules.yang",
         "yang/openconfig-hercules-interfaces.yang",
+        "yang/openconfig-hercules-platform.yang",
+        "yang/openconfig-hercules-platform-chassis.yang",
+        "yang/openconfig-hercules-platform-linecard.yang",
         "yang/openconfig-hercules-platform-node.yang",
-    ]
+        "yang/openconfig-hercules-platform-port.yang",
+        "yang/openconfig-hercules-qos.yang",
+    ],
 )
 
 yang_to_proto(
     name = "openconfig_yang_proto",
     srcs = [
-        "@com_github_openconfig_public//:openconfig_yang_models",
         ":hercules_yang_models",
         "@//stratum/public/model:stratum_models",
+        "@com_github_openconfig_public//:openconfig_yang_models",
+    ],
+    outs = [
+        "openconfig/enums/enums.proto",
+        "openconfig/openconfig.proto",
     ],
     hdrs = [
         "@com_github_openconfig_public//:openconfig_yang_models_hdrs",
         "@com_github_yang_models_yang//:ietf_yang_models",
     ],
-    outs = [
-        "openconfig/openconfig.proto",
-        "openconfig/enums/enums.proto",
-    ],
-    pkg_name = "openconfig",
     exclude_modules = ["ietf-interfaces"],
+    pkg_name = "openconfig",
 )
 
 proto_library(
@@ -47,14 +48,14 @@ proto_library(
         "@com_github_openconfig_hercules//:openconfig_yang_proto",
     ],
     deps = [
-        "@com_github_openconfig_ygot_proto//:ywrapper_proto",
         "@com_github_openconfig_ygot_proto//:yext_proto",
-        "@com_google_protobuf//:descriptor_proto",
+        "@com_github_openconfig_ygot_proto//:ywrapper_proto",
         "@com_google_protobuf//:any_proto",
-    ]
+        "@com_google_protobuf//:descriptor_proto",
+    ],
 )
 
 cc_proto_library(
     name = "openconfig_cc_proto",
-    deps = [":openconfig_proto"]
+    deps = [":openconfig_proto"],
 )

--- a/bazel/external/ocpublic.BUILD
+++ b/bazel/external/ocpublic.BUILD
@@ -4,25 +4,25 @@
 licenses(["notice"])  # Apache v2
 
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "openconfig_yang_models",
     srcs = [
-        "release/models/interfaces/openconfig-interfaces.yang",
         "release/models/interfaces/openconfig-if-ip.yang",
+        "release/models/interfaces/openconfig-interfaces.yang",
         "release/models/lacp/openconfig-lacp.yang",
         "release/models/platform/openconfig-platform.yang",
         "release/models/platform/openconfig-platform-linecard.yang",
         "release/models/platform/openconfig-platform-port.yang",
         "release/models/platform/openconfig-platform-transceiver.yang",
-        "release/models/vlan/openconfig-vlan.yang",
         "release/models/system/openconfig-system.yang",
-    ]
+        "release/models/vlan/openconfig-vlan.yang",
+    ],
 )
 
 filegroup(
     name = "openconfig_yang_models_hdrs",
-    srcs = glob(["release/models/**/*.yang"])
+    srcs = glob(["release/models/**/*.yang"]),
 )

--- a/bazel/external/p4c.BUILD
+++ b/bazel/external/p4c.BUILD
@@ -1,8 +1,6 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 # Bazel BUILD file for p4c in Stratum, limited to the following outputs:
 #   - Several cc_library targets to link with Stratum-specific p4c backends.
 #   - The p4c IR definitions and IR generator binary.
@@ -27,8 +25,10 @@ load(
     "P4C_BACKEND_IR_FILES",
 )
 
+licenses(["notice"])  # Apache v2
+
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 # Instead of using cmake to generate the config.h, this genrule produces
@@ -76,7 +76,7 @@ genrule(
     name = "p4lexer_lex",
     srcs = ["frontends/parsers/p4/p4lexer.ll"],
     outs = ["frontends/parsers/p4/p4lexer.lex"],
-    cmd = ("sed '/%option outfile=\"lex.yy.c\"/d' $< > $@"),
+    cmd = "sed '/%option outfile=\"lex.yy.c\"/d' $< > $@",
     visibility = ["//visibility:private"],
 )
 
@@ -92,7 +92,7 @@ genrule(
     name = "v1lexer_lex",
     srcs = ["frontends/parsers/v1/v1lexer.ll"],
     outs = ["frontends/parsers/v1/v1lexer.lex"],
-    cmd = ("sed '/%option outfile=\"lex.yy.c\"/d' $< > $@"),
+    cmd = "sed '/%option outfile=\"lex.yy.c\"/d' $< > $@",
     visibility = ["//visibility:private"],
 )
 
@@ -164,7 +164,7 @@ cc_library(
         "tools/ir-generator/ir-generator-lex.c",
         "tools/ir-generator/ir-generator-yacc.hh",
     ] + glob([
-        "tools/ir-generator/*.h"
+        "tools/ir-generator/*.h",
     ]),
     deps = [
         ":p4c_includes",
@@ -176,8 +176,8 @@ cc_library(
 cc_binary(
     name = "irgenerator",
     srcs = ["tools/ir-generator/generator.cpp"],
-    visibility = [":__subpackages__"],
     linkopts = ["-lgmp"],
+    visibility = [":__subpackages__"],
     deps = [
         ":p4c_ir_generator_lib",
         ":p4c_toolkit",
@@ -241,8 +241,8 @@ cc_library(
     ]),
     #visibility = STRATUM_INTERNAL,
     deps = [
-        ":p4c_includes",
         ":p4c_frontend_h",
+        ":p4c_includes",
         ":p4c_toolkit",
     ],
 )
@@ -342,7 +342,6 @@ cc_library(
     ],
 )
 
-
 # These rules build p4c binaries with the bmv2 soft switch and PSA backends.
 # These binaries are for example purposes.  Backends for Stratum production will
 # be implemented elsewhere and build with dependencies on the libraries above.
@@ -389,7 +388,7 @@ genrule(
     name = "p4c_bmv2_version",
     srcs = ["backends/bmv2/simple_switch/version.h.cmake"],
     outs = ["backends/bmv2/simple_switch/version.h"],
-    cmd = ("sed 's|@P4C_VERSION@|0.0.0.0|g' $< > $@"),
+    cmd = "sed 's|@P4C_VERSION@|0.0.0.0|g' $< > $@",
     visibility = ["//visibility:private"],
 )
 
@@ -423,7 +422,7 @@ genrule(
     name = "p4c_p4test_version",
     srcs = ["backends/p4test/version.h.cmake"],
     outs = ["backends/p4test/version.h"],
-    cmd = ("sed 's|@P4C_VERSION@|0.0.0.0|g' $< > $@"),
+    cmd = "sed 's|@P4C_VERSION@|0.0.0.0|g' $< > $@",
     #visibility = ["//visibility:private"],
 )
 
@@ -437,14 +436,14 @@ cc_library(
         "backends/p4test/version.h",
     ],
     copts = P4C_BUILD_DEFAULT_COPTS,
+    data = [
+        ":p4c_p4test_version",
+    ],
     deps = [
         ":p4c_frontend_midend",
         ":p4c_ir",
         ":p4c_toolkit",
     ],
-    data = [
-        ":p4c_p4test_version",
-    ]
 )
 
 cc_binary(
@@ -460,15 +459,15 @@ cc_binary(
     deps = [
         ":control_plane",
         ":control_plane_h",
+        ":p4c_backend_p4test_lib",
         ":p4c_frontend_midend",
         ":p4c_ir",
         ":p4c_toolkit",
-        ":p4c_backend_p4test_lib",
     ],
 )
 
 # Includes all valid P4_16 test files
 filegroup(
     name = "testdata_p4_16_samples",
-    data = glob(["testdata/p4_16_samples/*.p4"])
+    data = glob(["testdata/p4_16_samples/*.p4"]),
 )

--- a/bazel/external/systemd.BUILD
+++ b/bazel/external/systemd.BUILD
@@ -4,7 +4,7 @@
 licenses(["notice"])  # Apache v2
 
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/bazel/external/taish_proto.BUILD
+++ b/bazel/external/taish_proto.BUILD
@@ -8,22 +8,22 @@ load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 licenses(["notice"])  # Apache v2
 
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 proto_library(
-  name = "taish_proto",
-  srcs = ["taish/taish.proto"],
+    name = "taish_proto",
+    srcs = ["taish/taish.proto"],
 )
 
 cc_proto_library(
-  name = "taish_cc_proto",
-  deps = [":taish_proto"],
+    name = "taish_cc_proto",
+    deps = [":taish_proto"],
 )
 
 cc_grpc_library(
-  name = "taish_cc_grpc",
-  srcs = [":taish_proto"],
-  deps = [":taish_cc_proto"],
-  grpc_only = True,
+    name = "taish_cc_grpc",
+    srcs = [":taish_proto"],
+    grpc_only = True,
+    deps = [":taish_cc_proto"],
 )

--- a/bazel/external/yang.BUILD
+++ b/bazel/external/yang.BUILD
@@ -3,17 +3,16 @@
 
 licenses(["notice"])  # Apache v2
 
-
 package(
-    default_visibility = [ "//visibility:public" ],
+    default_visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "ietf_yang_models",
     srcs = [
+        "standard/ietf/RFC/iana-if-type@2017-01-19.yang",
         "standard/ietf/RFC/ietf-inet-types@2013-07-15.yang",
         "standard/ietf/RFC/ietf-interfaces@2014-05-08.yang",
         "standard/ietf/RFC/ietf-yang-types@2013-07-15.yang",
-        "standard/ietf/RFC/iana-if-type@2017-01-19.yang",
-    ]
+    ],
 )

--- a/bazel/external/ygot_proto.BUILD
+++ b/bazel/external/ygot_proto.BUILD
@@ -1,16 +1,15 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
-
-package(
-    default_visibility = [ "//visibility:public" ],
-)
-
 load(
     "@com_github_stratum_stratum//bazel/rules:proto_rule.bzl",
     "wrapped_proto_library",
+)
+
+licenses(["notice"])  # Apache v2
+
+package(
+    default_visibility = ["//visibility:public"],
 )
 
 PREFIX = "github.com/openconfig/ygot/proto/"
@@ -25,17 +24,17 @@ wrapped_proto_library(
 wrapped_proto_library(
     name = "yext_proto",
     srcs = ["proto/yext/yext.proto"],
-    deps = ["@com_google_protobuf//:descriptor_proto"],
     new_proto_dir = PREFIX,
     proto_source_root = "proto/",
+    deps = ["@com_google_protobuf//:descriptor_proto"],
 )
 
 cc_proto_library(
     name = "ywrapper_cc_proto",
-    deps = [":ywrapper_proto"]
+    deps = [":ywrapper_proto"],
 )
 
 cc_proto_library(
     name = "yext_cc_proto",
-    deps = [":yext_proto"]
+    deps = [":yext_proto"],
 )

--- a/stratum/hal/config/BUILD
+++ b/stratum/hal/config/BUILD
@@ -14,29 +14,110 @@ package(default_visibility = STRATUM_INTERNAL)
 
 licenses(["notice"])  # Apache v2
 
-platform_config_test("x86-64-accton-as7712-32x-r0", bcm_target=True)
-platform_config_test("x86-64-accton-as7716-24sc-r0", bcm_target=True)
-platform_config_test("x86-64-accton-as7716-24xc-r0", bcm_target=True)
-platform_config_test("x86-64-accton-as6712-32x-r0", bcm_target=True)
-platform_config_test("x86-64-dell-z9100-c2538-r0", bcm_target=True)
-platform_config_test("x86-64-inventec-d7032q28b-r0", bcm_target=True)
-platform_config_test("x86-64-inventec-d7054q28b-r0", bcm_target=True)
-platform_config_test("x86-64-inventec-d6254qs-r0", bcm_target=True)
-platform_config_test("x86-64-quanta-ix1-rangeley-r0", bcm_target=True)
+platform_config_test(
+    "x86-64-accton-as7712-32x-r0",
+    bcm_target = True,
+)
 
-platform_config_test("barefoot-tofino-model", sim_target=True)
+platform_config_test(
+    "x86-64-accton-as7716-24sc-r0",
+    bcm_target = True,
+)
 
-platform_config_test("x86-64-accton-wedge100bf-32x-r0", tofino_target=True)
-platform_config_test("x86-64-accton-wedge100bf-32qs-r0", tofino_target=True)
-platform_config_test("x86-64-accton-wedge100bf-65x-r0", tofino_target=True)
-platform_config_test("x86-64-delta-ag9064v1-r0", tofino_target=True)
-platform_config_test("x86-64-inventec-d5254-r0", tofino_target=True)
-platform_config_test("x86-64-inventec-d5264q28b-r0", tofino_target=True)
-platform_config_test("x86-64-netberg-aurora-610-r0", tofino_target=True)
-platform_config_test("x86-64-netberg-aurora-710-r0", tofino_target=True)
-platform_config_test("x86-64-netberg-aurora-750-r0", tofino_target=True)
-platform_config_test("x86-64-stordis-bf2556x-1t-r0", tofino_target=True)
-platform_config_test("x86-64-stordis-bf6064x-t-r0", tofino_target=True)
+platform_config_test(
+    "x86-64-accton-as7716-24xc-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "x86-64-accton-as6712-32x-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "x86-64-dell-z9100-c2538-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "x86-64-inventec-d7032q28b-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "x86-64-inventec-d7054q28b-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "x86-64-inventec-d6254qs-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "x86-64-quanta-ix1-rangeley-r0",
+    bcm_target = True,
+)
+
+platform_config_test(
+    "barefoot-tofino-model",
+    sim_target = True,
+)
+
+platform_config_test(
+    "x86-64-accton-wedge100bf-32x-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-accton-wedge100bf-32qs-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-accton-wedge100bf-65x-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-delta-ag9064v1-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-inventec-d5254-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-inventec-d5264q28b-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-netberg-aurora-610-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-netberg-aurora-710-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-netberg-aurora-750-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-stordis-bf2556x-1t-r0",
+    tofino_target = True,
+)
+
+platform_config_test(
+    "x86-64-stordis-bf6064x-t-r0",
+    tofino_target = True,
+)
 
 filegroup(
     name = "platform_configs",

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -2,18 +2,16 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
     "stratum_cc_test",
 )
-
 load("//bazel:deps.bzl", "P4RUNTIME_VER")
-
 load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -31,25 +29,25 @@ stratum_cc_library(
     deps = [
         ":admin_utils",
         ":admin_utils_interface",
-        "@com_google_googletest//:gtest",
         ":common_cc_proto",
         ":error_buffer",
         ":switch_interface",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
         "//stratum/glue:logging",
-        "@com_github_openconfig_gnoi//:system_cc_grpc",
+        "//stratum/glue/gtl:map_util",
+        "//stratum/glue/status",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
-        "//stratum/glue/status:status",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_openconfig_gnoi//:system_cc_grpc",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -106,11 +104,11 @@ stratum_cc_library(
         "//stratum/lib:utils",
         "//stratum/public/lib:error",
         "@com_github_google_glog//:glog",
-        "@com_github_openconfig_gnoi//:types_cc_proto",
+        "@com_github_grpc_grpc//:grpc++",
         "@com_github_openconfig_gnoi//:common_cc_proto",
         "@com_github_openconfig_gnoi//:system_cc_grpc",
+        "@com_github_openconfig_gnoi//:types_cc_proto",
         "@com_google_absl//absl/memory",
-        "@com_github_grpc_grpc//:grpc++",
     ],
 )
 
@@ -126,21 +124,21 @@ stratum_cc_library(
         ":common_cc_proto",
         ":error_buffer",
         ":switch_interface",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
         "//stratum/glue:logging",
-        "@com_github_openconfig_gnoi//:cert_cc_grpc",
+        "//stratum/glue/gtl:map_util",
+        "//stratum/glue/status",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
-        "//stratum/glue/status:status",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_openconfig_gnoi//:cert_cc_grpc",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -175,10 +173,10 @@ stratum_cc_library(
     name = "client_sync_reader_writer",
     hdrs = ["client_sync_reader_writer.h"],
     deps = [
+        "//stratum/glue:logging",
+        "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
-        "//stratum/glue:logging",
     ],
 )
 
@@ -189,13 +187,13 @@ proto_library(
 
 cc_proto_library(
     name = "common_cc_proto",
-    deps = [":common_proto"]
+    deps = [":common_proto"],
 )
 
 py_proto_library(
     name = "common_py_proto",
     deps = [
-        ":common_proto"
+        ":common_proto",
     ],
 )
 
@@ -212,6 +210,10 @@ stratum_cc_library(
         "gnmi_publisher.h",
         "yang_parse_tree.h",
         "yang_parse_tree_paths.h",
+    ],
+    data = [
+        # TODO(Yi): generate this when we generating the OpenConfig proto files
+        "gnmi_caps.pb.txt",
     ],
     deps = [
         ":channel_writer_wrapper",
@@ -250,10 +252,6 @@ stratum_cc_library(
         #FIXME(boc)
         #"//util/time:clock",
     ],
-    data = [
-        # TODO(Yi): generate this when we generating the OpenConfig proto files
-        "gnmi_caps.pb.txt"
-    ],
 )
 
 stratum_cc_test(
@@ -264,6 +262,10 @@ stratum_cc_test(
         "yang_parse_tree_mock.h",
         "yang_parse_tree_test.cc",
     ],
+    data = [
+        # TODO(Yi): generate this when we generating the OpenConfig proto files
+        "gnmi_caps.pb.txt",
+    ],
     deps = [
         ":config_monitoring_service",
         ":error_buffer",
@@ -271,15 +273,8 @@ stratum_cc_test(
         ":subscribe_reader_writer_mock",
         ":switch_mock",
         ":test_main",
+        ":testdata",
         ":writer_mock",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:constants",
         "//stratum/lib:timer_daemon",
@@ -287,12 +282,15 @@ stratum_cc_test(
         "//stratum/lib/security:auth_policy_checker_mock",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
-        ":testdata",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "@com_github_openconfig_hercules//:openconfig_cc_proto",
-    ],
-    data = [
-        # TODO(Yi): generate this when we generating the OpenConfig proto files
-        "gnmi_caps.pb.txt"
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -303,9 +301,9 @@ cc_library(
     testonly = 1,
     hdrs = ["subscribe_reader_writer_mock.h"],
     deps = [
-        "@com_google_googletest//:gtest",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -323,19 +321,19 @@ cc_library(
         ":switch_interface",
         ":switch_mock",
         ":writer_interface",
-        "@com_google_googletest//:gtest",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
-        "@com_github_openconfig_gnmi_proto//:gnmi_cc_grpc",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/lib:macros",
         "//stratum/lib:timer_daemon",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_grpc",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -360,20 +358,20 @@ stratum_cc_library(
         ":common_cc_proto",
         ":error_buffer",
         ":switch_interface",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
         "//stratum/glue:logging",
-        "@com_github_openconfig_gnoi//:diag_cc_grpc",
+        "//stratum/glue/gtl:map_util",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_openconfig_gnoi//:diag_cc_grpc",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -430,12 +428,12 @@ stratum_cc_test(
     deps = [
         ":error_buffer",
         ":test_main",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest",
-        "@com_google_absl//absl/memory",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -451,21 +449,21 @@ stratum_cc_library(
         ":common_cc_proto",
         ":error_buffer",
         ":switch_interface",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
         "//stratum/glue:logging",
-        "@com_github_openconfig_gnoi//:file_cc_grpc",
+        "//stratum/glue/gtl:map_util",
+        "//stratum/glue/status",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
-        "//stratum/glue/status:status",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_openconfig_gnoi//:file_cc_grpc",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -510,19 +508,19 @@ stratum_cc_library(
         ":file_service",
         ":p4_service",
         ":switch_interface",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
         "//stratum/glue:logging",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/lib/security:credentials_manager",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -535,9 +533,6 @@ stratum_cc_test(
         ":hal",
         ":switch_mock",
         ":test_main",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest",
-        "@com_google_absl//absl/strings",
         "//stratum/glue/net_util:ports",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
@@ -545,6 +540,9 @@ stratum_cc_test(
         "//stratum/lib/security:credentials_manager_mock",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -552,27 +550,17 @@ stratum_cc_library(
     name = "p4_service",
     srcs = ["p4_service.cc"],
     hdrs = ["p4_service.h"],
+    defines = [
+        "P4RUNTIME_VER=" + P4RUNTIME_VER,
+    ],
     deps = [
         ":channel_writer_wrapper",
         ":common_cc_proto",
         ":error_buffer",
         ":server_writer_wrapper",
         ":switch_interface",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/cleanup",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/numeric:int128",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_absl//absl/time",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_google_googleapis//google/rpc:code_cc_proto",
-        "@com_google_googleapis//google/rpc:status_cc_proto",
         "//stratum/glue:logging",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/glue/status:statusor",
@@ -582,11 +570,21 @@ stratum_cc_library(
         "//stratum/lib/channel",
         "//stratum/lib/security:auth_policy_checker",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/numeric:int128",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
+        "@com_google_googleapis//google/rpc:status_cc_proto",
+        "@com_google_protobuf//:protobuf",
     ],
-    defines = [
-        "P4RUNTIME_VER=" + P4RUNTIME_VER,
-    ]
 )
 
 stratum_cc_test(
@@ -594,30 +592,30 @@ stratum_cc_test(
     srcs = [
         "p4_service_test.cc",
     ],
+    defines = [
+        "P4RUNTIME_VER=" + P4RUNTIME_VER,
+    ],
     deps = [
         ":error_buffer",
         ":p4_service",
         ":switch_mock",
         ":test_main",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/numeric:int128",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_google_googleapis//google/rpc:code_cc_proto",
         "//stratum/glue/net_util:ports",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
         "//stratum/lib/security:auth_policy_checker_mock",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/numeric:int128",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
+        "@com_google_googletest//:gtest",
     ],
-    defines = [
-        "P4RUNTIME_VER=" + P4RUNTIME_VER,
-    ]
 )
 
 stratum_cc_library(
@@ -625,9 +623,9 @@ stratum_cc_library(
     hdrs = ["phal_interface.h"],
     deps = [
         ":common_cc_proto",
-        "//stratum/hal/lib/phal:sfp_configurator",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/phal:sfp_configurator",
         "//stratum/lib/channel",
     ],
 )
@@ -689,18 +687,18 @@ stratum_cc_library(
     deps = [
         ":common_cc_proto",
         ":writer_interface",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/synchronization",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
-        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
-        "@com_github_openconfig_gnmi_proto//:gnmi_cc_grpc",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/lib:timer_daemon",
-        "//stratum/lib/channel",
         "//stratum/lib:utils",
-        "//stratum/glue/gtl:map_util",
+        "//stratum/lib/channel",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_grpc",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -719,10 +717,10 @@ cc_library(
     testonly = 1,
     srcs = ["test_main.cc"],
     deps = [
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest",
         "//stratum/glue:init_google",
         "//stratum/glue:logging",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -733,14 +731,14 @@ stratum_cc_library(
     deps = [
         ":common_cc_proto",
         ":constants",
+        "//stratum/glue/status:statusor",
+        "//stratum/lib:constants",
+        "//stratum/lib:macros",
+        "//stratum/public/lib:error",
+        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
-        "@com_github_openconfig_gnmi_proto//:gnmi_cc_proto",
-        "//stratum/lib:constants",
-        "//stratum/lib:macros",
-        "//stratum/glue/status:statusor",
-        "//stratum/public/lib:error",
     ],
 )
 
@@ -750,12 +748,12 @@ stratum_cc_test(
     deps = [
         ":test_main",
         ":utils",
-        "@com_google_googletest//:gtest",
+        "//stratum/glue/status:status_test_util",
+        "//stratum/lib:constants",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_protobuf//:protobuf",
-        "//stratum/lib:constants",
-        "//stratum/glue/status:status_test_util",
     ],
 )
 
@@ -792,10 +790,10 @@ stratum_cc_test(
         ":test_main",
         ":testdata",
         ":utils",
-        "@com_google_googletest//:gtest",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
         "//stratum/lib/test_utils:matchers",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -2,15 +2,15 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
+    "HOST_ARCHES",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
     "stratum_cc_test",
-    "HOST_ARCHES",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -21,9 +21,9 @@ proto_library(
     name = "common_flow_entry_proto",
     srcs = ["common_flow_entry.proto"],
     deps = [
-        "@com_github_p4lang_p4runtime//:p4runtime_proto",
-        "//stratum/public/proto:p4_table_defs_proto",
         "//stratum/public/proto:p4_annotation_proto",
+        "//stratum/public/proto:p4_table_defs_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_proto",
     ],
 )
 
@@ -54,12 +54,12 @@ stratum_cc_library(
         ":p4_pipeline_config_cc_proto",
         ":p4_table_map_cc_proto",
         ":utils",
-        "//stratum/lib:macros",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/glue/gtl:map_util",
         "//stratum/glue/gtl:stl_util",
+        "//stratum/lib:macros",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -72,16 +72,16 @@ stratum_cc_test(
         ":p4_pipeline_config_cc_proto",
         ":p4_table_map_cc_proto",
         ":testdata",
-        "//stratum/lib:utils",
-        "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "//stratum/public/proto:p4_annotation_cc_proto",
-        "//stratum/public/proto:p4_table_defs_cc_proto",
         "//stratum/glue/gtl:map_util",
         "//stratum/glue/status:status_test_util",
+        "//stratum/lib:utils",
+        "//stratum/lib/test_utils:matchers",
+        "//stratum/public/proto:p4_annotation_cc_proto",
+        "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -94,19 +94,19 @@ stratum_cc_library(
         ":p4_table_map_cc_proto",
         ":p4_write_request_differ",
         ":utils",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "//stratum/glue:logging",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/lib:macros",
         "//stratum/public/lib:error",
         "//stratum/public/proto:p4_annotation_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -119,16 +119,16 @@ stratum_cc_test(
         ":p4_pipeline_config_cc_proto",
         ":p4_table_map_cc_proto",
         ":testdata",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -138,20 +138,20 @@ stratum_cc_library(
     hdrs = ["p4_info_manager.h"],
     deps = [
         ":utils",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/strings",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/glue:logging",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/glue/status:statusor",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
-        "//stratum/glue/gtl:map_util",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -172,13 +172,13 @@ stratum_cc_test(
     deps = [
         ":p4_info_manager",
         ":testdata",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -189,13 +189,13 @@ stratum_cc_library(
     deps = [
         ":common_flow_entry_cc_proto",
         ":p4_table_map_cc_proto",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "//stratum/glue/status:status_macros",
         "//stratum/lib:utils",
         "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -205,11 +205,11 @@ stratum_cc_test(
     copts = ["-funsigned-char"],
     deps = [
         ":p4_match_key",
-        "@com_google_googletest//:gtest_main",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "//stratum/glue/status:status_test_util",
         "//stratum/public/lib:error",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -233,8 +233,8 @@ proto_library(
     deps = [
         ":p4_control_proto",
         ":p4_table_map_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_proto",
         "//stratum/public/proto:p4_annotation_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_proto",
     ],
 )
 
@@ -248,9 +248,9 @@ proto_library(
     srcs = ["p4_table_map.proto"],
     deps = [
         ":common_flow_entry_proto",
-        "@com_github_p4lang_p4runtime//:p4info_proto",
         "//stratum/public/proto:p4_annotation_proto",
         "//stratum/public/proto:p4_table_defs_proto",
+        "@com_github_p4lang_p4runtime//:p4info_proto",
     ],
 )
 
@@ -297,14 +297,14 @@ stratum_cc_test(
     deps = [
         ":p4_table_mapper",
         ":p4_table_mapper_mock",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc", #FIXME actually p4runtime_cc_proto
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",  #FIXME actually p4runtime_cc_proto
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -329,13 +329,8 @@ stratum_cc_library(
         ":p4_table_map_cc_proto",
         ":p4_write_request_differ",
         ":utils",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc", #FIXME actually p4runtime_cc_proto
         "//stratum/glue:logging",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/net_util:ipaddress",
         "//stratum/glue/status",
         "//stratum/hal/lib/common:common_cc_proto",
@@ -343,7 +338,12 @@ stratum_cc_library(
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",  #FIXME actually p4runtime_cc_proto
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -366,14 +366,14 @@ stratum_cc_test(
         ":p4_static_entry_mapper_mock",
         ":p4_table_mapper",
         ":testdata",
-        "@com_github_google_glog//:glog",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
         "//stratum/glue:logging",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
         "//stratum/lib/test_utils:matchers",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -382,13 +382,13 @@ stratum_cc_library(
     srcs = ["p4_write_request_differ.cc"],
     hdrs = ["p4_write_request_differ.h"],
     deps = [
-        "@com_github_google_glog//:glog",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc", #FIXME actually p4runtime_cc_proto
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/lib:macros",
         "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",  #FIXME actually p4runtime_cc_proto
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -397,13 +397,13 @@ stratum_cc_test(
     srcs = ["p4_write_request_differ_test.cc"],
     deps = [
         ":p4_write_request_differ",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc", #FIXME actually p4runtime_cc_proto
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:utils",
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",  #FIXME actually p4runtime_cc_proto
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -414,18 +414,18 @@ stratum_cc_library(
     deps = [
         ":p4_pipeline_config_cc_proto",
         ":p4_table_map_cc_proto",
+        "//stratum/glue:integral_types",
+        "//stratum/glue/gtl:map_util",
+        "//stratum/glue/status:statusor",
         "//stratum/lib:macros",
         "//stratum/lib:utils",
         "//stratum/public/lib:error",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googleapis//google/rpc:code_cc_proto",
         "@com_google_googleapis//google/rpc:status_cc_proto",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "//stratum/glue/gtl:map_util",
-        "//stratum/glue:integral_types",
-        "//stratum/glue/status:statusor",
     ],
 )
 
@@ -439,13 +439,13 @@ stratum_cc_test(
         ":p4_table_map_cc_proto",
         ":testdata",
         ":utils",
-        "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "//stratum/lib:utils",
         "//stratum/glue/gtl:map_util",
         "//stratum/glue/status:status_test_util",
+        "//stratum/lib:utils",
+        "//stratum/lib/test_utils:matchers",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/stratum/hal/lib/phal/onlp/BUILD
+++ b/stratum/hal/lib/phal/onlp/BUILD
@@ -2,17 +2,17 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 load(
     "//bazel:rules.bzl",
+    "EMBEDDED_ARCHES",
+    "HOST_ARCHES",
     "STRATUM_INTERNAL",
     "stratum_cc_binary",
     "stratum_cc_library",
     "stratum_cc_test",
-    "EMBEDDED_ARCHES",
-    "HOST_ARCHES",
 )
+
+licenses(["notice"])  # Apache v2
 
 package(
     #default_hdrs_check = "strict",
@@ -25,16 +25,15 @@ stratum_cc_library(
     hdrs = ["onlp_event_handler.h"],
     deps = [
         ":onlp_wrapper",
-        "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_absl//absl/time",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/hal/lib/common:common_cc_proto",
         "//stratum/hal/lib/common:phal_interface",
         "//stratum/lib:macros",
-        "//stratum/glue/gtl:map_util",
-
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
     ],
 )
 
@@ -56,13 +55,13 @@ stratum_cc_test(
         ":onlp_event_handler",
         ":onlp_event_handler_mock",
         ":onlp_wrapper_mock",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_absl//absl/time",
         "//stratum/glue/status",
+        "//stratum/glue/status:status_test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "//stratum/glue/status:status_test_util",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -94,9 +93,9 @@ stratum_cc_library(
     arches = HOST_ARCHES,
     deps = [
         ":onlp_wrapper",
-        "@com_google_googletest//:gtest",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -144,8 +143,8 @@ stratum_cc_test(
         "onlp_sfp_datasource_test.cc",
     ],
     deps = [
-        ":onlp_wrapper_mock",
         ":onlp_sfp_datasource",
+        ":onlp_wrapper_mock",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
@@ -154,11 +153,11 @@ stratum_cc_test(
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -190,8 +189,8 @@ stratum_cc_test(
         "onlp_fan_datasource_test.cc",
     ],
     deps = [
-        ":onlp_wrapper_mock",
         ":onlp_fan_datasource",
+        ":onlp_wrapper_mock",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
@@ -200,11 +199,11 @@ stratum_cc_test(
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -236,8 +235,8 @@ stratum_cc_test(
         "onlp_psu_datasource_test.cc",
     ],
     deps = [
-        ":onlp_wrapper_mock",
         ":onlp_psu_datasource",
+        ":onlp_wrapper_mock",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
@@ -246,11 +245,11 @@ stratum_cc_test(
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -304,8 +303,8 @@ stratum_cc_test(
         "onlp_thermal_datasource_test.cc",
     ],
     deps = [
-        ":onlp_wrapper_mock",
         ":onlp_thermal_datasource",
+        ":onlp_wrapper_mock",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
@@ -314,11 +313,11 @@ stratum_cc_test(
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -328,8 +327,8 @@ stratum_cc_test(
         "onlp_led_datasource_test.cc",
     ],
     deps = [
-        ":onlp_wrapper_mock",
         ":onlp_led_datasource",
+        ":onlp_wrapper_mock",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
@@ -338,11 +337,11 @@ stratum_cc_test(
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -352,8 +351,8 @@ stratum_cc_library(
     deps = [
         ":onlp_event_handler",
         ":onlp_sfp_configurator",
-        "//stratum/glue/status:statusor",
         "//stratum/glue/status",
+        "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:phal_interface",
         "//stratum/hal/lib/phal:attribute_database",
         "//stratum/hal/lib/phal:phal_backend_interface",
@@ -367,20 +366,20 @@ stratum_cc_library(
     srcs = ["onlp_phal.cc"],
     hdrs = ["onlp_phal.h"],
     deps = [
-        ":onlp_phal_interface",
         ":onlp_event_handler",
-        ":onlp_wrapper",
-        ":onlp_switch_configurator",
+        ":onlp_phal_interface",
         ":onlp_sfp_configurator",
         ":onlp_sfp_datasource",
-        "//stratum/lib/channel:channel",
-        "//stratum/lib:macros",
+        ":onlp_switch_configurator",
+        ":onlp_wrapper",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
-        "//stratum/hal/lib/common:constants",
         "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/common:constants",
         "//stratum/hal/lib/common:phal_interface",
         "//stratum/hal/lib/phal:attribute_database",
+        "//stratum/lib:macros",
+        "//stratum/lib/channel",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/synchronization",
     ],
@@ -391,13 +390,13 @@ stratum_cc_test(
     srcs = ["onlp_phal_test.cc"],
     copts = ["-Wno-thread-safety-analysis"],  # TODO(max)
     deps = [
+        ":onlp_event_handler_mock",
         ":onlp_phal",
         ":onlp_wrapper_mock",
-        ":onlp_event_handler_mock",
-        "@com_google_googletest//:gtest_main",
         "//stratum/glue/status",
         "//stratum/glue/status:status_test_util",
         "//stratum/lib:macros",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -405,17 +404,17 @@ stratum_cc_library(
     name = "onlp_phal_mock",
     hdrs = ["onlp_phal_mock.h"],
     deps = [
-        ":onlp_phal_interface",
         ":onlp_event_handler",
-        ":onlp_wrapper_mock",
+        ":onlp_phal_interface",
         ":onlp_sfp_datasource",
-        "//stratum/lib:macros",
+        ":onlp_wrapper_mock",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
-        "//stratum/hal/lib/common:constants",
         "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/common:constants",
         "//stratum/hal/lib/common:phal_interface",
         "//stratum/hal/lib/phal:attribute_database",
+        "//stratum/lib:macros",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/synchronization",
     ],
@@ -426,22 +425,22 @@ stratum_cc_library(
     srcs = ["onlp_switch_configurator.cc"],
     hdrs = ["onlp_switch_configurator.h"],
     deps = [
-        ":onlp_phal_interface",
+        ":onlp_event_handler",
         ":onlp_fan_datasource",
         ":onlp_led_datasource",
-        ":onlp_event_handler",
-        ":onlp_wrapper",
+        ":onlp_phal_interface",
         ":onlp_psu_datasource",
         ":onlp_sfp_configurator",
         ":onlp_sfp_datasource",
         ":onlp_thermal_datasource",
-        "@com_google_protobuf//:protobuf",
+        ":onlp_wrapper",
         "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/common:common_cc_proto",
         "//stratum/hal/lib/common:phal_interface",
         "//stratum/hal/lib/phal:attribute_database",
         "//stratum/hal/lib/phal:attribute_group",
         "//stratum/hal/lib/phal:phal_cc_proto",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -452,12 +451,12 @@ stratum_cc_library(
     deps = [
         ":onlp_sfp_datasource",
         "//stratum/hal/lib/common:common_cc_proto",
-        "//stratum/hal/lib/phal:sfp_configurator",
-        "//stratum/hal/lib/phal:phal_cc_proto",
-        "//stratum/hal/lib/phal:attribute_group",
-        "//stratum/hal/lib/phal:attribute_database",
-        "//stratum/hal/lib/phal/onlp:onlp_event_handler",
         "//stratum/hal/lib/common:phal_interface",
+        "//stratum/hal/lib/phal:attribute_database",
+        "//stratum/hal/lib/phal:attribute_group",
+        "//stratum/hal/lib/phal:phal_cc_proto",
+        "//stratum/hal/lib/phal:sfp_configurator",
+        "//stratum/hal/lib/phal/onlp:onlp_event_handler",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -501,19 +500,19 @@ stratum_cc_binary(
     ],
     deps = [
         ":onlp_phal",
-        ":onlp_switch_configurator",
         ":onlp_sfp_configurator",
+        ":onlp_switch_configurator",
+        "//stratum/glue:init_google",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/glue/status:statusor",
+        "//stratum/lib:macros",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@local_onlp_bin//:onlp",
         "@local_onlp_bin//:onlp_platform",
         "@local_onlp_bin//:onlp_platform_defaults",
-        "//stratum/glue:init_google",
-        "//stratum/glue/status",
-        "//stratum/glue/status:status_macros",
-        "//stratum/glue/status:statusor",
-        "//stratum/lib:macros",
     ],
 )
 
@@ -522,25 +521,25 @@ stratum_cc_test(
     srcs = ["onlp_switch_configurator_test.cc"],
     deps = [
         ":onlp_phal_mock",
-        ":onlp_switch_configurator",
         ":onlp_sfp_configurator",
+        ":onlp_switch_configurator",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
         "//stratum/hal/lib/phal:attribute_database",
         "//stratum/hal/lib/phal:attribute_group_mock",
         "//stratum/hal/lib/phal:datasource",
-        "//stratum/hal/lib/phal:sfp_configurator",
         "//stratum/hal/lib/phal:db_cc_proto",
         "//stratum/hal/lib/phal:phal_cc_proto",
+        "//stratum/hal/lib/phal:sfp_configurator",
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -551,19 +550,18 @@ stratum_cc_test(
         ":onlp_event_handler_mock",
         ":onlp_sfp_configurator",
         ":onlp_wrapper_mock",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-        "@com_google_googletest//:gtest_main",
-        "//stratum/glue/status:statusor",
         "//stratum/glue/status",
+        "//stratum/glue/status:statusor",
         "//stratum/hal/lib/common:common_cc_proto",
         "//stratum/hal/lib/phal:adapter",
         "//stratum/hal/lib/phal:db_cc_proto",
         "//stratum/hal/lib/phal:test_util",
         "//stratum/lib:macros",
         "//stratum/lib/test_utils:matchers",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
     ],
 )
-

--- a/stratum/p4c_backends/fpm/BUILD
+++ b/stratum/p4c_backends/fpm/BUILD
@@ -2,12 +2,9 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-licenses(["notice"])  # Apache v2
-
 # This file builds the switch-specific p4c_backends components.
 load(
     "//bazel:rules.bzl",
-    "stratum_cc_library",
     "STRATUM_INTERNAL",
     "stratum_license_tar",
 )
@@ -15,8 +12,9 @@ load(
     "//stratum/p4c_backends/test:build_defs.bzl",
     "p4c_save_ir",
 )
+load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
+licenses(["notice"])  # Apache v2
 
 package(
     # default_copts = [
@@ -25,7 +23,6 @@ package(
     # default_hdrs_check = "warn",
     default_visibility = STRATUM_INTERNAL,
 )
-
 
 """google only
 # This rule makes a copy of production P4 role specs for generating local test
@@ -114,10 +111,10 @@ cc_library(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
+        "//stratum/lib:utils",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
         "@com_github_p4lang_p4c//:p4c_toolkit",
-        "//stratum/lib:utils",
     ],
 )
 
@@ -140,11 +137,11 @@ cc_test(
         ":action_decoder",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -159,8 +156,6 @@ cc_library(
     deps = [
         ":p4_annotation_map_cc_proto",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/container:node_hash_map",
-        "@com_google_absl//absl/strings",
         "//stratum/hal/lib/p4:common_flow_entry_cc_proto",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
@@ -168,6 +163,8 @@ cc_library(
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_annotation_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -195,7 +192,7 @@ cc_test(
         "//stratum/lib:macros",
         "//stratum/public/proto:p4_table_defs_cc_proto",
         # "//util/task:status",
-        "//stratum/glue/status:status",
+        "//stratum/glue/status",
     ],
 )
 
@@ -209,8 +206,8 @@ cc_library(
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
         "//stratum/glue:logging",
-        "@com_google_absl//absl/strings:str_format",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -228,12 +225,12 @@ cc_test(
     deps = [
         ":condition_inspector",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
+        "@com_github_grpc_grpc//:grpc++",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
         "@com_github_p4lang_p4c//:p4c_toolkit",
-        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -252,14 +249,14 @@ cc_library(
         ":p4c_switch_utils",
         ":switch_case_decoder",
         ":table_map_generator",
-        "//stratum/hal/lib/p4:p4_info_manager",
-        "//stratum/hal/lib/p4:p4_control_cc_proto",
         "//stratum/glue:logging",
         "//stratum/glue/gtl:map_util",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/debugging:leak_check",
+        "//stratum/hal/lib/p4:p4_control_cc_proto",
+        "//stratum/hal/lib/p4:p4_info_manager",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/debugging:leak_check",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -293,13 +290,13 @@ cc_test(
         ":table_map_generator",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/hal/lib/p4:p4_info_manager_mock",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/p4c_backends/test:test_target_info",
         "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -315,11 +312,11 @@ cc_library(
         ":field_name_inspector",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -341,11 +338,11 @@ cc_test(
         ":expression_inspector",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -360,11 +357,11 @@ cc_library(
     deps = [
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
     ],
 )
 
@@ -382,13 +379,13 @@ cc_test(
     deps = [
         ":field_cross_reference",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -436,11 +433,11 @@ cc_test(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -456,8 +453,8 @@ cc_library(
         ":p4_model_names_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_google_absl//absl/debugging:leak_check",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -481,10 +478,10 @@ cc_test(
         ":p4_model_names_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -500,8 +497,8 @@ cc_library(
         ":p4_model_names_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -527,11 +524,11 @@ cc_test(
         ":p4_model_names_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
+        "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_github_p4lang_p4c//:p4c_ir",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4c//:p4c_ir",
-        "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -548,10 +545,10 @@ cc_library(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
-        "@com_google_absl//absl/memory",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -574,9 +571,9 @@ cc_test(
         ":p4c_switch_utils",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -594,15 +591,15 @@ cc_library(
         ":p4c_switch_utils",
         ":tunnel_optimizer_interface",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "//stratum/glue/gtl:map_util",
+        "//stratum/glue/gtl:stl_util",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_match_key",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
-        "//stratum/glue/gtl:stl_util",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -624,18 +621,18 @@ cc_test(
         ":table_map_generator",
         ":tunnel_optimizer_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_info_manager_mock",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -650,15 +647,15 @@ cc_library(
     deps = [
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "//stratum/glue/gtl:map_util",
+        "//stratum/glue/gtl:stl_util",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
-        "//stratum/glue/gtl:stl_util",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -681,17 +678,17 @@ cc_test(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_info_manager_mock",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -706,9 +703,9 @@ cc_library(
     deps = [
         "//stratum/glue:logging",
         "//stratum/lib:macros",
-        "@com_google_absl//absl/debugging:leak_check",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -736,10 +733,10 @@ cc_test(
     deps = [
         ":hit_assign_mapper",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/p4c_backends/test:test_inspectors",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -756,12 +753,12 @@ cc_library(
         ":table_map_generator",
         ":tunnel_optimizer_interface",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/strings",
-        "@com_google_protobuf//:protobuf",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -783,12 +780,12 @@ cc_test(
         ":table_map_generator_mock",
         ":tunnel_optimizer_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -804,11 +801,11 @@ cc_library(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
     ],
 )
 
@@ -827,8 +824,8 @@ cc_test(
         ":meta_key_mapper",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -848,11 +845,11 @@ cc_library(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -888,11 +885,11 @@ cc_test(
         ":table_map_generator",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_google_protobuf//:protobuf",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -909,11 +906,11 @@ cc_library(
         ":p4_model_names_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_google_absl//absl/debugging:leak_check",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -935,10 +932,10 @@ cc_test(
         ":method_call_decoder",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -952,10 +949,10 @@ cc_library(
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
+        "//stratum/p4c_backends/common:midend_interface",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
-        "//stratum/p4c_backends/common:midend_interface",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -976,12 +973,12 @@ cc_test(
     deps = [
         ":midend",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/p4c_backends/common:program_inspector",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -999,9 +996,9 @@ cc_library(
         ":p4_parser_map_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -1012,10 +1009,10 @@ cc_test(
         "-fexceptions",
     ],
     data = [
+        "testdata/parse_annotated_state.ir.json",
         "testdata/parse_basic.ir.json",
         "testdata/parse_complex.ir.json",
         "testdata/parse_value_set.ir.json",
-        "testdata/parse_annotated_state.ir.json",
         "//stratum/p4c_backends/test:testdata/simple_vlan_stack_16.ir.json",
     ],
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
@@ -1026,10 +1023,10 @@ cc_test(
     deps = [
         ":parser_decoder",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1047,9 +1044,9 @@ cc_library(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
+        "//stratum/glue/gtl:map_util",
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/strings",
-        "//stratum/glue/gtl:map_util",
     ],
 )
 
@@ -1077,10 +1074,10 @@ cc_test(
         ":table_map_generator",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/strings",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1097,13 +1094,13 @@ cc_library(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -1128,12 +1125,12 @@ cc_test(
         ":table_map_generator",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_info_manager_mock",
         "//stratum/p4c_backends/test:ir_test_helpers",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1171,10 +1168,10 @@ cc_test(
     deps = [
         ":pipeline_optimizer",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/p4c_backends/test:test_target_info",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1189,10 +1186,10 @@ cc_library(
     deps = [
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
+        "//stratum/public/proto:p4_annotation_cc_proto",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
-        "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -1214,12 +1211,12 @@ cc_test(
     deps = [
         ":p4c_switch_utils",
         ":pipeline_block_passes",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/p4c_backends/test:test_inspectors",
         "//stratum/p4c_backends/test:test_target_info",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1234,10 +1231,10 @@ cc_library(
     deps = [
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
+        "//stratum/public/proto:p4_annotation_cc_proto",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
         "@com_github_p4lang_p4c//:p4c_ir",
-        "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -1264,13 +1261,13 @@ cc_test(
         ":p4c_switch_utils",
         ":pipeline_block_passes",
         ":pipeline_intra_block_passes",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/p4c_backends/test:test_inspectors",
         "//stratum/p4c_backends/test:test_target_info",
         "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1312,9 +1309,9 @@ cc_test(
     deps = [
         ":simple_hit_inspector",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1331,12 +1328,12 @@ cc_library(
         ":p4c_switch_utils",
         ":sliced_field_map_cc_proto",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -1359,12 +1356,12 @@ cc_test(
         ":slice_cross_reference",
         ":sliced_field_map_cc_proto",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1382,9 +1379,9 @@ cc_library(
         ":p4_model_names_cc_proto",
         ":table_map_generator",
         "//stratum/glue:logging",
+        "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:macros",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "//stratum/hal/lib/p4:p4_table_map_cc_proto",
     ],
 )
 
@@ -1410,11 +1407,11 @@ cc_test(
         ":switch_case_decoder",
         ":table_map_generator_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_google_protobuf//:protobuf",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -1477,10 +1474,6 @@ cc_library(
         ":tunnel_optimizer_interface",
         ":tunnel_type_mapper",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/debugging:leak_check",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_ir",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
@@ -1488,6 +1481,10 @@ cc_library(
         "//stratum/p4c_backends/common:backend_extension_interface",
         "//stratum/p4c_backends/common:p4c_front_mid_interface",
         "//stratum/p4c_backends/common:program_inspector",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_google_absl//absl/debugging:leak_check",
+        "@com_google_absl//absl/memory",
     ],
 )
 
@@ -1519,19 +1516,19 @@ cc_test(
         ":switch_p4c_backend",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/common:p4c_common_mocks",
         "//stratum/p4c_backends/fpm/bcm:bcm_tunnel_optimizer",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/p4c_backends/test:test_target_info",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -1547,8 +1544,8 @@ cc_library(
         ":simple_hit_inspector",
         "//stratum/glue:logging",
         "//stratum/lib:macros",
-        "@com_google_absl//absl/debugging:leak_check",
         "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_google_absl//absl/debugging:leak_check",
     ],
 )
 
@@ -1582,9 +1579,9 @@ cc_test(
         ":p4c_switch_utils",
         ":table_hit_inspector",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
         "//stratum/p4c_backends/test:ir_test_helpers",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1604,13 +1601,13 @@ cc_library(
         ":p4_model_names_cc_proto",
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -1630,13 +1627,13 @@ cc_test(
         ":p4c_switch_utils",
         ":table_map_generator",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
-        "@com_google_protobuf//:protobuf",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -1688,14 +1685,14 @@ cc_test(
         ":p4c_switch_utils",
         ":table_type_mapper",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1724,8 +1721,8 @@ cc_test(
         ":target_info",
         ":target_info_mock",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
         "//stratum/public/proto:p4_annotation_cc_proto",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1770,10 +1767,10 @@ cc_library(
     deps = [
         ":p4c_switch_utils",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/strings",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -1793,13 +1790,13 @@ cc_test(
         ":table_map_generator",
         ":tunnel_type_mapper",
         "//stratum/glue:logging",
-        "@com_google_googletest//:gtest_main",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
         "//stratum/hal/lib/p4:p4_table_map_cc_proto",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -1820,9 +1817,7 @@ cc_library(
         ":p4_parser_map_cc_proto",
         ":target_info",
         "//stratum/glue:logging",
-        "@com_google_absl//absl/strings",
-        "@com_github_p4lang_p4c//:p4c_frontend_midend",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "//stratum/glue/gtl:map_util",
         "//stratum/hal/lib/p4:p4_control_cc_proto",
         "//stratum/hal/lib/p4:p4_info_manager",
         "//stratum/hal/lib/p4:p4_pipeline_config_cc_proto",
@@ -1830,7 +1825,9 @@ cc_library(
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_annotation_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
-        "//stratum/glue/gtl:map_util",
+        "@com_github_p4lang_p4c//:p4c_frontend_midend",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -1856,15 +1853,15 @@ cc_test(
         ":p4c_switch_utils",
         ":table_map_generator",
         ":target_info_mock",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/memory",
-        "@com_github_p4lang_p4c//:p4c_ir",
-        "@com_github_p4lang_p4c//:p4c_toolkit",
-        "@com_google_protobuf//:protobuf",
         "//stratum/hal/lib/p4:p4_info_manager_mock",
         "//stratum/lib:utils",
         "//stratum/p4c_backends/test:ir_test_helpers",
         "//stratum/public/proto:p4_table_defs_cc_proto",
+        "@com_github_p4lang_p4c//:p4c_ir",
+        "@com_github_p4lang_p4c//:p4c_toolkit",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -1908,21 +1905,21 @@ cc_binary(
 
 pkg_tar(
     name = "fpm_p4c_bin",
-    strip_prefix = "/stratum/p4c_backends/fpm",
-    package_dir = "/usr/bin",
     srcs = [":p4c-fpm"],
     mode = "0755",
+    package_dir = "/usr/bin",
+    strip_prefix = "/stratum/p4c_backends/fpm",
 )
 
 pkg_tar(
     name = "fpm_p4c_includes",
-    strip_prefix = "/external/com_github_p4lang_p4c",
-    package_dir = "/usr/share/p4c/",
     srcs = [
-        "@com_github_p4lang_p4c//:p4include/v1model.p4",
         "@com_github_p4lang_p4c//:p4include/core.p4",
+        "@com_github_p4lang_p4c//:p4include/v1model.p4",
     ],
     mode = "0644",
+    package_dir = "/usr/share/p4c/",
+    strip_prefix = "/external/com_github_p4lang_p4c",
 )
 
 stratum_license_tar(
@@ -1947,12 +1944,12 @@ pkg_tar(
 
 pkg_deb(
     name = "p4c_fpm_deb",
-    package = "p4-fpm",
-    version = "0.1",
-    description = "P4 compiler for FPM",
     architecture = "amd64",
     data = ":fpm_p4c_data",
+    description = "P4 compiler for FPM",
     maintainer = "https://stratumproject.org/",
+    package = "p4-fpm",
+    version = "0.0.1",
 )
 
 filegroup(


### PR DESCRIPTION
This PR formats all Bazel `.BUILD` files known to git with `buildifier` and adds them to the CI check. No more lists or exceptions.