### PR TITLE
Format and check all C++ `.h` header files

### DIFF
--- a/.circleci/check-cpp-format.sh
+++ b/.circleci/check-cpp-format.sh
@@ -10,6 +10,9 @@ CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/main -- '*.h' '*.cc'
 # All proto files.
 PROTO_FILES=$(git ls-files "*.proto")
 
+# All header files.
+HEADER_FILES=$(git ls-files "*.h")
+
 # List of files that are already formatted.
 read -r -d '\0' KNOWN_FILES << EOF
 stratum/glue/gtl/map_util_test.cc
@@ -262,7 +265,7 @@ stratum/tools/gnmi/gnmi_cli.cc
 \0
 EOF
 
-echo -e "$KNOWN_FILES\n$CHANGED_FILES\n$PROTO_FILES" | sort -u | xargs -t -n1 clang-format --style=file -i
+echo -e "$KNOWN_FILES\n$CHANGED_FILES\n$PROTO_FILES\n$HEADER_FILES" | sort -u | xargs -t -n1 clang-format --style=file -i
 
 # Report which files need to be fixed.
 git update-index --refresh

--- a/stratum/glue/status/canonical_errors.h
+++ b/stratum/glue/status/canonical_errors.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_GLUE_STATUS_CANONICAL_ERRORS_H_
 #define STRATUM_GLUE_STATUS_CANONICAL_ERRORS_H_
 

--- a/stratum/glue/status/posix_error_space.h
+++ b/stratum/glue/status/posix_error_space.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This package defines the POSIX error space (think 'errno'
 // values). Given a (stable) errno value, this class can be used to
 // translate that value to a string description by calling the
@@ -20,7 +19,6 @@
 // circuited by the implementation of Status to be equivalent to
 // Status::OK, ignoring this error space and the provided message.
 //
-
 
 #ifndef STRATUM_GLUE_STATUS_POSIX_ERROR_SPACE_H_
 #define STRATUM_GLUE_STATUS_POSIX_ERROR_SPACE_H_

--- a/stratum/hal/lib/bcm/acl_table.h
+++ b/stratum/hal/lib/bcm/acl_table.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_ACL_TABLE_H_
 #define STRATUM_HAL_LIB_BCM_ACL_TABLE_H_
 
@@ -28,8 +27,9 @@ class AclTable : public BcmFlowTable {
   //  Constructors
   //***************************************************************************
   AclTable(const ::p4::config::v1::Table& table, BcmAclStage stage,
-           int priority, const absl::flat_hash_map<P4HeaderType, bool,
-           EnumHash<P4HeaderType>>& const_conditions)
+           int priority,
+           const absl::flat_hash_map<P4HeaderType, bool,
+                                     EnumHash<P4HeaderType>>& const_conditions)
       : BcmFlowTable(table),
         stage_(stage),
         match_fields_(),
@@ -47,9 +47,9 @@ class AclTable : public BcmFlowTable {
   AclTable(const ::p4::config::v1::Table& table,
            P4Annotation::PipelineStage stage, int priority,
            const absl::flat_hash_map<P4HeaderType, bool,
-           EnumHash<P4HeaderType>>& const_conditions)
+                                     EnumHash<P4HeaderType>>& const_conditions)
       : AclTable(table, P4PipelineToBcmAclStage(stage), priority,
-        const_conditions) {}
+                 const_conditions) {}
 
   AclTable(const AclTable& other)
       : BcmFlowTable(other),
