### PR TITLE
Simplify bazel coverage flags

### DIFF
--- a/.circleci/bazelrc
+++ b/.circleci/bazelrc
@@ -28,5 +28,5 @@ test --test_verbose_timeout_warnings
 build --profile=/tmp/bazel.profile.json
 
 # Coverage
-coverage --combined_report=lcov --coverage_report_generator @bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main
+coverage --combined_report=lcov
 


### PR DESCRIPTION
Bazel now uses '@bazel_tools//tools/test:coverage_report_generator' as
default coverage report generator and it should work.

TODO: see if CI can generate correct report