### PR TITLE
Touch up `CredentialsManager`

### DIFF
--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -20,19 +20,24 @@ DEFINE_string(server_cert_file, "", "gRPC Server certificate path");
 
 namespace stratum {
 
-CredentialsManager::~CredentialsManager() {}
+using ::grpc::experimental::FileWatcherCertificateProvider;
+using ::grpc::experimental::TlsServerCredentials;
+using ::grpc::experimental::TlsServerCredentialsOptions;
+
 CredentialsManager::CredentialsManager() {}
 
-std::shared_ptr<::grpc::ServerCredentials>
-CredentialsManager::GenerateExternalFacingServerCredentials() const {
-  return server_credentials_;
-}
+CredentialsManager::~CredentialsManager() {}
 
 ::util::StatusOr<std::unique_ptr<CredentialsManager>>
 CredentialsManager::CreateInstance() {
   auto instance_ = absl::WrapUnique(new CredentialsManager());
   RETURN_IF_ERROR(instance_->Initialize());
   return std::move(instance_);
+}
+
+std::shared_ptr<::grpc::ServerCredentials>
+CredentialsManager::GenerateExternalFacingServerCredentials() const {
+  return server_credentials_;
 }
 
 ::util::Status CredentialsManager::Initialize() {
@@ -56,10 +61,13 @@ CredentialsManager::CreateInstance() {
 }
 
 ::util::Status CredentialsManager::LoadNewCredential(
-    const std::string root_certs, const std::string cert_chain,
-    const std::string private_key) {
+    const std::string& root_certs, const std::string& cert_chain,
+    const std::string& private_key) {
   ::util::Status status;
   // TODO(Kevin): Validate the provided key material if possible
+  // TODO(max): According to the API of FileWatcherCertificateProvider, any key
+  // and certifcate update must happen atomically. The below code does not
+  // guarantee that.
   status.Update(WriteStringToFile(root_certs, FLAGS_ca_cert_file));
   status.Update(WriteStringToFile(cert_chain, FLAGS_server_cert_file));
   status.Update(WriteStringToFile(private_key, FLAGS_server_key_file));

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -15,22 +15,23 @@
 #include "stratum/glue/status/statusor.h"
 
 namespace stratum {
-using ::grpc::experimental::FileWatcherCertificateProvider;
-using ::grpc::experimental::TlsServerCredentials;
-using ::grpc::experimental::TlsServerCredentialsOptions;
 
 // CredentialsManager manages the server credentials for (external facing) gRPC
 // servers. It handles starting and shutting down TSI as well as generating the
-// server credentials. This class is supposed to be created
-// once for each binary.
+// server credentials. This class is supposed to be created once for each
+// binary.
 class CredentialsManager {
  public:
   virtual ~CredentialsManager();
 
-  // Generates server credentials for an external facing gRPC
-  // server.
+  // Generates server credentials for an external facing gRPC server.
   virtual std::shared_ptr<::grpc::ServerCredentials>
   GenerateExternalFacingServerCredentials() const;
+
+  // Loads new credentials.
+  virtual ::util::Status LoadNewCredential(const std::string& ca_cert,
+                                           const std::string& cert,
+                                           const std::string& key);
 
   // Factory functions for creating the instance of the class.
   static ::util::StatusOr<std::unique_ptr<CredentialsManager>> CreateInstance();
@@ -38,11 +39,6 @@ class CredentialsManager {
   // CredentialsManager is neither copyable nor movable.
   CredentialsManager(const CredentialsManager&) = delete;
   CredentialsManager& operator=(const CredentialsManager&) = delete;
-
-  // Loads new credentials
-  ::util::Status LoadNewCredential(const std::string ca_cert,
-                                   const std::string cert,
-                                   const std::string key);
 
  protected:
   // Default constructor. To be called by the Mock class instance as well as
@@ -53,8 +49,9 @@ class CredentialsManager {
   // Function to initialize the credentials manager.
   ::util::Status Initialize();
   std::shared_ptr<::grpc::ServerCredentials> server_credentials_;
-  std::shared_ptr<TlsServerCredentialsOptions> tls_opts_;
-  std::shared_ptr<FileWatcherCertificateProvider> certificate_provider_;
+  std::shared_ptr<::grpc::experimental::TlsServerCredentialsOptions> tls_opts_;
+  std::shared_ptr<::grpc::experimental::FileWatcherCertificateProvider>
+      certificate_provider_;
 };
 
 }  // namespace stratum

--- a/stratum/lib/security/credentials_manager_mock.h
+++ b/stratum/lib/security/credentials_manager_mock.h
@@ -18,9 +18,9 @@ class CredentialsManagerMock : public CredentialsManager {
   MOCK_CONST_METHOD0(GenerateExternalFacingServerCredentials,
                      std::shared_ptr<::grpc::ServerCredentials>());
   MOCK_CONST_METHOD3(LoadNewCredential,
-                     ::util::Status(const std::string ca_cert,
-                                    const std::string cert,
-                                    const std::string key));
+                     ::util::Status(const std::string& ca_cert,
+                                    const std::string& cert,
+                                    const std::string& key));
 };
 
 }  // namespace stratum


### PR DESCRIPTION
Some cleanup and application of best practices and convention:

- string const ref
- Member function order
- Comment reflow
- no `using` in headers
- missing virtual on `LoadNewCredential`