@@ -110,9 +110,9 @@ class AclTable : public BcmFlowTable {
   const absl::flat_hash_set<uint32>& UdfMatchFields() const {
     return udf_match_fields_;
   }
-  const absl::flat_hash_map<P4HeaderType, bool,
-    EnumHash<P4HeaderType>>& ConstConditions() const {
-      return const_conditions_;
+  const absl::flat_hash_map<P4HeaderType, bool, EnumHash<P4HeaderType>>&
+  ConstConditions() const {
+    return const_conditions_;
   }
 
   // Returns the BCM ACL ID for an entry in this table.
@@ -134,8 +134,8 @@ class AclTable : public BcmFlowTable {
 
   // Performs a dry-run of InsertEntry. Returns an error if the entry cannot be
   // inserted into the table. Returns util::OkStatus if it can.
-  util::Status DryRunInsertEntry(const ::p4::v1::TableEntry& entry)
-  const override;
+  util::Status DryRunInsertEntry(
+      const ::p4::v1::TableEntry& entry) const override;
 
   // Attempts to add the entry to this table with the provided Bcm ACL ID
   // mapping.
@@ -193,12 +193,12 @@ class AclTable : public BcmFlowTable {
   // match_fields_.
   absl::flat_hash_set<uint32> udf_match_fields_;
   // Mapping from entries to their respective Bcm ACL IDs.
-  absl::flat_hash_map<::p4::v1::TableEntry, uint32,
-  TableEntryHash, TableEntryEqual>
+  absl::flat_hash_map<::p4::v1::TableEntry, uint32, TableEntryHash,
+                      TableEntryEqual>
       bcm_acl_id_map_;
   // Stores const conditions
-  absl::flat_hash_map<P4HeaderType, bool,
-  EnumHash<P4HeaderType>> const_conditions_;
+  absl::flat_hash_map<P4HeaderType, bool, EnumHash<P4HeaderType>>
+      const_conditions_;
 };
 
 }  // namespace bcm

--- a/stratum/hal/lib/bcm/bcm_acl_manager.h
+++ b/stratum/hal/lib/bcm/bcm_acl_manager.h
@@ -2,13 +2,15 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_ACL_MANAGER_H_
 #define STRATUM_HAL_LIB_BCM_BCM_ACL_MANAGER_H_
 
 #include <memory>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/bcm/bcm_chassis_ro_interface.h"
@@ -18,9 +20,6 @@
 #include "stratum/hal/lib/p4/p4_control.pb.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_mapper.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 
 DECLARE_string(bcm_hardware_specs_file);
 

--- a/stratum/hal/lib/bcm/bcm_acl_manager_mock.h
+++ b/stratum/hal/lib/bcm/bcm_acl_manager_mock.h
@@ -2,12 +2,11 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_ACL_MANAGER_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_ACL_MANAGER_MOCK_H_
 
-#include "stratum/hal/lib/bcm/bcm_acl_manager.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/bcm/bcm_acl_manager.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_chassis_ro_interface.h
+++ b/stratum/hal/lib/bcm/bcm_chassis_ro_interface.h
@@ -6,16 +6,16 @@
 #define STRATUM_HAL_LIB_BCM_BCM_CHASSIS_RO_INTERFACE_H_
 
 #include <map>
-#include <string>
 #include <set>
+#include <string>
 
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/bcm/bcm.pb.h"
 #include "stratum/hal/lib/bcm/utils.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/utils.h"
-#include "stratum/glue/integral_types.h"
-#include "stratum/glue/status/status.h"
-#include "stratum/glue/status/statusor.h"
 
 namespace stratum {
 

--- a/stratum/hal/lib/bcm/bcm_diag_shell.h
+++ b/stratum/hal/lib/bcm/bcm_diag_shell.h
@@ -2,16 +2,15 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_DIAG_SHELL_H_
 #define STRATUM_HAL_LIB_BCM_BCM_DIAG_SHELL_H_
 
 #include <pthread.h>
 
-#include "stratum/glue/status/status.h"
-#include "stratum/glue/status/statusor.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/statusor.h"
 
 namespace stratum {
 namespace hal {
@@ -51,13 +50,19 @@ class BcmDiagShell {
   static constexpr unsigned char kTelnetEcho = 1;
   static constexpr unsigned char kTelnetSGA = 3;
   static constexpr unsigned char kTelnetWillSGA[] = {
-      kTelnetCmd, kTelnetWill, kTelnetSGA
+      kTelnetCmd,
+      kTelnetWill,
+      kTelnetSGA,
   };
   static constexpr unsigned char kTelnetWillEcho[] = {
-    kTelnetCmd, kTelnetWill, kTelnetEcho
+      kTelnetCmd,
+      kTelnetWill,
+      kTelnetEcho,
   };
   static constexpr unsigned char kTelnetDontEcho[] = {
-    kTelnetCmd, kTelnetDont, kTelnetEcho
+      kTelnetCmd,
+      kTelnetDont,
+      kTelnetEcho,
   };
   static constexpr int kNumberOfBytesRead = 82;
 

--- a/stratum/hal/lib/bcm/bcm_flow_table.h
+++ b/stratum/hal/lib/bcm/bcm_flow_table.h
@@ -2,25 +2,23 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_FLOW_TABLE_H_
 #define STRATUM_HAL_LIB_BCM_BCM_FLOW_TABLE_H_
 
-#include <utility>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <utility>
 
+#include "absl/container/node_hash_set.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
+#include "stratum/glue/status/statusor.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/container/node_hash_set.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "stratum/glue/status/status.h"
-#include "stratum/glue/status/statusor.h"
-
-#include "absl/strings/string_view.h"
-#include "absl/strings/str_cat.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_l2_manager.h
+++ b/stratum/hal/lib/bcm/bcm_l2_manager.h
@@ -7,8 +7,8 @@
 
 #include <map>
 #include <memory>
-#include <tuple>
 #include <string>
+#include <tuple>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/strings/str_cat.h"

--- a/stratum/hal/lib/bcm/bcm_l2_manager_mock.h
+++ b/stratum/hal/lib/bcm/bcm_l2_manager_mock.h
@@ -2,12 +2,11 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_L2_MANAGER_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_L2_MANAGER_MOCK_H_
 
-#include "stratum/hal/lib/bcm/bcm_l2_manager.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/bcm/bcm_l2_manager.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_l3_manager.h
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.h
@@ -2,18 +2,17 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_L3_MANAGER_H_
 #define STRATUM_HAL_LIB_BCM_BCM_L3_MANAGER_H_
 
 #include <memory>
-#include <utility>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "stratum/glue/integral_types.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/bcm/bcm.pb.h"
 #include "stratum/hal/lib/bcm/bcm_sdk_interface.h"

--- a/stratum/hal/lib/bcm/bcm_l3_manager_mock.h
+++ b/stratum/hal/lib/bcm/bcm_l3_manager_mock.h
@@ -2,12 +2,11 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_L3_MANAGER_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_L3_MANAGER_MOCK_H_
 
-#include "stratum/hal/lib/bcm/bcm_l3_manager.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/bcm/bcm_l3_manager.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_sdk_sim.h
+++ b/stratum/hal/lib/bcm/bcm_sdk_sim.h
@@ -2,18 +2,17 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_SDK_SIM_H_
 #define STRATUM_HAL_LIB_BCM_BCM_SDK_SIM_H_
 
 #include <map>
 #include <string>
 
-#include "stratum/glue/status/status.h"
-#include "stratum/hal/lib/bcm/bcm_sdk_wrapper.h"
-#include "stratum/glue/integral_types.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/bcm/bcm_sdk_wrapper.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_table_manager.h
+++ b/stratum/hal/lib/bcm/bcm_table_manager.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_TABLE_MANAGER_H_
 #define STRATUM_HAL_LIB_BCM_BCM_TABLE_MANAGER_H_
 
@@ -13,6 +12,11 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/bcm/acl_table.h"
@@ -24,11 +28,6 @@
 #include "stratum/hal/lib/p4/common_flow_entry.pb.h"
 #include "stratum/hal/lib/p4/p4_table_mapper.h"
 #include "stratum/lib/utils.h"
-#include "stratum/glue/integral_types.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_table_manager_mock.h
+++ b/stratum/hal/lib/bcm/bcm_table_manager_mock.h
@@ -2,16 +2,15 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_BCM_TABLE_MANAGER_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_TABLE_MANAGER_MOCK_H_
 
-#include <vector>
 #include <set>
+#include <vector>
 
-#include "stratum/hal/lib/bcm/bcm_table_manager.h"
-#include "gmock/gmock.h"
 #include "absl/container/flat_hash_map.h"
+#include "gmock/gmock.h"
+#include "stratum/hal/lib/bcm/bcm_table_manager.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/bcm/bcm_tunnel_manager.h
+++ b/stratum/hal/lib/bcm/bcm_tunnel_manager.h
@@ -10,12 +10,12 @@
 #include <memory>
 #include <utility>
 
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/bcm/bcm.pb.h"
 #include "stratum/hal/lib/bcm/bcm_sdk_interface.h"
 #include "stratum/hal/lib/bcm/bcm_table_manager.h"
-#include "stratum/glue/integral_types.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "stratum/glue/status/status.h"
 
 namespace stratum {
 

--- a/stratum/hal/lib/bcm/bcm_tunnel_manager_mock.h
+++ b/stratum/hal/lib/bcm/bcm_tunnel_manager_mock.h
@@ -5,8 +5,8 @@
 #ifndef STRATUM_HAL_LIB_BCM_BCM_TUNNEL_MANAGER_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_TUNNEL_MANAGER_MOCK_H_
 
-#include "stratum/hal/lib/bcm/bcm_tunnel_manager.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/bcm/bcm_tunnel_manager.h"
 
 namespace stratum {
 

--- a/stratum/hal/lib/bcm/bcm_udf_manager.h
+++ b/stratum/hal/lib/bcm/bcm_udf_manager.h
@@ -6,16 +6,16 @@
 #define STRATUM_HAL_LIB_BCM_BCM_UDF_MANAGER_H_
 
 #include <functional>
-#include <memory>
 #include <map>
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "stratum/hal/lib/bcm/acl_table.h"
 #include "stratum/hal/lib/bcm/bcm.pb.h"
 #include "stratum/hal/lib/bcm/bcm_sdk_interface.h"
 #include "stratum/hal/lib/p4/p4_table_mapper.h"
-#include "absl/container/flat_hash_set.h"
 
 namespace stratum {
 
@@ -314,11 +314,11 @@ class BcmUdfManager {
   // ***************************************************************************
   // Member Variables
   // ***************************************************************************
-  BcmSdkInterface* bcm_sdk_interface_;   // Interface to the Bcm SDK. Not owned
-                                         // by this class.
-  std::map<int, UdfSet> udf_sets_;       // UDF sets managed by this object.
-  int chunk_size_;                       // The size of each chunk in bits.
-  int chunks_per_set_;                   // Number of chunks available per set.
+  BcmSdkInterface* bcm_sdk_interface_;  // Interface to the Bcm SDK. Not owned
+                                        // by this class.
+  std::map<int, UdfSet> udf_sets_;      // UDF sets managed by this object.
+  int chunk_size_;                      // The size of each chunk in bits.
+  int chunks_per_set_;                  // Number of chunks available per set.
 
   // Fixed zero-based BCM unit number corresponding to the node/ASIC managed by
   // this class instance. Assigned in the class constructor.

--- a/stratum/hal/lib/bcm/constants.h
+++ b/stratum/hal/lib/bcm/constants.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_CONSTANTS_H_
 #define STRATUM_HAL_LIB_BCM_CONSTANTS_H_
 

--- a/stratum/hal/lib/bcm/pipeline_processor.h
+++ b/stratum/hal/lib/bcm/pipeline_processor.h
@@ -6,21 +6,21 @@
 #define STRATUM_HAL_LIB_BCM_PIPELINE_PROCESSOR_H_
 
 #include <memory>
-#include <vector>
-#include <utility>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_map.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/p4/common_flow_entry.pb.h"
 #include "stratum/hal/lib/p4/p4_control.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/node_hash_map.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "absl/container/flat_hash_set.h"
-#include "stratum/glue/status/status.h"
-#include "stratum/glue/status/statusor.h"
 
 namespace stratum {
 

--- a/stratum/hal/lib/bcm/sdk_build_undef.h
+++ b/stratum/hal/lib/bcm/sdk_build_undef.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This file is used to undefine preprocessor definitions specific to
 // Broadcom SDK that conflict with definitions in depot3/google3.
 // It should be included at the start and at the end of a list of

--- a/stratum/hal/lib/bcm/utils.h
+++ b/stratum/hal/lib/bcm/utils.h
@@ -2,15 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_BCM_UTILS_H_
 #define STRATUM_HAL_LIB_BCM_UTILS_H_
 
 #include <string>
 
-#include "stratum/hal/lib/bcm/bcm.pb.h"
-#include "stratum/glue/integral_types.h"
 #include "absl/strings/str_cat.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/hal/lib/bcm/bcm.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/error_buffer.h
+++ b/stratum/hal/lib/common/error_buffer.h
@@ -2,17 +2,16 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_ERROR_BUFFER_H_
 #define STRATUM_HAL_LIB_COMMON_ERROR_BUFFER_H_
 
 #include <string>
 #include <vector>
 
-#include "stratum/glue/status/status.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "stratum/glue/gtl/source_location.h"
+#include "stratum/glue/status/status.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/gnmi_publisher.h
+++ b/stratum/hal/lib/common/gnmi_publisher.h
@@ -2,20 +2,21 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_GNMI_PUBLISHER_H_
 #define STRATUM_HAL_LIB_COMMON_GNMI_PUBLISHER_H_
 
 #include <pthread.h>
 #include <time.h>
 
-#include <memory>
-#include <string>
 #include <algorithm>
 #include <map>
+#include <memory>
+#include <string>
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
 #include "gnmi/gnmi.grpc.pb.h"
-// FIXME(boc) is this required?
+#include "stratum/glue/gtl/map_util.h"
 #include "stratum/glue/logging.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
@@ -23,9 +24,6 @@
 #include "stratum/hal/lib/common/yang_parse_tree.h"
 #include "stratum/lib/timer_daemon.h"
 #include "stratum/public/lib/error.h"
-#include "absl/synchronization/mutex.h"
-#include "absl/container/flat_hash_map.h"
-#include "stratum/glue/gtl/map_util.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/gnmi_publisher_mock.h
+++ b/stratum/hal/lib/common/gnmi_publisher_mock.h
@@ -5,9 +5,9 @@
 #ifndef STRATUM_HAL_LIB_COMMON_GNMI_PUBLISHER_MOCK_H_
 #define STRATUM_HAL_LIB_COMMON_GNMI_PUBLISHER_MOCK_H_
 
+#include "gmock/gmock.h"
 #include "stratum/hal/lib/common/gnmi_publisher.h"
 #include "stratum/hal/lib/common/switch_mock.h"
-#include "gmock/gmock.h"
 
 namespace stratum {
 namespace hal {
@@ -16,29 +16,29 @@ namespace hal {
 class GnmiPublisherMock : public GnmiPublisher {
  public:
   MOCK_METHOD4(SubscribePeriodic,
-               ::util::Status(const Frequency &, const ::gnmi::Path &,
-                              GnmiSubscribeStream *, SubscriptionHandle *));
+               ::util::Status(const Frequency&, const ::gnmi::Path&,
+                              GnmiSubscribeStream*, SubscriptionHandle*));
 
   MOCK_METHOD3(SubscribePoll,
-               ::util::Status(const ::gnmi::Path &, GnmiSubscribeStream *,
-                              SubscriptionHandle *));
+               ::util::Status(const ::gnmi::Path&, GnmiSubscribeStream*,
+                              SubscriptionHandle*));
   MOCK_METHOD3(SubscribeOnChange,
-               ::util::Status(const ::gnmi::Path &, GnmiSubscribeStream *,
-                              SubscriptionHandle *));
+               ::util::Status(const ::gnmi::Path&, GnmiSubscribeStream*,
+                              SubscriptionHandle*));
 
   MOCK_METHOD1(UnSubscribe, ::util::Status(const SubscriptionHandle& h));
 
-  MOCK_METHOD1(HandlePoll, ::util::Status(const SubscriptionHandle &));
+  MOCK_METHOD1(HandlePoll, ::util::Status(const SubscriptionHandle&));
 
   MOCK_METHOD2(UpdateSubscriptionWithTargetSpecificModeSpecification,
-               ::util::Status(const ::gnmi::Path &path,
-                              ::gnmi::Subscription *subscription));
+               ::util::Status(const ::gnmi::Path& path,
+                              ::gnmi::Subscription* subscription));
 
-  explicit GnmiPublisherMock(SwitchInterface *switch_interface)
+  explicit GnmiPublisherMock(SwitchInterface* switch_interface)
       : GnmiPublisher(switch_interface), switch_interface_(switch_interface) {}
 
  private:
-  SwitchInterface *switch_interface_;
+  SwitchInterface* switch_interface_;
 };
 
 }  // namespace hal

--- a/stratum/hal/lib/common/phal_interface.h
+++ b/stratum/hal/lib/common/phal_interface.h
@@ -2,21 +2,20 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_PHAL_INTERFACE_H_
 #define STRATUM_HAL_LIB_COMMON_PHAL_INTERFACE_H_
 
 #include <functional>
+#include <memory>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <memory>
 
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
-#include "stratum/lib/channel/channel.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/phal/sfp_configurator.h"
+#include "stratum/lib/channel/channel.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/common/phal_mock.h
+++ b/stratum/hal/lib/common/phal_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_PHAL_MOCK_H_
 #define STRATUM_HAL_LIB_COMMON_PHAL_MOCK_H_
 
 #include <memory>
 
-#include "stratum/hal/lib/common/phal_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/common/phal_interface.h"
 
 namespace stratum {
 namespace hal {
@@ -36,9 +35,10 @@ class PhalMock : public PhalInterface {
                               const OpticalTransceiverInfo& ot_info));
   MOCK_METHOD5(SetPortLedState, ::util::Status(int slot, int port, int channel,
                                                LedColor color, LedState state));
-  MOCK_METHOD3(RegisterSfpConfigurator,
-    ::util::Status(int slot, int port,
-      ::stratum::hal::phal::SfpConfigurator* configurator));
+  MOCK_METHOD3(
+      RegisterSfpConfigurator,
+      ::util::Status(int slot, int port,
+                     ::stratum::hal::phal::SfpConfigurator* configurator));
 };
 
 }  // namespace hal

--- a/stratum/hal/lib/common/subscribe_reader_writer_mock.h
+++ b/stratum/hal/lib/common/subscribe_reader_writer_mock.h
@@ -5,8 +5,8 @@
 #ifndef STRATUM_HAL_LIB_COMMON_SUBSCRIBE_READER_WRITER_MOCK_H_
 #define STRATUM_HAL_LIB_COMMON_SUBSCRIBE_READER_WRITER_MOCK_H_
 
-#include "gnmi/gnmi.grpc.pb.h"
 #include "gmock/gmock.h"
+#include "gnmi/gnmi.grpc.pb.h"
 #include "gtest/gtest.h"
 
 // A mock class for ServerReaderWriter stream used for gNMI subscriptions. Used

--- a/stratum/hal/lib/common/writer_mock.h
+++ b/stratum/hal/lib/common/writer_mock.h
@@ -2,12 +2,11 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_COMMON_WRITER_MOCK_H_
 #define STRATUM_HAL_LIB_COMMON_WRITER_MOCK_H_
 
-#include "stratum/hal/lib/common/writer_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/common/writer_interface.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_action_mapper.h
+++ b/stratum/hal/lib/p4/p4_action_mapper.h
@@ -13,14 +13,14 @@
 #ifndef STRATUM_HAL_LIB_P4_P4_ACTION_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_ACTION_MAPPER_H_
 
-#include "stratum/hal/lib/p4/p4_info_manager.h"
-#include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
-#include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "absl/container/flat_hash_map.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
+#include "stratum/hal/lib/p4/p4_table_map.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -95,8 +95,7 @@ class P4ActionMapper {
   // P4PipelineConfig; hence they are not owned by this class.
   struct ActionMapEntry {
     explicit ActionMapEntry(const P4ActionDescriptor* action)
-        : original_action(action),
-          internal_action(nullptr) {}
+        : original_action(action), internal_action(nullptr) {}
 
     const P4ActionDescriptor* original_action;
     const P4ActionDescriptor* internal_action;
@@ -108,8 +107,8 @@ class P4ActionMapper {
   // complex case where internal_action is only used by the applied_tables
   // in internal_link.  Both methods update map_entry with data about when
   // internal_action replaces the original_action.
-  ::util::Status AddAction(
-      const P4ActionDescriptor& internal_action, ActionMapEntry* map_entry);
+  ::util::Status AddAction(const P4ActionDescriptor& internal_action,
+                           ActionMapEntry* map_entry);
   ::util::Status AddAppliedTableAction(
       const P4InfoManager& p4_info_manager,
       const P4ActionDescriptor::P4InternalActionLink& internal_link,

--- a/stratum/hal/lib/p4/p4_config_verifier.h
+++ b/stratum/hal/lib/p4/p4_config_verifier.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // P4ConfigVerifier verifies consistency among various P4 objects in the P4Info
 // and the P4PipelineConfig.  It helps P4TableMapper verify forwarding
 // pipeline config pushes.  It also has a role in some unit tests that verify
@@ -15,12 +14,12 @@
 #include <memory>
 #include <string>
 
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -113,9 +112,9 @@ class P4ConfigVerifier {
 
   // These two methods verify assignments within P4 action bodies.
   ::util::Status VerifyHeaderAssignment();
-  ::util::Status VerifyFieldAssignment(
-      const std::string& destination_field,
-      const P4AssignSourceValue& source_value, const std::string& action_name);
+  ::util::Status VerifyFieldAssignment(const std::string& destination_field,
+                                       const P4AssignSourceValue& source_value,
+                                       const std::string& action_name);
 
   // Verifies that the input P4FieldDescriptor contains a known field type.
   bool VerifyKnownFieldType(const P4FieldDescriptor& descriptor);

--- a/stratum/hal/lib/p4/p4_static_entry_mapper.h
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // P4StaticEntryMapper is a P4TableMapper helper class.  Similar to
 // P4TableMapper, one instance exists per configured P4 device ID.
 // P4StaticEntryMapper manages the static table entries, i.e. those defined
@@ -23,9 +22,9 @@
 #ifndef STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_H_
 
+#include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
-#include "p4/v1/p4runtime.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_static_entry_mapper_mock.h
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This is a mock implementation of P4StaticEntryMapper.
 
 #ifndef STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_MOCK_H_
 #define STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_MOCK_H_
 
-#include "stratum/hal/lib/p4/p4_static_entry_mapper.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/p4/p4_static_entry_mapper.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_table_mapper.h
+++ b/stratum/hal/lib/p4/p4_table_mapper.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_H_
 
@@ -11,10 +10,11 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/p4/common_flow_entry.pb.h"
@@ -24,7 +24,6 @@
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_table_mapper_mock.h
+++ b/stratum/hal/lib/p4/p4_table_mapper_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This is a mock implementation of P4TableMapper.
 
 #ifndef STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_MOCK_H_
 #define STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_MOCK_H_
 
-#include "stratum/hal/lib/p4/p4_table_mapper.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/p4/p4_table_mapper.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/datasource.h
+++ b/stratum/hal/lib/phal/datasource.h
@@ -2,20 +2,19 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_DATASOURCE_H_
 #define STRATUM_HAL_LIB_PHAL_DATASOURCE_H_
 
 #include <memory>
 #include <utility>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/phal/attribute_database_interface.h"
 #include "stratum/hal/lib/phal/managed_attribute.h"
 #include "stratum/hal/lib/phal/phal.pb.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
-#include "absl/time/time.h"
 
 namespace stratum {
 namespace hal {
@@ -101,7 +100,7 @@ class DataSource : public std::enable_shared_from_this<DataSource> {
   template <typename T>
   ::util::StatusOr<T> ReadAttribute(
       ::util::StatusOr<ManagedAttribute*> statusor_attr) const {
-    ASSIGN_OR_RETURN(ManagedAttribute* attr, std::move(statusor_attr));
+    ASSIGN_OR_RETURN(ManagedAttribute * attr, std::move(statusor_attr));
     return attr->ReadValue<T>();
   }
 

--- a/stratum/hal/lib/phal/datasource_mock.h
+++ b/stratum/hal/lib/phal/datasource_mock.h
@@ -2,15 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_DATASOURCE_MOCK_H_
 #define STRATUM_HAL_LIB_PHAL_DATASOURCE_MOCK_H_
 
 #include <memory>
 
+#include "gmock/gmock.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/phal/datasource.h"
-#include "gmock/gmock.h"
 
 namespace stratum {
 namespace hal {
@@ -20,7 +19,7 @@ class DataSourceMock : public DataSource {
  public:
   DataSourceMock() : DataSource(new NoCache()) {}
   MOCK_METHOD0(UpdateValuesAndLock, ::util::Status());
-  MOCK_METHOD0(LockAndFlushWrites, :: util::Status());
+  MOCK_METHOD0(LockAndFlushWrites, ::util::Status());
   // We use DataSource's implementation of GetSharedPointer, which just calls
   // through to shared_from_this() (from std). If a mocked function returns a
   // shared_ptr to its parent mock object, adding an EXPECT_CALL will create

--- a/stratum/hal/lib/phal/dummy_threadpool.h
+++ b/stratum/hal/lib/phal/dummy_threadpool.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_DUMMY_THREADPOOL_H_
 #define STRATUM_HAL_LIB_PHAL_DUMMY_THREADPOOL_H_
 
@@ -10,10 +9,10 @@
 #include <map>
 #include <vector>
 
-#include "stratum/glue/status/status.h"
-#include "stratum/hal/lib/phal/threadpool_interface.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/phal/threadpool_interface.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/filepath_stringsource.h
+++ b/stratum/hal/lib/phal/filepath_stringsource.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_FILEPATH_STRINGSOURCE_H_
 #define STRATUM_HAL_LIB_PHAL_FILEPATH_STRINGSOURCE_H_
 
@@ -50,9 +49,7 @@ class FilepathStringSource : public StringSourceInterface {
              << "Attempted to set an unsettable FilepathStringSource.";
     }
   }
-  bool CanSet() override {
-    return can_set_;
-  }
+  bool CanSet() override { return can_set_; }
 
  private:
   const SystemInterface* system_interface_;

--- a/stratum/hal/lib/phal/fixed_layout_datasource.h
+++ b/stratum/hal/lib/phal/fixed_layout_datasource.h
@@ -2,23 +2,22 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_FIXED_LAYOUT_DATASOURCE_H_
 #define STRATUM_HAL_LIB_PHAL_FIXED_LAYOUT_DATASOURCE_H_
 
 #include <ctime>
 #include <map>
 #include <memory>
-#include <vector>
-#include <utility>
 #include <set>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "absl/memory/memory.h"
 #include "stratum/hal/lib/phal/datasource.h"
 #include "stratum/hal/lib/phal/managed_attribute.h"
 #include "stratum/hal/lib/phal/stringsource_interface.h"
 #include "stratum/lib/macros.h"
-#include "absl/memory/memory.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/fixed_stringsource.h
+++ b/stratum/hal/lib/phal/fixed_stringsource.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_FIXED_STRINGSOURCE_H_
 #define STRATUM_HAL_LIB_PHAL_FIXED_STRINGSOURCE_H_
 
@@ -11,8 +10,8 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/statusor.h"
-#include "stratum/lib/macros.h"
 #include "stratum/hal/lib/phal/stringsource_interface.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/managed_attribute.h
+++ b/stratum/hal/lib/phal/managed_attribute.h
@@ -2,18 +2,17 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_MANAGED_ATTRIBUTE_H_
 #define STRATUM_HAL_LIB_PHAL_MANAGED_ATTRIBUTE_H_
 
 #include <functional>
 #include <memory>
 
+#include "google/protobuf/descriptor.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/hal/lib/phal/attribute_database_interface.h"
 #include "stratum/lib/macros.h"
-#include "google/protobuf/descriptor.h"
 
 namespace stratum {
 namespace hal {
@@ -37,7 +36,8 @@ class ManagedAttribute {
  public:
   virtual ~ManagedAttribute() {}
   virtual Attribute GetValue() const = 0;
-  template <typename T> ::util::StatusOr<T> ReadValue() const {
+  template <typename T>
+  ::util::StatusOr<T> ReadValue() const {
     Attribute value = GetValue();
     auto typed_value = absl::get_if<T>(&value);
     CHECK_RETURN_IF_FALSE(typed_value)
@@ -93,11 +93,12 @@ class EnumAttribute
   // Does not transfer ownership of datasource.
   explicit EnumAttribute(const ::google::protobuf::EnumDescriptor* descriptor,
                          DataSource* datasource)
-  : TypedAttribute<const ::google::protobuf::EnumValueDescriptor*>(datasource) {
+      : TypedAttribute<const ::google::protobuf::EnumValueDescriptor*>(
+            datasource) {
     value_ = descriptor->FindValueByNumber(0);  // Default enum value.
   }
   ::util::Status AssignValue(
-    const google::protobuf::EnumValueDescriptor* value) {
+      const google::protobuf::EnumValueDescriptor* value) {
     if (value->type() != value_->type()) {
       return MAKE_ERROR() << "Attempted to assign incorrect enum type "
                           << value->type()->name()

--- a/stratum/hal/lib/phal/managed_attribute_mock.h
+++ b/stratum/hal/lib/phal/managed_attribute_mock.h
@@ -2,16 +2,15 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_MANAGED_ATTRIBUTE_MOCK_H_
 #define STRATUM_HAL_LIB_PHAL_MANAGED_ATTRIBUTE_MOCK_H_
 
 #include <memory>
 
+#include "gmock/gmock.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/phal/attribute_database_interface.h"
 #include "stratum/hal/lib/phal/datasource.h"
-#include "gmock/gmock.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/optics_adapter.h
+++ b/stratum/hal/lib/phal/optics_adapter.h
@@ -37,9 +37,9 @@ class OpticsAdapter final : public Adapter {
   // Sets the data from ot_info into an optical transceiver module in the Phal
   // database.
   // See: PhalInterface::SetOpticalTransceiverInfo.
-  ::util::Status
-  SetOpticalTransceiverInfo(int32 module, int network_interface,
-                            const OpticalTransceiverInfo& ot_info);
+  ::util::Status SetOpticalTransceiverInfo(
+      int32 module, int network_interface,
+      const OpticalTransceiverInfo& ot_info);
 
  private:
   // Attribute Db path to get the hardware state of all sfp transceivers.

--- a/stratum/hal/lib/phal/phal_sim.h
+++ b/stratum/hal/lib/phal/phal_sim.h
@@ -2,20 +2,19 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_PHAL_SIM_H_
 #define STRATUM_HAL_LIB_PHAL_PHAL_SIM_H_
 
 #include <functional>
-#include <set>
 #include <map>
 #include <memory>
+#include <set>
 #include <utility>
 
+#include "absl/synchronization/mutex.h"
 #include "stratum/hal/lib/common/phal_interface.h"
 #include "stratum/hal/lib/phal/phal.pb.h"
 #include "stratum/hal/lib/phal/sfp_configurator.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {
@@ -41,11 +40,12 @@ class PhalSim : public PhalInterface {
       int slot, int port, FrontPanelPortInfo* fp_port_info) override
       LOCKS_EXCLUDED(config_lock_);
   ::util::Status GetOpticalTransceiverInfo(
-      int module, int network_interface, OpticalTransceiverInfo* ot_info)
-      override LOCKS_EXCLUDED(config_lock_);
+      int module, int network_interface,
+      OpticalTransceiverInfo* ot_info) override LOCKS_EXCLUDED(config_lock_);
   ::util::Status SetOpticalTransceiverInfo(
-      int module, int network_interface, const OpticalTransceiverInfo& ot_info)
-      override LOCKS_EXCLUDED(config_lock_);
+      int module, int network_interface,
+      const OpticalTransceiverInfo& ot_info) override
+      LOCKS_EXCLUDED(config_lock_);
   ::util::Status SetPortLedState(int slot, int port, int channel,
                                  LedColor color, LedState state) override
       LOCKS_EXCLUDED(config_lock_);
@@ -85,8 +85,8 @@ class PhalSim : public PhalInterface {
 
   // Map from std::pair<int, int> representing (slot, port) of singleton port
   // to the vector of sfp datasource id
-  std::map<std::pair<int, int>,
-    ::stratum::hal::phal::SfpConfigurator*> slot_port_to_configurator_;
+  std::map<std::pair<int, int>, ::stratum::hal::phal::SfpConfigurator*>
+      slot_port_to_configurator_;
 
   // Determines if PHAL is fully initialized.
   bool initialized_ GUARDED_BY(config_lock_);

--- a/stratum/hal/lib/phal/reader_writer_datasource.h
+++ b/stratum/hal/lib/phal/reader_writer_datasource.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_READER_WRITER_DATASOURCE_H_
 #define STRATUM_HAL_LIB_PHAL_READER_WRITER_DATASOURCE_H_
 
@@ -12,12 +11,12 @@
 #include <string>
 #include <utility>
 
-#include "stratum/hal/lib/phal/datasource.h"
-#include "stratum/hal/lib/phal/stringsource_interface.h"
-#include "stratum/lib/macros.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/phal/datasource.h"
+#include "stratum/hal/lib/phal/stringsource_interface.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/regex_datasource.h
+++ b/stratum/hal/lib/phal/regex_datasource.h
@@ -2,24 +2,22 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_REGEX_DATASOURCE_H_
 #define STRATUM_HAL_LIB_PHAL_REGEX_DATASOURCE_H_
 
 #include <map>
 #include <memory>
-#include <utility>
 #include <string>
+#include <utility>
 #include <vector>
 
-// FIXME(boc) google only #include "base/basictypes.h"
+#include "absl/memory/memory.h"
+#include "re2/re2.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/phal/datasource.h"
 #include "stratum/hal/lib/phal/managed_attribute.h"
 #include "stratum/hal/lib/phal/stringsource_interface.h"
 #include "stratum/lib/macros.h"
-#include "absl/memory/memory.h"
-#include "re2/re2.h"
 
 namespace stratum {
 namespace hal {
@@ -100,9 +98,7 @@ class RegexDataSource : public DataSource {
         : attribute_(parent), arg_(&arg_val_) {}
     ManagedAttribute* GetAttribute() override { return &attribute_; }
     RE2::Arg* GetArg() override { return &arg_; }
-    void Update() override {
-      attribute_.AssignValue(arg_val_);
-    }
+    void Update() override { attribute_.AssignValue(arg_val_); }
 
    protected:
     TypedAttribute<T> attribute_;
@@ -117,7 +113,7 @@ class RegexDataSource : public DataSource {
   // A dummy argument that we pass to RE2 for capture groups the user hasn't
   // requested. This can normally be done by passing nullptr directly, but this
   // doesn't work for RE2::FullMatchN.
-  RE2::Arg dummy_arg_ {static_cast<void*>(nullptr)};
+  RE2::Arg dummy_arg_{static_cast<void*>(nullptr)};
 };
 
 }  // namespace phal

--- a/stratum/hal/lib/phal/sfp_configurator.h
+++ b/stratum/hal/lib/phal/sfp_configurator.h
@@ -1,7 +1,6 @@
 // Copyright 2019 Dell EMC
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_SFP_CONFIGURATOR_H_
 #define STRATUM_HAL_LIB_PHAL_SFP_CONFIGURATOR_H_
 
@@ -15,11 +14,11 @@ namespace phal {
 
 class SfpConfigurator : public AttributeGroup::RuntimeConfiguratorInterface {
  public:
-    virtual ~SfpConfigurator() {}
-    virtual ::util::Status HandleEvent(HwState state) = 0;
+  virtual ~SfpConfigurator() {}
+  virtual ::util::Status HandleEvent(HwState state) = 0;
 
  protected:
-    SfpConfigurator() {}
+  SfpConfigurator() {}
 };
 
 }  // namespace phal

--- a/stratum/hal/lib/phal/stringsource_interface.h
+++ b/stratum/hal/lib/phal/stringsource_interface.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_STRINGSOURCE_INTERFACE_H_
 #define STRATUM_HAL_LIB_PHAL_STRINGSOURCE_INTERFACE_H_
 

--- a/stratum/hal/lib/phal/switch_configurator_interface.h
+++ b/stratum/hal/lib/phal/switch_configurator_interface.h
@@ -1,13 +1,12 @@
 // Copyright 2019 Dell EMC
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_SWITCH_CONFIGURATOR_INTERFACE_H_
 #define STRATUM_HAL_LIB_PHAL_SWITCH_CONFIGURATOR_INTERFACE_H_
 
-#include "stratum/hal/lib/phal/phal.pb.h"
-#include "stratum/hal/lib/phal/attribute_group.h"
 #include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/phal/attribute_group.h"
+#include "stratum/hal/lib/phal/phal.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/system_fake.h
+++ b/stratum/hal/lib/phal/system_fake.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_SYSTEM_FAKE_H_
 #define STRATUM_HAL_LIB_PHAL_SYSTEM_FAKE_H_
 
@@ -13,10 +12,10 @@
 #include <utility>
 #include <vector>
 
+#include "absl/synchronization/mutex.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/phal/system_interface.h"
-#include "absl/synchronization/mutex.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/system_interface.h
+++ b/stratum/hal/lib/phal/system_interface.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_SYSTEM_INTERFACE_H_
 #define STRATUM_HAL_LIB_PHAL_SYSTEM_INTERFACE_H_
 

--- a/stratum/hal/lib/phal/system_interface_mock.h
+++ b/stratum/hal/lib/phal/system_interface_mock.h
@@ -2,15 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_SYSTEM_INTERFACE_MOCK_H_
 #define STRATUM_HAL_LIB_PHAL_SYSTEM_INTERFACE_MOCK_H_
 
 #include <memory>
 #include <string>
 
-#include "stratum/hal/lib/phal/system_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/phal/system_interface.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/system_real.h
+++ b/stratum/hal/lib/phal/system_real.h
@@ -2,18 +2,17 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_SYSTEM_REAL_H_
 #define STRATUM_HAL_LIB_PHAL_SYSTEM_REAL_H_
 
 #include <libudev.h>
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
-#include <memory>
 
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"

--- a/stratum/hal/lib/phal/threadpool_interface.h
+++ b/stratum/hal/lib/phal/threadpool_interface.h
@@ -2,15 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_THREADPOOL_INTERFACE_H_
 #define STRATUM_HAL_LIB_PHAL_THREADPOOL_INTERFACE_H_
 
 #include <functional>
 #include <vector>
 
-#include "stratum/glue/status/status.h"
 #include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/phal/threadpool_interface_mock.h
+++ b/stratum/hal/lib/phal/threadpool_interface_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_PHAL_THREADPOOL_INTERFACE_MOCK_H_
 #define STRATUM_HAL_LIB_PHAL_THREADPOOL_INTERFACE_MOCK_H_
 
 #include <vector>
 
-#include "stratum/hal/lib/phal/threadpool_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/phal/threadpool_interface.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/lib/channel/channel_internal.h
+++ b/stratum/lib/channel/channel_internal.h
@@ -7,8 +7,8 @@
 
 #include <memory>
 
-#include "stratum/lib/macros.h"
 #include "absl/synchronization/mutex.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace channel_internal {

--- a/stratum/lib/channel/channel_mock.h
+++ b/stratum/lib/channel/channel_mock.h
@@ -2,15 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_LIB_CHANNEL_CHANNEL_MOCK_H_
 #define STRATUM_LIB_CHANNEL_CHANNEL_MOCK_H_
 
 #include <memory>
 #include <vector>
 
-#include "stratum/lib/channel/channel.h"
 #include "gmock/gmock.h"
+#include "stratum/lib/channel/channel.h"
 
 namespace stratum {
 

--- a/stratum/lib/macros.h
+++ b/stratum/lib/macros.h
@@ -2,17 +2,14 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_LIB_MACROS_H_
 #define STRATUM_LIB_MACROS_H_
 
 #include <string>
 
-/* START GOOGLE ONLY
-#include "stratum/glue/status/status_builder.h"
-   END GOOGLE ONLY */
-#include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/logging.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/status_macros.h"
 #include "stratum/public/lib/error.h"
 
 namespace stratum {
@@ -32,6 +29,7 @@ class BooleanStatus {
   // Implicitly cast to bool.
   operator bool() const { return status_.ok(); }
   inline ::util::Status status() const { return status_; }
+
  private:
   ::util::Status status_;
 };

--- a/stratum/lib/statemachine/example_state_machine.h
+++ b/stratum/lib/statemachine/example_state_machine.h
@@ -7,10 +7,10 @@
 
 #include <memory>
 
-#include "stratum/lib/statemachine/state_machine.h"
-#include "gmock/gmock.h"
 #include "absl/container/flat_hash_map.h"
+#include "gmock/gmock.h"
 #include "stratum/glue/status/status.h"
+#include "stratum/lib/statemachine/state_machine.h"
 
 namespace stratum {
 

--- a/stratum/lib/statemachine/state_machine.h
+++ b/stratum/lib/statemachine/state_machine.h
@@ -36,29 +36,29 @@ class StateMachine {
   // based on the recommended course of action. However, the recovery_event is
   // not automatically executed; it is merely a suggestion that may be used to
   // recover the state machine.
-  using CallbackType = std::function< ::util::Status(
-    Event event, State next_state, Event* recovery_event) >;
+  using CallbackType = std::function<::util::Status(
+      Event event, State next_state, Event* recovery_event)>;
   // A TransitionTable stores the valid transitions, indexed by the outgoing
   // state and the incoming event; table_[current_state_][incoming_event] yields
   // the next state, if it exists.
   using TransitionTable =
-    absl::flat_hash_map<State, absl::flat_hash_map<Event, State>>;
+      absl::flat_hash_map<State, absl::flat_hash_map<Event, State>>;
 
   // It is the client's responsibility to ensure that the initial state is safe
   // to enter before calling this constructor.
   explicit StateMachine(State initial_state, TransitionTable table)
-    : current_state_(initial_state), table_(table) {}
+      : current_state_(initial_state), table_(table) {}
 
   // Entry actions are executed in the order they are added.
   void AddEntryAction(State state, CallbackType callback)
-    LOCKS_EXCLUDED(state_machine_mutex_) {
+      LOCKS_EXCLUDED(state_machine_mutex_) {
     absl::MutexLock lock(&state_machine_mutex_);
     entry_actions_[state].push_back(callback);
   }
 
   // Exit actions are executed in the order they are added.
   void AddExitAction(State state, CallbackType callback)
-    LOCKS_EXCLUDED(state_machine_mutex_) {
+      LOCKS_EXCLUDED(state_machine_mutex_) {
     absl::MutexLock lock(&state_machine_mutex_);
     exit_actions_[state].push_back(callback);
   }
@@ -67,7 +67,8 @@ class StateMachine {
   // performs any entry and exit actions. The reason parameter describes why the
   // event was added to the StateMachine.
   ::util::Status ProcessEvent(Event event, absl::string_view reason,
-    Event* recovery_event) LOCKS_EXCLUDED(state_machine_mutex_) {
+                              Event* recovery_event)
+      LOCKS_EXCLUDED(state_machine_mutex_) {
     absl::MutexLock lock(&state_machine_mutex_);
     return ProcessEventUnlocked(event, reason, recovery_event);
   }
@@ -77,27 +78,28 @@ class StateMachine {
  private:
   // Performs the actions of ProcessEvent.
   ::util::Status ProcessEventUnlocked(Event event, absl::string_view reason,
-    Event* recovery_event) EXCLUSIVE_LOCKS_REQUIRED(state_machine_mutex_) {
+                                      Event* recovery_event)
+      EXCLUSIVE_LOCKS_REQUIRED(state_machine_mutex_) {
     // Do not change states if the transition is invalid.
     ASSIGN_OR_RETURN(State next_state, NextState(current_state_, event));
     // FIXME: Wait for ASSIGN_OR_RETURN impl with error message
-      // _.LogWarning() << "Event " << event << " [" << reason <<
-      //"] was discarded in State " << current_state_);
+    // _.LogWarning() << "Event " << event << " [" << reason <<
+    //"] was discarded in State " << current_state_);
 
     // Perform exit actions for the current state.
     for (const auto& exit_action : exit_actions_[current_state_]) {
-      RETURN_IF_ERROR_WITH_APPEND(exit_action(event, next_state,
-        recovery_event)) <<
-        "Failed to perform exit action of state " << current_state_ <<
-        " in transition to " << next_state << ".";
+      RETURN_IF_ERROR_WITH_APPEND(
+          exit_action(event, next_state, recovery_event))
+          << "Failed to perform exit action of state " << current_state_
+          << " in transition to " << next_state << ".";
     }
 
     // Perform entry actions for the next state.
     for (const auto& entry_action : entry_actions_[next_state]) {
-      RETURN_IF_ERROR_WITH_APPEND(entry_action(event, next_state,
-        recovery_event)) <<
-        "Failed to perform entry action of state " << next_state <<
-        " in transition from " << current_state_ << ".";
+      RETURN_IF_ERROR_WITH_APPEND(
+          entry_action(event, next_state, recovery_event))
+          << "Failed to perform entry action of state " << next_state
+          << " in transition from " << current_state_ << ".";
     }
 
     // Update only if the entry and exit actions were successful.
@@ -131,10 +133,10 @@ class StateMachine {
   absl::Mutex state_machine_mutex_;
   // A vector of actions that are executed upon entry to any given state.
   absl::flat_hash_map<State, std::vector<CallbackType>> entry_actions_
-    GUARDED_BY(state_machine_mutex_);
+      GUARDED_BY(state_machine_mutex_);
   // A vector of actions that are executed upon exit from any given state.
   absl::flat_hash_map<State, std::vector<CallbackType>> exit_actions_
-    GUARDED_BY(state_machine_mutex_);
+      GUARDED_BY(state_machine_mutex_);
 };
 
 }  // namespace state_machine

--- a/stratum/lib/test_utils/matchers.h
+++ b/stratum/lib/test_utils/matchers.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <type_traits>
 
-#include "google/protobuf/util/message_differencer.h"
-#include "gmock/gmock.h"
 // FIXME(boc) already included
 #include "gmock/gmock-matchers.h"  // NOLINT
+#include "gmock/gmock.h"
+#include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 
 namespace stratum {

--- a/stratum/lib/test_utils/p4_proto_builders.h
+++ b/stratum/lib/test_utils/p4_proto_builders.h
@@ -7,15 +7,15 @@
 #ifndef STRATUM_LIB_TEST_UTILS_P4_PROTO_BUILDERS_H_
 #define STRATUM_LIB_TEST_UTILS_P4_PROTO_BUILDERS_H_
 
-#include <utility>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/hal/lib/p4/p4_control.pb.h"
 #include "stratum/public/proto/p4_annotation.pb.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "absl/strings/str_cat.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace test_utils {

--- a/stratum/lib/timer_daemon.h
+++ b/stratum/lib/timer_daemon.h
@@ -2,24 +2,24 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_LIB_TIMER_DAEMON_H_
 #define STRATUM_LIB_TIMER_DAEMON_H_
 
 #include <pthread.h>
+
 #include <algorithm>
 #include <functional>
-#include <vector>
 #include <memory>
+#include <vector>
 
+#include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/lib/macros.h"
 #include "stratum/public/lib/error.h"
-#include "absl/synchronization/mutex.h"
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/p4c_backends/common/backend_extension_mock.h
+++ b/stratum/p4c_backends/common/backend_extension_mock.h
@@ -6,8 +6,8 @@
 #ifndef STRATUM_P4C_BACKENDS_COMMON_BACKEND_EXTENSION_MOCK_H_
 #define STRATUM_P4C_BACKENDS_COMMON_BACKEND_EXTENSION_MOCK_H_
 
-#include "stratum/p4c_backends/common/backend_extension_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/p4c_backends/common/backend_extension_interface.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/common/midend_p4c_open.h
+++ b/stratum/p4c_backends/common/midend_p4c_open.h
@@ -10,9 +10,9 @@
 
 #include <memory>
 
-#include "stratum/p4c_backends/common/midend_interface.h"
 #include "external/com_github_p4lang_p4c/backends/p4test/midend.h"
 #include "external/com_github_p4lang_p4c/frontends/common/options.h"
+#include "stratum/p4c_backends/common/midend_interface.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/common/p4c_front_mid_mock.h
+++ b/stratum/p4c_backends/common/p4c_front_mid_mock.h
@@ -6,8 +6,8 @@
 #ifndef STRATUM_P4C_BACKENDS_COMMON_P4C_FRONT_MID_MOCK_H_
 #define STRATUM_P4C_BACKENDS_COMMON_P4C_FRONT_MID_MOCK_H_
 
-#include "stratum/p4c_backends/common/p4c_front_mid_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/p4c_backends/common/p4c_front_mid_interface.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/common/p4c_front_mid_real.h
+++ b/stratum/p4c_backends/common/p4c_front_mid_real.h
@@ -10,11 +10,11 @@
 #include <functional>
 #include <memory>
 
-#include "stratum/p4c_backends/common/midend_interface.h"
-#include "stratum/p4c_backends/common/p4c_front_mid_interface.h"
 #include "external/com_github_p4lang_p4c/frontends/common/options.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/frontend.h"
 #include "external/com_github_p4lang_p4c/lib/compile_context.h"
+#include "stratum/p4c_backends/common/midend_interface.h"
+#include "stratum/p4c_backends/common/p4c_front_mid_interface.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -33,7 +33,8 @@ class P4cFrontMidReal : public P4cFrontMidInterface {
   // callback runs during RunMidEndPass to create a custom midend.  This class
   // takes ownership of the callback's returned MidEndInterface pointer.
   typedef std::function<std::unique_ptr<MidEndInterface>(
-      CompilerOptions* p4c_options)> MidEndCreateCallback;
+      CompilerOptions* p4c_options)>
+      MidEndCreateCallback;
 
   P4cFrontMidReal();
   explicit P4cFrontMidReal(MidEndCreateCallback callback);

--- a/stratum/p4c_backends/common/program_inspector.h
+++ b/stratum/p4c_backends/common/program_inspector.h
@@ -71,12 +71,8 @@ class ProgramInspector : public Inspector {
   const std::vector<const IR::PathExpression*>& struct_paths() const {
     return struct_paths_;
   }
-  const std::vector<const IR::P4Table*>& tables() const {
-    return tables_;
-  }
-  const std::vector<const IR::P4Parser*>& parsers() const {
-    return parsers_;
-  }
+  const std::vector<const IR::P4Table*>& tables() const { return tables_; }
+  const std::vector<const IR::P4Parser*>& parsers() const { return parsers_; }
   const std::vector<const IR::P4Control*>& controls() const {
     return controls_;
   }

--- a/stratum/p4c_backends/fpm/action_decoder.h
+++ b/stratum/p4c_backends/fpm/action_decoder.h
@@ -10,10 +10,10 @@
 #include <set>
 #include <string>
 
-#include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/p4c_backends/fpm/table_map_generator.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -28,8 +28,8 @@ class ActionDecoder {
   // ownership of all pointers.  ActionDecoder expects the shared instance of
   // P4ModelNames to identify model-dependent prefixes, externs, and other
   // resources.
-  ActionDecoder(TableMapGenerator* table_mapper,
-                P4::ReferenceMap* ref_map, P4::TypeMap* type_map);
+  ActionDecoder(TableMapGenerator* table_mapper, P4::ReferenceMap* ref_map,
+                P4::TypeMap* type_map);
 
   // Converts the statements within one P4 action into a P4PipelineConfig table
   // map action descriptor.  The body parameter is the IR representation of the

--- a/stratum/p4c_backends/fpm/annotation_mapper.h
+++ b/stratum/p4c_backends/fpm/annotation_mapper.h
@@ -12,12 +12,13 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+
+#include "absl/container/node_hash_map.h"
 #include "stratum/glue/logging.h"
 #include "stratum/hal/lib/p4/p4_info_manager.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/p4c_backends/fpm/annotation_map.pb.h"
 #include "stratum/public/proto/p4_annotation.pb.h"
-#include "absl/container/node_hash_map.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -79,14 +80,15 @@ class AnnotationMapper {
  private:
   // This private class maintains mappings from field/table/action addenda
   // name to the corresponding addenda data in the P4AnnotationMap.
-  template <class T> class AddendaLookupMap {
+  template <class T>
+  class AddendaLookupMap {
    public:
     AddendaLookupMap() {}
     virtual ~AddendaLookupMap() {}
 
     // Populates the addenda_lookup_ map for this instance.
     bool BuildMap(
-      const ::google::protobuf::RepeatedPtrField<T>& addenda_fields) {
+        const ::google::protobuf::RepeatedPtrField<T>& addenda_fields) {
       bool map_ok = true;
       for (const auto& addendum : addenda_fields) {
         if (!addendum.name().empty()) {
@@ -143,8 +145,8 @@ class AnnotationMapper {
   // adjusting the action_descriptor as specified by any annotation mappings
   // found.
   bool HandleActionAnnotations(const std::string& action_name,
-                              const hal::P4InfoManager& p4_info_manager,
-                              hal::P4ActionDescriptor* action_descriptor);
+                               const hal::P4InfoManager& p4_info_manager,
+                               hal::P4ActionDescriptor* action_descriptor);
   bool MapActionAnnotation(const std::string& annotation,
                            hal::P4ActionDescriptor* action_descriptor);
 

--- a/stratum/p4c_backends/fpm/control_inspector.h
+++ b/stratum/p4c_backends/fpm/control_inspector.h
@@ -11,16 +11,16 @@
 
 #include <map>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
+#include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
+#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
+#include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "stratum/hal/lib/p4/p4_control.pb.h"
 #include "stratum/hal/lib/p4/p4_info_manager.h"
 #include "stratum/p4c_backends/fpm/switch_case_decoder.h"
 #include "stratum/p4c_backends/fpm/table_map_generator.h"
-#include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -37,11 +37,10 @@ class ControlInspector : public Inspector {
   // IR::SwitchStatements.  The caller retains ownership of all pointers.
   // ControlInspector expects the shared P4ModelNames instance to identify
   // control and extern functions from the P4 architecture model.
-  ControlInspector(
-      const hal::P4InfoManager* p4_info_manager,
-      P4::ReferenceMap* ref_map, P4::TypeMap* type_map,
-      SwitchCaseDecoder* switch_case_decoder,
-      TableMapGenerator* table_map_generator);
+  ControlInspector(const hal::P4InfoManager* p4_info_manager,
+                   P4::ReferenceMap* ref_map, P4::TypeMap* type_map,
+                   SwitchCaseDecoder* switch_case_decoder,
+                   TableMapGenerator* table_map_generator);
   ~ControlInspector() override {}
 
   // The Inspect method visits the IR node hierarchy underneath the input

--- a/stratum/p4c_backends/fpm/expression_inspector.h
+++ b/stratum/p4c_backends/fpm/expression_inspector.h
@@ -10,12 +10,12 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_EXPRESSION_INSPECTOR_H_
 #define STRATUM_P4C_BACKENDS_FPM_EXPRESSION_INSPECTOR_H_
 
-#include "stratum/hal/lib/p4/p4_table_map.pb.h"
-#include "stratum/public/proto/p4_table_defs.pb.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/hal/lib/p4/p4_table_map.pb.h"
+#include "stratum/public/proto/p4_table_defs.pb.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/field_cross_reference.h
+++ b/stratum/p4c_backends/fpm/field_cross_reference.h
@@ -23,9 +23,9 @@
 #include <set>
 #include <vector>
 
+#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/field_decoder.h
+++ b/stratum/p4c_backends/fpm/field_decoder.h
@@ -11,13 +11,13 @@
 
 #include <map>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
+#include "external/com_github_p4lang_p4c/ir/ir.h"
 #include "stratum/p4c_backends/fpm/header_path_inspector.h"
 #include "stratum/p4c_backends/fpm/parser_map.pb.h"
 #include "stratum/p4c_backends/fpm/table_map_generator.h"
-#include "external/com_github_p4lang_p4c/ir/ir.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -104,17 +104,17 @@ class FieldDecoder {
   // bit_offset and bit_width describe the field's position with its
   // surrounding header.
   void UpdateFieldMapData(const std::string& fq_field_name,
-                             const std::string& header_type_name,
-                             const std::string& field_name,
-                             const AnnotatedFieldTypeMap& annotated_types,
-                             uint32_t bit_offset, uint32_t bit_width);
+                          const std::string& header_type_name,
+                          const std::string& field_name,
+                          const AnnotatedFieldTypeMap& annotated_types,
+                          uint32_t bit_offset, uint32_t bit_width);
 
   // Determines whether the input field has an annotated field type.  If the
   // annotation exists, StoreFieldTypeAnnotation parses the field type and
   // stores it in annotated_types for future use.
-  static void StoreFieldTypeAnnotation(
-      const IR::StructField& field, const std::string& header_type_name,
-      AnnotatedFieldTypeMap* annotated_types);
+  static void StoreFieldTypeAnnotation(const IR::StructField& field,
+                                       const std::string& header_type_name,
+                                       AnnotatedFieldTypeMap* annotated_types);
 
   // Accumulates decoded IR field objects in the output table map, injected
   // by the caller of the constructor, not owned by this class.

--- a/stratum/p4c_backends/fpm/header_path_inspector.h
+++ b/stratum/p4c_backends/fpm/header_path_inspector.h
@@ -15,6 +15,7 @@
 #include <deque>
 #include <map>
 #include <string>
+
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 
 namespace stratum {

--- a/stratum/p4c_backends/fpm/header_valid_inspector.h
+++ b/stratum/p4c_backends/fpm/header_valid_inspector.h
@@ -37,11 +37,11 @@
 #include <set>
 #include <string>
 
-#include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/p4c_backends/fpm/table_map_generator.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/hidden_table_mapper.h
+++ b/stratum/p4c_backends/fpm/hidden_table_mapper.h
@@ -172,7 +172,7 @@ class HiddenTableMapper {
     const std::string field_name_;
 
     // This member is injected by the constructor.
-    ActionRedirectMap *action_redirects_;
+    ActionRedirectMap* action_redirects_;
 
     // This P4FieldDescriptor stores table map updates relative to a local
     // metadata field's role as an indirect table lookup key.  If this

--- a/stratum/p4c_backends/fpm/hit_assign_mapper.h
+++ b/stratum/p4c_backends/fpm/hit_assign_mapper.h
@@ -47,9 +47,9 @@ class HitAssignMapper : public Transform {
   // RunPreTestTransform typically runs during test setup
   // from IRTestHelperJson::TransformP4Control to prepare an IR for
   // testing other classes that depend on HitAssignMapper transforms.
-  static const IR::P4Control* RunPreTestTransform(
-      const IR::P4Control& control,
-      P4::ReferenceMap* ref_map, P4::TypeMap* type_map);
+  static const IR::P4Control* RunPreTestTransform(const IR::P4Control& control,
+                                                  P4::ReferenceMap* ref_map,
+                                                  P4::TypeMap* type_map);
 
   // HitAssignMapper is neither copyable nor movable.
   HitAssignMapper(const HitAssignMapper&) = delete;

--- a/stratum/p4c_backends/fpm/meta_key_mapper.h
+++ b/stratum/p4c_backends/fpm/meta_key_mapper.h
@@ -9,10 +9,10 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_META_KEY_MAPPER_H_
 #define STRATUM_P4C_BACKENDS_FPM_META_KEY_MAPPER_H_
 
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/meter_color_mapper.h
+++ b/stratum/p4c_backends/fpm/meter_color_mapper.h
@@ -12,12 +12,12 @@
 
 #include <string>
 
-#include "stratum/hal/lib/p4/p4_table_map.pb.h"
-#include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/hal/lib/p4/p4_table_map.pb.h"
+#include "stratum/p4c_backends/fpm/table_map_generator.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/method_call_decoder.h
+++ b/stratum/p4c_backends/fpm/method_call_decoder.h
@@ -16,9 +16,9 @@
 
 #include <string>
 
-#include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
+#include "stratum/hal/lib/p4/p4_table_map.pb.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/midend.h
+++ b/stratum/p4c_backends/fpm/midend.h
@@ -11,11 +11,11 @@
 
 #include <memory>
 
-#include "stratum/p4c_backends/common/midend_interface.h"
 #include "external/com_github_p4lang_p4c/frontends/common/options.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeMap.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/p4c_backends/common/midend_interface.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/parser_decoder.h
+++ b/stratum/p4c_backends/fpm/parser_decoder.h
@@ -10,10 +10,11 @@
 
 #include <map>
 #include <string>
-#include "stratum/p4c_backends/fpm/parser_map.pb.h"
+
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/p4c_backends/fpm/parser_map.pb.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/parser_field_mapper.h
+++ b/stratum/p4c_backends/fpm/parser_field_mapper.h
@@ -19,10 +19,10 @@
 #include <string>
 #include <unordered_map>
 
+#include "absl/container/node_hash_map.h"
 #include "stratum/p4c_backends/fpm/field_decoder.h"
 #include "stratum/p4c_backends/fpm/parser_map.pb.h"
 #include "stratum/p4c_backends/fpm/table_map_generator.h"
-#include "absl/container/node_hash_map.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -60,8 +60,7 @@ class ParserFieldMapper {
                    const std::string& p4_state_name, bool is_tunnel_entry)
         : target_state_name(target_state_name),
           p4_state_name(p4_state_name),
-          is_tunnel_entry(is_tunnel_entry) {
-    }
+          is_tunnel_entry(is_tunnel_entry) {}
 
     const std::string target_state_name;
     const std::string p4_state_name;

--- a/stratum/p4c_backends/fpm/parser_value_set_mapper.h
+++ b/stratum/p4c_backends/fpm/parser_value_set_mapper.h
@@ -13,14 +13,14 @@
 #include <map>
 #include <string>
 
-#include "stratum/hal/lib/p4/p4_info_manager.h"
-#include "stratum/p4c_backends/fpm/parser_map.pb.h"
-#include "stratum/p4c_backends/fpm/table_map_generator.h"
-#include "stratum/public/proto/p4_table_defs.pb.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/p4c_backends/fpm/parser_map.pb.h"
+#include "stratum/p4c_backends/fpm/table_map_generator.h"
+#include "stratum/public/proto/p4_table_defs.pb.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -58,9 +58,7 @@ class ParserValueSetMapper : public Inspector {
   // by the content of a ValueSet.
   struct ValueSetState {
     explicit ValueSetState(const std::string& vs_name)
-        : value_set_name(vs_name),
-          header_type(P4_HEADER_UNKNOWN) {
-    }
+        : value_set_name(vs_name), header_type(P4_HEADER_UNKNOWN) {}
 
     const std::string value_set_name;
     P4HeaderType header_type;

--- a/stratum/p4c_backends/fpm/pipeline_block_passes.h
+++ b/stratum/p4c_backends/fpm/pipeline_block_passes.h
@@ -25,11 +25,11 @@
 #include <set>
 #include <vector>
 
-#include "stratum/public/proto/p4_annotation.pb.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/visitor.h"
+#include "stratum/public/proto/p4_annotation.pb.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/pipeline_intra_block_passes.h
+++ b/stratum/p4c_backends/fpm/pipeline_intra_block_passes.h
@@ -23,11 +23,11 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_PIPELINE_INTRA_BLOCK_PASSES_H_
 #define STRATUM_P4C_BACKENDS_FPM_PIPELINE_INTRA_BLOCK_PASSES_H_
 
-#include "stratum/public/proto/p4_annotation.pb.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
 #include "external/com_github_p4lang_p4c/ir/visitor.h"
+#include "stratum/public/proto/p4_annotation.pb.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/slice_cross_reference.h
+++ b/stratum/p4c_backends/fpm/slice_cross_reference.h
@@ -21,11 +21,11 @@
 #include <memory>
 #include <vector>
 
+#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/p4c_backends/fpm/expression_inspector.h"
 #include "stratum/p4c_backends/fpm/sliced_field_map.pb.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/switch_case_decoder.h
+++ b/stratum/p4c_backends/fpm/switch_case_decoder.h
@@ -11,14 +11,14 @@
 
 #include <map>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
-#include "stratum/hal/lib/p4/p4_table_map.pb.h"
-#include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
+#include "stratum/hal/lib/p4/p4_table_map.pb.h"
+#include "stratum/p4c_backends/fpm/table_map_generator.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -97,7 +97,7 @@ class SwitchCaseDecoder : public Inspector {
   std::vector<std::pair<std::string, std::string>> color_actions_;
 
   // These members track the decoded state of the current case.
-  std::string action_;     // Name of the action affected by the case.
+  std::string action_;  // Name of the action affected by the case.
 };
 
 }  // namespace p4c_backends

--- a/stratum/p4c_backends/fpm/switch_case_decoder_mock.h
+++ b/stratum/p4c_backends/fpm/switch_case_decoder_mock.h
@@ -6,12 +6,12 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_SWITCH_CASE_DECODER_MOCK_H_
 #define STRATUM_P4C_BACKENDS_FPM_SWITCH_CASE_DECODER_MOCK_H_
 
-#include <string>
-#include <set>
 #include <map>
+#include <set>
+#include <string>
 
-#include "stratum/p4c_backends/fpm/switch_case_decoder.h"
 #include "gmock/gmock.h"
+#include "stratum/p4c_backends/fpm/switch_case_decoder.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/switch_p4c_backend.h
+++ b/stratum/p4c_backends/fpm/switch_p4c_backend.h
@@ -13,6 +13,11 @@
 #include <string>
 #include <vector>
 
+#include "external/com_github_p4lang_p4c/frontends/common/options.h"
+#include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
+#include "external/com_github_p4lang_p4c/frontends/p4/fromv1.0/v1model.h"
+#include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
+#include "external/com_github_p4lang_p4c/ir/ir.h"
 #include "stratum/hal/lib/p4/p4_info_manager.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/p4c_backends/common/backend_extension_interface.h"
@@ -29,11 +34,6 @@
 #include "stratum/p4c_backends/fpm/switch_case_decoder.h"
 #include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "stratum/p4c_backends/fpm/tunnel_optimizer_interface.h"
-#include "external/com_github_p4lang_p4c/frontends/common/options.h"
-#include "external/com_github_p4lang_p4c/frontends/common/resolveReferences/referenceMap.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/fromv1.0/v1model.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/typeChecking/typeChecker.h"
-#include "external/com_github_p4lang_p4c/ir/ir.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -48,7 +48,7 @@ class SwitchP4cBackend : public BackendExtensionInterface {
                    P4cFrontMidInterface* front_mid_interface,
                    AnnotationMapper* annotation_mapper,
                    TunnelOptimizerInterface* tunnel_optimizer);
-  ~SwitchP4cBackend() override {};
+  ~SwitchP4cBackend() override{};
 
   // The Compile method does all the work to translate the top_level IR program
   // into a P4PipelineConfig for runtime use on a Stratum fixed-function

--- a/stratum/p4c_backends/fpm/table_hit_inspector.h
+++ b/stratum/p4c_backends/fpm/table_hit_inspector.h
@@ -81,8 +81,8 @@ class TableHitInspector : public Inspector {
   //                         on a prior table hit condition.
   //    true        true     Invalid state.
   // The ref_map and type_map parameters come from the p4c midend output.
-  TableHitInspector(bool table_hit, bool table_miss,
-                    P4::ReferenceMap* ref_map, P4::TypeMap* type_map);
+  TableHitInspector(bool table_hit, bool table_miss, P4::ReferenceMap* ref_map,
+                    P4::TypeMap* type_map);
   ~TableHitInspector() override {}
 
   // The Inspect method inspects all IR nodes under the input statement to

--- a/stratum/p4c_backends/fpm/table_map_generator.h
+++ b/stratum/p4c_backends/fpm/table_map_generator.h
@@ -12,10 +12,10 @@
 #include <set>
 #include <string>
 
+#include "stratum/glue/integral_types.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "stratum/glue/integral_types.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -74,8 +74,8 @@ class TableMapGenerator {
   virtual void SetFieldType(const std::string& field_name, P4FieldType type);
   virtual void SetFieldAttributes(const std::string& field_name,
                                   P4FieldType field_type,
-                                  P4HeaderType header_type,
-                                  uint32_t bit_offset, uint32_t bit_width);
+                                  P4HeaderType header_type, uint32_t bit_offset,
+                                  uint32_t bit_width);
   virtual void SetFieldLocalMetadataFlag(const std::string& field_name);
   virtual void SetFieldValueSet(const std::string& field_name,
                                 const std::string& value_set_name,
@@ -121,23 +121,21 @@ class TableMapGenerator {
   // define the action behavior according to the IR definition.
   virtual void AddAction(const std::string& action_name);
   virtual void AssignActionSourceValueToField(
-      const std::string& action_name,
-      const P4AssignSourceValue& source_value,
+      const std::string& action_name, const P4AssignSourceValue& source_value,
       const std::string& field_name);
-  virtual void AssignActionParameterToField(
-      const std::string& action_name, const std::string& param_name,
-      const std::string& field_name);
-  virtual void AssignHeaderToHeader(
-      const std::string& action_name,
-      const P4AssignSourceValue& source_header,
-      const std::string& destination_header);
+  virtual void AssignActionParameterToField(const std::string& action_name,
+                                            const std::string& param_name,
+                                            const std::string& field_name);
+  virtual void AssignHeaderToHeader(const std::string& action_name,
+                                    const P4AssignSourceValue& source_header,
+                                    const std::string& destination_header);
   virtual void AddDropPrimitive(const std::string& action_name);
   virtual void AddNopPrimitive(const std::string& action_name);
   virtual void AddMeterColorAction(
       const std::string& action_name,
       const hal::P4ActionDescriptor::P4MeterColorAction& color_action);
-  virtual void AddMeterColorActionsFromString(
-      const std::string& action_name, const std::string& color_actions);
+  virtual void AddMeterColorActionsFromString(const std::string& action_name,
+                                              const std::string& color_actions);
   virtual void AddTunnelAction(
       const std::string& action_name,
       const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action);
@@ -176,8 +174,8 @@ class TableMapGenerator {
   //      the depth parameter to 0, and the existing depth value will be
   //      unchanged.
   virtual void AddHeader(const std::string& header_name);
-  virtual void SetHeaderAttributes(
-      const std::string& header_name, P4HeaderType type, int32 depth);
+  virtual void SetHeaderAttributes(const std::string& header_name,
+                                   P4HeaderType type, int32 depth);
 
   // This method adds a P4ActionDescriptor for an internally-generated action
   // to the P4PipelineConfig output.  An internal action is an action that

--- a/stratum/p4c_backends/fpm/table_map_generator_mock.h
+++ b/stratum/p4c_backends/fpm/table_map_generator_mock.h
@@ -6,11 +6,11 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_TABLE_MAP_GENERATOR_MOCK_H_
 #define STRATUM_P4C_BACKENDS_FPM_TABLE_MAP_GENERATOR_MOCK_H_
 
-#include <string>
 #include <set>
+#include <string>
 
-#include "stratum/p4c_backends/fpm/table_map_generator.h"
 #include "gmock/gmock.h"
+#include "stratum/p4c_backends/fpm/table_map_generator.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -18,58 +18,64 @@ namespace p4c_backends {
 class TableMapGeneratorMock : public TableMapGenerator {
  public:
   MOCK_METHOD1(AddField, void(const std::string& field_name));
-  MOCK_METHOD2(SetFieldType, void(
-      const std::string& field_name, P4FieldType type));
-  MOCK_METHOD5(SetFieldAttributes, void(
-      const std::string& field_name, P4FieldType field_type,
-      P4HeaderType header_type, uint32_t bit_offset, uint32_t bit_width));
+  MOCK_METHOD2(SetFieldType,
+               void(const std::string& field_name, P4FieldType type));
+  MOCK_METHOD5(SetFieldAttributes,
+               void(const std::string& field_name, P4FieldType field_type,
+                    P4HeaderType header_type, uint32_t bit_offset,
+                    uint32_t bit_width));
   MOCK_METHOD1(SetFieldLocalMetadataFlag, void(const std::string& field_name));
-  MOCK_METHOD3(SetFieldValueSet, void(
-      const std::string& field_name, const std::string& value_set_name,
-      P4HeaderType header_type));
-  MOCK_METHOD3(AddFieldMatch, void(
-      const std::string& field_name, const std::string& match_type,
-      int bit_width));
+  MOCK_METHOD3(SetFieldValueSet, void(const std::string& field_name,
+                                      const std::string& value_set_name,
+                                      P4HeaderType header_type));
+  MOCK_METHOD3(AddFieldMatch,
+               void(const std::string& field_name,
+                    const std::string& match_type, int bit_width));
   MOCK_METHOD2(ReplaceFieldDescriptor,
                void(const std::string& field_name,
                     const hal::P4FieldDescriptor& new_descriptor));
   MOCK_METHOD1(AddAction, void(const std::string& action_name));
-  MOCK_METHOD3(AssignActionSourceValueToField, void(
-      const std::string& action_name,
-      const P4AssignSourceValue& source_value,
-      const std::string& field_name));
-  MOCK_METHOD3(AssignActionParameterToField, void(
-      const std::string& action_name, const std::string& param_name,
-      const std::string& field_name));
-  MOCK_METHOD3(AssignHeaderToHeader, void(
-      const std::string& action_name, const P4AssignSourceValue& source_header,
-      const std::string& destination_header));
+  MOCK_METHOD3(AssignActionSourceValueToField,
+               void(const std::string& action_name,
+                    const P4AssignSourceValue& source_value,
+                    const std::string& field_name));
+  MOCK_METHOD3(AssignActionParameterToField,
+               void(const std::string& action_name,
+                    const std::string& param_name,
+                    const std::string& field_name));
+  MOCK_METHOD3(AssignHeaderToHeader,
+               void(const std::string& action_name,
+                    const P4AssignSourceValue& source_header,
+                    const std::string& destination_header));
   MOCK_METHOD1(AddDropPrimitive, void(const std::string& action_name));
   MOCK_METHOD1(AddNopPrimitive, void(const std::string& action_name));
-  MOCK_METHOD2(AddMeterColorAction, void(
-      const std::string& action_name,
-      const hal::P4ActionDescriptor::P4MeterColorAction& color_action));
-  MOCK_METHOD2(AddMeterColorActionsFromString, void(
-      const std::string& action_name, const std::string& color_actions));
-  MOCK_METHOD2(AddTunnelAction, void(
-      const std::string& action_name,
-      const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action));
-  MOCK_METHOD2(ReplaceActionDescriptor, void(
-      const std::string& action_name,
-      const hal::P4ActionDescriptor& new_descriptor));
+  MOCK_METHOD2(
+      AddMeterColorAction,
+      void(const std::string& action_name,
+           const hal::P4ActionDescriptor::P4MeterColorAction& color_action));
+  MOCK_METHOD2(AddMeterColorActionsFromString,
+               void(const std::string& action_name,
+                    const std::string& color_actions));
+  MOCK_METHOD2(
+      AddTunnelAction,
+      void(const std::string& action_name,
+           const hal::P4ActionDescriptor::P4TunnelAction& tunnel_action));
+  MOCK_METHOD2(ReplaceActionDescriptor,
+               void(const std::string& action_name,
+                    const hal::P4ActionDescriptor& new_descriptor));
   MOCK_METHOD1(AddTable, void(const std::string& table_name));
-  MOCK_METHOD2(SetTableType, void(
-      const std::string& table_name, P4TableType type));
+  MOCK_METHOD2(SetTableType,
+               void(const std::string& table_name, P4TableType type));
   MOCK_METHOD1(SetTableStaticEntriesFlag, void(const std::string& table_name));
-  MOCK_METHOD2(SetTableValidHeaders, void(
-      const std::string& table_name,
-      const std::set<std::string>& header_names));
+  MOCK_METHOD2(SetTableValidHeaders,
+               void(const std::string& table_name,
+                    const std::set<std::string>& header_names));
   MOCK_METHOD1(AddHeader, void(const std::string& header_name));
-  MOCK_METHOD3(SetHeaderAttributes, void(
-      const std::string& header_name, P4HeaderType type, int32 depth));
-  MOCK_METHOD2(AddInternalAction, void(
-      const std::string& action_name,
-      const hal::P4ActionDescriptor& internal_descriptor));
+  MOCK_METHOD3(SetHeaderAttributes, void(const std::string& header_name,
+                                         P4HeaderType type, int32 depth));
+  MOCK_METHOD2(AddInternalAction,
+               void(const std::string& action_name,
+                    const hal::P4ActionDescriptor& internal_descriptor));
   MOCK_CONST_METHOD0(generated_map, const hal::P4PipelineConfig&());
 };
 

--- a/stratum/p4c_backends/fpm/target_info_mock.h
+++ b/stratum/p4c_backends/fpm/target_info_mock.h
@@ -6,9 +6,8 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_TARGET_INFO_MOCK_H_
 #define STRATUM_P4C_BACKENDS_FPM_TARGET_INFO_MOCK_H_
 
-#include "stratum/p4c_backends/fpm/target_info.h"
-
 #include "gmock/gmock.h"
+#include "stratum/p4c_backends/fpm/target_info.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/fpm/tunnel_optimizer_mock.h
+++ b/stratum/p4c_backends/fpm/tunnel_optimizer_mock.h
@@ -6,17 +6,16 @@
 #ifndef STRATUM_P4C_BACKENDS_FPM_TUNNEL_OPTIMIZER_MOCK_H_
 #define STRATUM_P4C_BACKENDS_FPM_TUNNEL_OPTIMIZER_MOCK_H_
 
-#include "stratum/p4c_backends/fpm/tunnel_optimizer_interface.h"
 #include "gmock/gmock.h"
+#include "stratum/p4c_backends/fpm/tunnel_optimizer_interface.h"
 
 namespace stratum {
 namespace p4c_backends {
 
 class TunnelOptimizerMock : public TunnelOptimizerInterface {
  public:
-  MOCK_METHOD2(Optimize,
-               bool(const hal::P4ActionDescriptor& input_action,
-                    hal::P4ActionDescriptor* optimized_action));
+  MOCK_METHOD2(Optimize, bool(const hal::P4ActionDescriptor& input_action,
+                              hal::P4ActionDescriptor* optimized_action));
   MOCK_METHOD3(MergeAndOptimize,
                bool(const hal::P4ActionDescriptor& input_action1,
                     const hal::P4ActionDescriptor& input_action2,

--- a/stratum/p4c_backends/fpm/utils.h
+++ b/stratum/p4c_backends/fpm/utils.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
+#include "external/com_github_p4lang_p4c/frontends/p4/methodInstance.h"
 #include "stratum/glue/logging.h"
 #include "stratum/hal/lib/p4/p4_control.pb.h"
 #include "stratum/hal/lib/p4/p4_info_manager.h"
@@ -16,8 +18,6 @@
 #include "stratum/p4c_backends/fpm/parser_map.pb.h"
 #include "stratum/public/proto/p4_annotation.pb.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
-#include "external/com_github_p4lang_p4c/frontends/p4/methodInstance.h"
 
 namespace stratum {
 namespace p4c_backends {
@@ -132,8 +132,7 @@ const hal::P4HeaderDescriptor& FindHeaderDescriptorOrDie(
     const std::string& header_name,
     const hal::P4PipelineConfig& p4_pipeline_config);
 const hal::P4HeaderDescriptor& FindHeaderDescriptorForFieldOrDie(
-    const std::string& field_name,
-    P4HeaderType header_type,
+    const std::string& field_name, P4HeaderType header_type,
     const hal::P4PipelineConfig& p4_pipeline_config);
 
 // These utility functions provide common support for field descriptor lookup.
@@ -158,8 +157,8 @@ void DeleteRepeatedFields(
     const std::vector<int>& delete_indexes,
     ::google::protobuf::RepeatedPtrField<ELEMENT>* repeated_fields) {
   int prior_index = repeated_fields->size();
-  for (auto r_iter = delete_indexes.rbegin();
-       r_iter !=  delete_indexes.rend(); ++r_iter) {
+  for (auto r_iter = delete_indexes.rbegin(); r_iter != delete_indexes.rend();
+       ++r_iter) {
     DCHECK(0 <= *r_iter && *r_iter < prior_index)
         << "Invalid deleted field index " << *r_iter
         << " must be non-negative in ascending order";

--- a/stratum/p4c_backends/test/ir_test_helpers.h
+++ b/stratum/p4c_backends/test/ir_test_helpers.h
@@ -7,16 +7,16 @@
 #ifndef STRATUM_P4C_BACKENDS_TEST_IR_TEST_HELPERS_H_
 #define STRATUM_P4C_BACKENDS_TEST_IR_TEST_HELPERS_H_
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
-#include <map>
 
-#include "stratum/p4c_backends/common/p4c_front_mid_real.h"
-#include "stratum/p4c_backends/common/program_inspector.h"
 #include "external/com_github_p4lang_p4c/ir/ir.h"
 #include "external/com_github_p4lang_p4c/lib/compile_context.h"
 #include "p4/config/v1/p4info.pb.h"
+#include "stratum/p4c_backends/common/p4c_front_mid_real.h"
+#include "stratum/p4c_backends/common/program_inspector.h"
 
 namespace stratum {
 namespace p4c_backends {

--- a/stratum/p4c_backends/test/test_inspectors.h
+++ b/stratum/p4c_backends/test/test_inspectors.h
@@ -6,8 +6,8 @@
 #ifndef STRATUM_P4C_BACKENDS_TEST_TEST_INSPECTORS_H_
 #define STRATUM_P4C_BACKENDS_TEST_TEST_INSPECTORS_H_
 
-#include <string>
 #include <set>
+#include <string>
 
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/ir/visitor.h"
@@ -26,8 +26,7 @@ class StatementCounter : public Inspector {
       : pipeline_statement_count_(0),
         if_statement_count_(0),
         block_statement_count_(0),
-        hit_statement_count_(0) {
-  }
+        hit_statement_count_(0) {}
   ~StatementCounter() override {}
 
   // Visits nodes under p4_control and accumulates counts for interesting

--- a/stratum/public/lib/error.h
+++ b/stratum/public/lib/error.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_PUBLIC_LIB_ERROR_H_
 #define STRATUM_PUBLIC_LIB_ERROR_H_
 
@@ -23,8 +22,7 @@ namespace util {
 namespace status_macros {
 
 template <>
-class ErrorCodeOptions<::stratum::ErrorCode>
-    : public BaseErrorCodeOptions {
+class ErrorCodeOptions<::stratum::ErrorCode> : public BaseErrorCodeOptions {
  public:
   const ::util::ErrorSpace* GetErrorSpace() {
     return ::stratum::StratumErrorSpace();


### PR DESCRIPTION
This PR formats all C++ `.h` files known to git with `clang-format` and adds them to the CI check. No more lists or exceptions.