### PR TITLE
Add `-O2` copt to `release` config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,5 +46,6 @@ build:tsan --strip=never
 
 # Release build (build with -O2, no asserts, strip all symbols, and stamp)
 build:release --compilation_mode=opt
+build:release --copt='-O2'
 build:release --linkopt=-Wl,--strip-all
 build:release --stamp


### PR DESCRIPTION
Currently we append a special bazelrc file for CI runs. It overrides the compiler optimization level with `-O0`. This is not suitable for release builds. Therefore we add the copt for release builds explicitly.

fixes #891