### PR TITLE
Add bmv2-commit label to mn-stratum image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@
 
 ARG BAZELISK_VERSION=1.8.0
 ARG PI_COMMIT=a5fd855d4b3293e23816ef6154e83dc6621aed6a
-ARG BMV2_COMMIT=b0fb01ecacbf3a7d7f0c01e2f149b0c6a957f779
+ARG BMV2_COMMIT=$BMV2_COMMIT
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/stretch/  llvm-toolchain-stretch-11 main"
 

--- a/tools/mininet/Dockerfile
+++ b/tools/mininet/Dockerfile
@@ -75,6 +75,7 @@ FROM bitnami/minideb:stretch as runtime
 
 LABEL maintainer="Stratum dev <stratum-dev@lists.stratumproject.org>"
 LABEL description="Docker-based Mininet image that uses stratum_bmv2 as the default switch"
+LABEL bmv2-commit="$BMV2_COMMIT"
 
 # Mininet and BMv2 simple_switch runtime dependencies
 ENV RUNTIME_DEPS \

--- a/tools/mininet/build-stratum-bmv2-container.sh
+++ b/tools/mininet/build-stratum-bmv2-container.sh
@@ -7,6 +7,7 @@ DOCKERFILE_DIR=$( cd $(dirname "${BASH_SOURCE[0]}") >/dev/null 2>&1 && pwd )
 STRATUM_ROOT=${STRATUM_ROOT:-"$( cd "$DOCKERFILE_DIR/../.." >/dev/null 2>&1 && pwd )"}
 STRATUM_TARGET=stratum_bmv2
 JOBS=${JOBS:-4}
+BMV2_COMMIT=e1fcd5d54cecf7679f46ac462fdf92e049711e6c
 DOCKER_IMG=${DOCKER_IMG:-stratumproject/build:build}
 
 print_help() {
@@ -77,6 +78,7 @@ fi
 DOCKER_BUILD_OPTS+="--label stratum-target=$STRATUM_TARGET "
 DOCKER_BUILD_OPTS+="--label build-timestamp=$(date +%FT%T%z) "
 DOCKER_BUILD_OPTS+="--label build-machine=$(hostname) "
+DOCKER_BUILD_OPTS+="--label bmv2-commit=$BMV2_COMMIT "
 
 # Add VCS labels
 pushd $STRATUM_ROOT


### PR DESCRIPTION
This PR adds a label to image `mn-stratum` showing the commit used to build bmv2.