### PR TITLE
Enable `-Werror=overloaded-virtual` compiler flag

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -69,6 +69,7 @@ STRATUM_COMPILER_ERRORS_GCC = [
 STRATUM_COMPILER_ERRORS_LLVM = [
     "-Werror=implicit-fallthrough",  # TODO(max): move to common after gcc 7
     "-Werror=inconsistent-missing-destructor-override",
+    "-Werror=overloaded-virtual",
     "-Werror=reorder-ctor",
     "-Werror=return-type",  # TODO(max): move to common after gcc update
     "-Werror=thread-safety-analysis",

--- a/stratum/hal/lib/bcm/bcm_node_mock.h
+++ b/stratum/hal/lib/bcm/bcm_node_mock.h
@@ -5,6 +5,7 @@
 #ifndef STRATUM_HAL_LIB_BCM_BCM_NODE_MOCK_H_
 #define STRATUM_HAL_LIB_BCM_BCM_NODE_MOCK_H_
 
+#include <memory>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -36,11 +37,9 @@ class BcmNodeMock : public BcmNode {
                ::util::Status(const ::p4::v1::ReadRequest& req,
                               WriterInterface<::p4::v1::ReadResponse>* writer,
                               std::vector<::util::Status>* details));
-  MOCK_METHOD1(
-      RegisterStreamMessageResponseWriter,
-      ::util::Status(
-          std::function<void(const ::p4::v1::StreamMessageResponse& resp)>
-              callback));
+  MOCK_METHOD1(RegisterStreamMessageResponseWriter,
+               ::util::Status(const std::shared_ptr<WriterInterface<
+                                  ::p4::v1::StreamMessageResponse>>& writer));
   MOCK_METHOD1(HandleStreamMessageRequest,
                ::util::Status(const ::p4::v1::StreamMessageRequest& req));
   MOCK_METHOD1(UpdatePortState, ::util::Status(uint32 port_id));

--- a/stratum/lib/security/credentials_manager_mock.h
+++ b/stratum/lib/security/credentials_manager_mock.h
@@ -17,10 +17,9 @@ class CredentialsManagerMock : public CredentialsManager {
  public:
   MOCK_CONST_METHOD0(GenerateExternalFacingServerCredentials,
                      std::shared_ptr<::grpc::ServerCredentials>());
-  MOCK_CONST_METHOD3(LoadNewCredential,
-                     ::util::Status(const std::string& ca_cert,
-                                    const std::string& cert,
-                                    const std::string& key));
+  MOCK_METHOD3(LoadNewCredential,
+               ::util::Status(const std::string& ca_cert,
+                              const std::string& cert, const std::string& key));
 };
 
 }  // namespace stratum


### PR DESCRIPTION
This catches virtual functions that got overloaded by accident, e.g., different parameter types or constness.