### PR TITLE
Make file CLI flags and usage messages uniform

### DIFF
--- a/stratum/lib/security/README.md
+++ b/stratum/lib/security/README.md
@@ -30,9 +30,9 @@ You can use tools like [OpenSSL][2] to generate these files. We also provide a [
 
 To start Stratum with SSL/TLS, add the following flags:
 ```
---ca-cert=[CA certificate file]
---server-cert=[Server certificate file]
---server-key=[Server private key file]
+--ca_cert_file=[CA certificate file]
+--server_cert_file=[Server certificate file]
+--server_key_file=[Server private key file]
 ```
 
 [1]:https://grpc.io/docs/guides/auth/#with-server-authentication-ssltls-5

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -14,9 +14,9 @@
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 
-DEFINE_string(ca_cert, "", "CA certificate path");
-DEFINE_string(server_key, "", "gRPC Server pricate key path");
-DEFINE_string(server_cert, "", "gRPC Server certificate path");
+DEFINE_string(ca_cert_file, "", "CA certificate path");
+DEFINE_string(server_key_file, "", "gRPC Server private key path");
+DEFINE_string(server_cert_file, "", "gRPC Server certificate path");
 
 namespace stratum {
 
@@ -36,13 +36,13 @@ CredentialsManager::CreateInstance() {
 }
 
 ::util::Status CredentialsManager::Initialize() {
-  if (FLAGS_ca_cert.empty() && FLAGS_server_key.empty() &&
-      FLAGS_server_cert.empty()) {
+  if (FLAGS_ca_cert_file.empty() && FLAGS_server_key_file.empty() &&
+      FLAGS_server_cert_file.empty()) {
     LOG(WARNING) << "Using insecure server credentials";
     server_credentials_ = ::grpc::InsecureServerCredentials();
   } else {
     certificate_provider_ = std::make_shared<FileWatcherCertificateProvider>(
-        FLAGS_server_key, FLAGS_server_cert, FLAGS_ca_cert, 1);
+        FLAGS_server_key_file, FLAGS_server_cert_file, FLAGS_ca_cert_file, 1);
 
     tls_opts_ =
         std::make_shared<TlsServerCredentialsOptions>(certificate_provider_);
@@ -60,9 +60,9 @@ CredentialsManager::CreateInstance() {
     const std::string private_key) {
   ::util::Status status;
   // TODO(Kevin): Validate the provided key material if possible
-  status.Update(WriteStringToFile(root_certs, FLAGS_ca_cert));
-  status.Update(WriteStringToFile(cert_chain, FLAGS_server_cert));
-  status.Update(WriteStringToFile(private_key, FLAGS_server_key));
+  status.Update(WriteStringToFile(root_certs, FLAGS_ca_cert_file));
+  status.Update(WriteStringToFile(cert_chain, FLAGS_server_cert_file));
+  status.Update(WriteStringToFile(private_key, FLAGS_server_key_file));
   return status;
 }
 

--- a/stratum/lib/security/credentials_manager_test.cc
+++ b/stratum/lib/security/credentials_manager_test.cc
@@ -21,9 +21,9 @@
 #include "stratum/lib/security/test.grpc.pb.h"
 #include "stratum/lib/utils.h"
 
-DECLARE_string(ca_cert);
-DECLARE_string(server_key);
-DECLARE_string(server_cert);
+DECLARE_string(ca_cert_file);
+DECLARE_string(server_key_file);
+DECLARE_string(server_cert_file);
 DECLARE_string(test_tmpdir);
 
 namespace stratum {
@@ -63,18 +63,19 @@ util::Status GenerateCerts(std::string* ca_crt, std::string* server_crt,
 
 void SetCerts(const std::string& ca_crt, const std::string& server_crt,
               const std::string& server_key) {
-  ASSERT_OK(WriteStringToFile(ca_crt, FLAGS_ca_cert));
-  ASSERT_OK(WriteStringToFile(server_crt, FLAGS_server_cert));
-  ASSERT_OK(WriteStringToFile(server_key, FLAGS_server_key));
+  ASSERT_OK(WriteStringToFile(ca_crt, FLAGS_ca_cert_file));
+  ASSERT_OK(WriteStringToFile(server_crt, FLAGS_server_cert_file));
+  ASSERT_OK(WriteStringToFile(server_key, FLAGS_server_key_file));
 }
 
 class CredentialsManagerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    FLAGS_ca_cert = absl::StrFormat("%s/%s", FLAGS_test_tmpdir, kCaCertFile);
-    FLAGS_server_cert =
+    FLAGS_ca_cert_file =
+        absl::StrFormat("%s/%s", FLAGS_test_tmpdir, kCaCertFile);
+    FLAGS_server_cert_file =
         absl::StrFormat("%s/%s", FLAGS_test_tmpdir, kServerCertFile);
-    FLAGS_server_key =
+    FLAGS_server_key_file =
         absl::StrFormat("%s/%s", FLAGS_test_tmpdir, kServerKeyFile);
 
     std::string server_crt, server_key;
@@ -154,9 +155,9 @@ TEST_F(CredentialsManagerTest, LoadNewCredentials) {
   std::string ca_cert_actual;
   std::string cert_actual;
   std::string key_actual;
-  ASSERT_OK(ReadFileToString(FLAGS_ca_cert, &ca_cert_actual));
-  ASSERT_OK(ReadFileToString(FLAGS_server_cert, &cert_actual));
-  ASSERT_OK(ReadFileToString(FLAGS_server_key, &key_actual));
+  ASSERT_OK(ReadFileToString(FLAGS_ca_cert_file, &ca_cert_actual));
+  ASSERT_OK(ReadFileToString(FLAGS_server_cert_file, &cert_actual));
+  ASSERT_OK(ReadFileToString(FLAGS_server_key_file, &key_actual));
   EXPECT_EQ(ca_cert_actual, ca_crt);
   EXPECT_EQ(cert_actual, server_crt);
   EXPECT_EQ(key_actual, server_key);

--- a/stratum/tools/gnmi/README.md
+++ b/stratum/tools/gnmi/README.md
@@ -9,29 +9,8 @@ gNMI tool
 
 ### Usage
 
-```
-usage: gnmi_cli [--help] [Options] {get,set,cap,del,sub-onchange,sub-sample} path
-
-Basic gNMI CLI
-
-positional arguments:
-  {get,set,cap,del,sub-onchange,sub-sample}         gNMI command
-  path                                              gNMI path
-
-optional arguments:
-  --help            show this help message and exit
-  --grpc_addr GRPC_ADDR    gNMI server address
-  --bool_val BOOL_VAL      [SetRequest only] Set boolean value
-  --int_val INT_VAL        [SetRequest only] Set int value (64-bit)
-  --uint_val UINT_VAL      [SetRequest only] Set uint value (64-bit)
-  --string_val STRING_VAL  [SetRequest only] Set string value
-  --float_val FLOAT_VAL    [SetRequest only] Set float value
-  --interval INTERVAL      [Sample subscribe only] Sample subscribe poll interval in ms
-  --replace                [SetRequest only] Use replace instead of update
-  --get-type               [GetRequest only] Use specific data type for get request (ALL,CONFIG,STATE,OPERATIONAL)
-  --ca-cert                CA certificate
-  --client-cert            gRPC Client certificate
-  --client-key             gRPC Client key
+```bash
+bazel run //stratum/tools/gnmi:gnmi_cli -- --helpshort
 ```
 
 ### Examples

--- a/stratum/tools/stratum_replay/README.md
+++ b/stratum/tools/stratum_replay/README.md
@@ -122,14 +122,6 @@ for a given pipeline config file.
 
 # Usage and available options:
 
-`stratum_replay [options] [p4runtime write log file]`
-
-```
--device_id: The device ID (default: 1)
--election_id: Election ID for arbitration update (high,low). (default: "0,1")
--grpc_addr: Stratum gRPC address (default: "127.0.0.1:9339")
--pipeline_cfg: The pipeline config file (default: "pipeline.pb.bin")
--ca_cert: CA certificate(optional), will use insecure credentials if empty (default: "")
--client_cert: Client certificate (optional) (default: "")
--client_key: Client key (optional) (default: "")
+```bash
+bazel run //stratum/tools/stratum_replay -- --helpshort
 ```


### PR DESCRIPTION
The CLI flags related to TLS are ambiguous whether they expect a path to a file, or the actually file content. Established convention is using `<flag>_file` for files. This PR fixes this.

It also removes the duplicate usage strings in both the docs and code, as they are auto-generated by gflags with the `--helpshort` flag. Some were already outdated and incorrect.