### PR TITLE
Re-add `build_stack_rules_proto` dep

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -78,6 +78,13 @@ def stratum_deps():
             sha256 = P4RUNTIME_SHA,
         )
 
+    if "build_stack_rules_proto" not in native.existing_rules():
+        remote_workspace(
+            name = "build_stack_rules_proto",
+            remote = "https://github.com/stackb/rules_proto",
+            commit = "2f4e4f62a3d7a43654d69533faa0652e1c4f5082",
+        )
+
     if "com_github_p4lang_PI" not in native.existing_rules():
         # ----- PI -----
         remote_workspace(


### PR DESCRIPTION
PR #872 removed a few (seemingly) unneeded dependencies. As CI is not building the `stratum_bf/stratum_bfrt` targets we did not catch the missing dependency for older PI versions, which requires `build_stack_rules_proto`.

Note:
Bazel also tries to build PI when building stratum_bfrt target, need to find out the reason.
