### PR TITLE
Remove `RETURN_ERROR` macro

### DIFF
--- a/.circleci/check-cpp-format.sh
+++ b/.circleci/check-cpp-format.sh
@@ -22,6 +22,7 @@ stratum/glue/gtl/stl_util.h
 stratum/glue/init_google.h
 stratum/glue/status/posix_error_space.cc
 stratum/glue/status/status_test_util.cc
+stratum/glue/status/status_test_util.h
 stratum/hal/bin/barefoot/bf_pipeline_builder.cc
 stratum/hal/bin/barefoot/main_bfrt.cc
 stratum/hal/bin/barefoot/main.cc
@@ -144,6 +145,7 @@ stratum/hal/lib/phal/attribute_group_test.cc
 stratum/hal/lib/phal/attribute_group.cc
 stratum/hal/lib/phal/attribute_group.h
 stratum/hal/lib/phal/datasource_mock.cc
+stratum/hal/lib/phal/datasource.cc
 stratum/hal/lib/phal/onlp/onlp_cli.cc
 stratum/hal/lib/phal/onlp/onlp_event_handler_mock.h
 stratum/hal/lib/phal/onlp/onlp_event_handler_test.cc

--- a/stratum/glue/status/status_macros.h
+++ b/stratum/glue/status/status_macros.h
@@ -12,13 +12,14 @@
 //   ::util::StatusOr<ValueType> Method(arg, ...);
 //
 // Inside the method, to return errors, use the macros
-//   RETURN_ERROR() << "Message with ::util::error::UNKNOWN code";
-//   RETURN_ERROR(code_enum)
-//       << "Message with an error code, in that error_code's ErrorSpace "
-//       << "(See ErrorCodeOptions below)";
-//   RETURN_ERROR(error_space, code_int)
-//       << "Message with integer error code in specified ErrorSpace "
-//       << "(Not recommended - use previous form with an enum code instead)";
+//   return MAKE_ERROR() << "Message with ::util::error::UNKNOWN code";
+//   return MAKE_ERROR(code_enum)
+//          << "Message with an error code, in that error_code's ErrorSpace "
+//          << "(See ErrorCodeOptions below)";
+//   return MAKE_ERROR(error_space, code_int)
+//          << "Message with integer error code in specified ErrorSpace "
+//          << "(Not recommended - use previous form with an enum code "
+//          << "instead)";
 //
 // When calling another method, use this to propagate status easily.
 //   RETURN_IF_ERROR(method(args));
@@ -45,8 +46,7 @@
 // WARNING: ASSIGN_OR_RETURN expands into multiple statements; it cannot be used
 //  in a single statement (e.g. as the body of an if statement without {})!
 //
-// To construct an error without immediately returning it, use MAKE_ERROR,
-// which supports the same argument types as RETURN_ERROR.
+// To construct an error without immediately returning it, use MAKE_ERROR.
 //   ::util::Status status = MAKE_ERROR(...) << "Message";
 //
 // To add additional text onto an existing error, use
@@ -58,7 +58,7 @@
 // They can also be used to return from a function that returns
 // ::util::StatusOr:
 //   ::util::StatusOr<T> MyFunction() {
-//     RETURN_ERROR(...) << "Message";
+//     return MAKE_ERROR(...) << "Message";
 //   }
 //
 //
@@ -75,16 +75,16 @@
 //
 // Logging:
 //
-// RETURN_ERROR and MAKE_ERROR log the error to LOG(ERROR) by default.
+// MAKE_ERROR logs the error to LOG(ERROR) by default.
 //
 // Logging can be turned on or off for a specific error by using
-//   RETURN_ERROR().with_logging() << "Message logged to LOG(ERROR)";
-//   RETURN_ERROR().without_logging() << "Message not logged";
-//   RETURN_ERROR().set_logging(false) << "Message not logged";
-//   RETURN_ERROR().severity(INFO) << "Message logged to LOG(INFO)";
+//   return MAKE_ERROR().with_logging() << "Message logged to LOG(ERROR)";
+//   return MAKE_ERROR().without_logging() << "Message not logged";
+//   return MAKE_ERROR().set_logging(false) << "Message not logged";
+//   return MAKE_ERROR().severity(INFO) << "Message logged to LOG(INFO)";
 //
 // If logging is enabled, this will make an error also log a stack trace.
-//   RETURN_ERROR().with_log_stack_trace() << "Message";
+//   return MAKE_ERROR().with_log_stack_trace() << "Message";
 //
 // Logging can also be controlled within a scope using
 // ScopedErrorLogSuppression.
@@ -369,12 +369,6 @@ class MakeErrorStream {
 //   return APPEND_ERROR(status) << ", more details";
 #define APPEND_ERROR(status) \
   ::util::status_macros::MakeErrorStream((status), __FILE__, __LINE__)
-
-// Shorthand to make an error (with MAKE_ERROR) and return it.
-//   if (error) {
-//     RETURN_ERROR() << "Message";
-//   }
-#define RETURN_ERROR return MAKE_ERROR
 
 // Wraps a ::util::Status so it can be assigned and used in an if-statement.
 // Implicitly converts from status and to bool.

--- a/stratum/hal/bin/barefoot/bf_pipeline_builder.cc
+++ b/stratum/hal/bin/barefoot/bf_pipeline_builder.cc
@@ -47,7 +47,8 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
   // TODO(max): replace with <filesystem> once we move to C++17
   char* resolved_path = realpath(FLAGS_unpack_dir.c_str(), nullptr);
   if (!resolved_path) {
-    RETURN_ERROR(ERR_INTERNAL) << "Unable to resolve path " << FLAGS_unpack_dir;
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Unable to resolve path " << FLAGS_unpack_dir;
   }
   std::string base_path(resolved_path);
   free(resolved_path);

--- a/stratum/hal/bin/dummy/dummy_cli.cc
+++ b/stratum/hal/bin/dummy/dummy_cli.cc
@@ -232,7 +232,7 @@ class DummyCli {
       ASSIGN_OR_RETURN(*new_state.mutable_health_indicator(),
                        ParseHealthIndicator(args[3]));
     } else {
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
     }
 
     return new_state;
@@ -245,7 +245,7 @@ class DummyCli {
     if (state == "node_packetio_debug_info") {
       new_state.mutable_node_packetio_debug_info()->set_debug_string(args[2]);
     } else {
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
     }
 
     return new_state;
@@ -263,7 +263,7 @@ class DummyCli {
       ASSIGN_OR_RETURN(*new_state.mutable_flow_programming_exception_alarm(),
                        ParseAlarm(alarm_args));
     } else {
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
     }
 
     return new_state;
@@ -278,7 +278,7 @@ class DummyCli {
       ASSIGN_OR_RETURN(*new_state.mutable_port_qos_counters(),
                        ParsePortQosCounters(port_queue_args));
     } else {
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
     }
 
     return new_state;
@@ -328,7 +328,7 @@ class DummyCli {
       ASSIGN_OR_RETURN(*req.mutable_state_update(),
                        ParsePortQueueNodeStates(args));
     } else {
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid state " << state << ".";
     }
 
     return req;

--- a/stratum/hal/bin/np4intel/main.cc
+++ b/stratum/hal/bin/np4intel/main.cc
@@ -102,7 +102,7 @@ void registerDeviceMgrLogger() {
 
     // Now log the return code message
     if (rc != 0) {
-      RETURN_ERROR(ERR_INTERNAL) << "DPDK EAL Init failed";
+      return MAKE_ERROR(ERR_INTERNAL) << "DPDK EAL Init failed";
     }
     LOG(INFO) << "DPDK EAL Init successful";
   }

--- a/stratum/hal/config/chassis_config_migrator.cc
+++ b/stratum/hal/config/chassis_config_migrator.cc
@@ -72,8 +72,8 @@ ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
   RETURN_IF_ERROR(ReadProtoFromTextFile(FLAGS_chassis_config_file, &config));
   if (config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO &&
       config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO2) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Chassis config is not for a Tofino platform";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Chassis config is not for a Tofino platform";
   }
   for (auto& singleton_port : *config.mutable_singleton_ports()) {
     RETURN_IF_ERROR(MigrateSingletonPort(&singleton_port));

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -95,14 +95,14 @@ BfChassisManager::~BfChassisManager() = default;
 
   const auto& config_params = singleton_port.config_params();
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   RETURN_IF_ERROR(bf_sde_interface_->AddPort(device, sdk_port_id,
@@ -168,9 +168,9 @@ BfChassisManager::~BfChassisManager() = default;
     config->admin_state = ADMIN_STATE_UNKNOWN;
     config->speed_bps.reset();
     config->fec_mode.reset();
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Port " << port_id << " in node " << node_id << " is not valid"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Port " << port_id << " in node " << node_id << " is not valid"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   const auto& config_params = singleton_port.config_params();
@@ -197,29 +197,29 @@ BfChassisManager::~BfChassisManager() = default;
       if (config_old.fec_mode)
         port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
       AddPortHelper(node_id, device, sdk_port_id, port_old, config);
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Could not add port " << port_id << " with new speed "
-          << singleton_port.speed_bps() << " to BF SDE"
-          << " (SDK Port " << sdk_port_id << ").";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Could not add port " << port_id << " with new speed "
+             << singleton_port.speed_bps() << " to BF SDE"
+             << " (SDK Port " << sdk_port_id << ").";
     }
   }
   // same for FEC mode
   if (config_params.fec_mode() != config_old.fec_mode) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "The FEC mode for port " << port_id << " in node " << node_id
-        << " has changed; you need to delete the port and add it again"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "The FEC mode for port " << port_id << " in node " << node_id
+           << " has changed; you need to delete the port and add it again"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   bool config_changed = false;
@@ -327,9 +327,9 @@ BfChassisManager::~BfChassisManager() = default;
 
     auto* device = gtl::FindOrNull(node_id_to_device, node_id);
     if (device == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid ChassisConfig, unknown node id " << node_id
-          << " for port " << port_id << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid ChassisConfig, unknown node id " << node_id
+             << " for port " << port_id << ".";
     }
     // Reset port state to unknown, we'll update it on the first port status
     // event or when requested.
@@ -413,9 +413,9 @@ BfChassisManager::~BfChassisManager() = default;
       // sanity-check: if admin_state is not ADMIN_STATE_UNKNOWN, then the port
       // was added and the speed_bps was set.
       if (!old_port_config->speed_bps) {
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Invalid internal state in BfChassisManager, "
-            << "speed_bps field should contain a value";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Invalid internal state in BfChassisManager, speed_bps field "
+                  "should contain a value";
       }
 
       // if anything fails, port_config.admin_state will be set to
@@ -480,9 +480,9 @@ BfChassisManager::~BfChassisManager() = default;
             break;
           }
           default:
-            RETURN_ERROR(ERR_INVALID_PARAM)
-                << "Unsupported port type in DropTarget "
-                << drop_target.ShortDebugString();
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+                   << "Unsupported port type in DropTarget "
+                   << drop_target.ShortDebugString();
         }
         RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(
             device, sdk_port_id, drop_target.queue()));
@@ -518,9 +518,9 @@ BfChassisManager::~BfChassisManager() = default;
             break;
           }
           default:
-            RETURN_ERROR(ERR_INVALID_PARAM)
-                << "Unsupported port type in PpgConfig "
-                << ppg_config.ShortDebugString() << ".";
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+                   << "Unsupported port type in PpgConfig "
+                   << ppg_config.ShortDebugString() << ".";
         }
       }
       for (auto& queue_config : *qos_config.mutable_queue_configs()) {
@@ -541,9 +541,9 @@ BfChassisManager::~BfChassisManager() = default;
             break;
           }
           default:
-            RETURN_ERROR(ERR_INVALID_PARAM)
-                << "Unsupported port type in QueueConfig "
-                << queue_config.ShortDebugString() << ".";
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+                   << "Unsupported port type in QueueConfig "
+                   << queue_config.ShortDebugString() << ".";
         }
       }
       const int device = node_id_to_device[node_id];
@@ -617,9 +617,9 @@ BfChassisManager::~BfChassisManager() = default;
           shaping_config.byte_shaping().rate_bps()));
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid port shaping config " << shaping_config.ShortDebugString()
-          << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid port shaping config "
+             << shaping_config.ShortDebugString() << ".";
   }
   RETURN_IF_ERROR(bf_sde_interface_->EnablePortShaping(device, sdk_port_id,
                                                        TRI_STATE_TRUE));
@@ -771,9 +771,9 @@ BfChassisManager::~BfChassisManager() = default;
             break;
           }
           default:
-            RETURN_ERROR(ERR_INVALID_PARAM)
-                << "Unsupported port type in QueueConfig "
-                << queue_config.ShortDebugString() << ".";
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+                   << "Unsupported port type in QueueConfig "
+                   << queue_config.ShortDebugString() << ".";
         }
         CHECK_RETURN_IF_FALSE(
             gtl::FindOrNull(node_id_to_sdk_port_id_to_port_id[node_id],
@@ -798,17 +798,17 @@ BfChassisManager::~BfChassisManager() = default;
   if (initialized_) {
     if (node_id_to_port_id_to_singleton_port_key !=
         node_id_to_port_id_to_singleton_port_key_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in the port layout. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+                "pushed config requires a change in the port layout. The stack "
+                "needs to be rebooted to finish config push.";
     }
 
     if (node_id_to_device != node_id_to_device_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in node_id_to_device. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+                "pushed config requires a change in node_id_to_device. The "
+                "stack needs to be rebooted to finish config push.";
     }
   }
 
@@ -987,7 +987,7 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       break;
     }
     default:
-      RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";
   }
   return resp;
 }
@@ -1075,14 +1075,14 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     }
 
     if (!config.speed_bps) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in BfChassisManager, "
-          << "speed_bps field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in BfChassisManager, speed_bps field "
+                "should contain a value";
     }
     if (!config.fec_mode) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in BfChassisManager, "
-          << "fec_mode field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in BfChassisManager, fec_mode field "
+                "should contain a value";
     }
 
     ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
@@ -1163,9 +1163,9 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported port type in DropTarget "
-            << drop_target.ShortDebugString();
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported port type in DropTarget "
+               << drop_target.ShortDebugString();
     }
 
     RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(

--- a/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
@@ -39,7 +39,8 @@ std::string Uint32ToLeByteStream(uint32 val) {
     return util::OkStatus();
   }
 
-  RETURN_ERROR(ERR_INVALID_PARAM) << "Unknown format for p4_device_config.";
+  return MAKE_ERROR(ERR_INVALID_PARAM)
+         << "Unknown format for p4_device_config.";
 }
 
 ::util::Status BfPipelineConfigToPiConfig(const BfPipelineConfig& bf_config,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -139,8 +139,8 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unknown key_type: " << static_cast<int>(key_type) << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unknown key_type: " << static_cast<int>(key_type) << ".";
     }
 
     absl::StrAppend(&s, field_name, " { field_id: ", field_id,
@@ -225,8 +225,8 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unknown data_type: " << static_cast<int>(data_type) << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unknown data_type: " << static_cast<int>(data_type) << ".";
     }
 
     absl::StrAppend(&s, field_name, " { field_id: ", field_id,
@@ -796,8 +796,8 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   bool is_active;
   RETURN_IF_BFRT_ERROR(table_data_->isActive(field_id, &is_active));
   if (!is_active) {
-    RETURN_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
-        << "Field $ACTION_MEMBER_ID is not active.";
+    return MAKE_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
+           << "Field $ACTION_MEMBER_ID is not active.";
   }
   RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, action_member_id));
 
@@ -828,8 +828,8 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   bool is_active;
   RETURN_IF_BFRT_ERROR(table_data_->isActive(field_id, &is_active));
   if (!is_active) {
-    RETURN_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
-        << "Field $SELECTOR_GROUP_ID is not active.";
+    return MAKE_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
+           << "Field $SELECTOR_GROUP_ID is not active.";
   }
   RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, selector_group_id));
 
@@ -989,7 +989,7 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     case kHundredGigBps:
       return BF_SPEED_100G;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
   }
 }
 
@@ -1002,7 +1002,7 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     case TRI_STATE_FALSE:
       return 2;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
   }
 }
 
@@ -1014,7 +1014,8 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     // we have to "guess" the FEC type to use based on the port speed.
     switch (speed_bps) {
       case kOneGigBps:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode for 1Gbps mode.";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Invalid FEC mode for 1Gbps mode.";
       case kTenGigBps:
       case kFortyGigBps:
         return BF_FEC_TYP_FIRECODE;
@@ -1025,10 +1026,10 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
       case kFourHundredGigBps:
         return BF_FEC_TYP_REED_SOLOMON;
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
+        return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
     }
   }
-  RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode.";
+  return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode.";
 }
 
 ::util::StatusOr<bf_loopback_mode_e> LoopbackModeToBf(
@@ -1039,9 +1040,9 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     case LOOPBACK_STATE_MAC:
       return BF_LPBK_MAC_NEAR;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Unsupported loopback mode: " << LoopbackState_Name(loopback_mode)
-          << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported loopback mode: "
+             << LoopbackState_Name(loopback_mode) << ".";
   }
 }
 
@@ -1194,7 +1195,7 @@ namespace {
     case TofinoConfig::TofinoQosConfig::EGRESS_APP_POOL_3:
       return BF_TM_EG_APP_POOL_3;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid pool " << pool;
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid pool " << pool;
   }
 }
 
@@ -1222,7 +1223,7 @@ namespace {
     case TofinoConfig::TofinoQosConfig::DISABLE_BAF:
       return BF_TM_PPG_BAF_DISABLE;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid baf " << baf;
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid baf " << baf;
   }
 }
 
@@ -1250,7 +1251,7 @@ namespace {
     case TofinoConfig::TofinoQosConfig::DISABLE_BAF:
       return BF_TM_Q_BAF_DISABLE;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid baf " << baf;
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid baf " << baf;
   }
 }
 
@@ -1274,7 +1275,7 @@ namespace {
     case TofinoConfig::TofinoQosConfig::PRIO_7:
       return BF_TM_SCH_PRIO_7;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid priority " << priority;
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid priority " << priority;
   }
 }
 
@@ -1301,7 +1302,8 @@ namespace {
     case TofinoConfig::TofinoQosConfig::UNKNOWN_LIMIT:
       return BF_TM_Q_COLOR_LIMIT_75_PERCENT;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid color limit " << color_limit;
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid color limit " << color_limit;
   }
 }
 
@@ -1351,8 +1353,9 @@ namespace {
         break;
       case TofinoConfig::TofinoQosConfig::PpgConfig::kPort:
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port type in PpgConfig "
-                                        << ppg_config.ShortDebugString() << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported port type in PpgConfig "
+               << ppg_config.ShortDebugString() << ".";
     }
     bf_tm_ppg_hdl ppg;
     if (ppg_config.is_default_ppg()) {
@@ -1384,9 +1387,9 @@ namespace {
         break;
       case TofinoConfig::TofinoQosConfig::QueueConfig::kPort:
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported port type in QueueConfig "
-            << queue_config.ShortDebugString() << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported port type in QueueConfig "
+               << queue_config.ShortDebugString() << ".";
     }
     for (const auto& queue_mapping : queue_config.queue_mapping()) {
       // Set gmin only when > 0, as it would otherwise disable the queue.
@@ -1436,9 +1439,9 @@ namespace {
               device, sdk_port, queue_mapping.queue_id()));
           break;
         default:
-          RETURN_ERROR(ERR_INVALID_PARAM)
-              << "Invalid queue maximum rate config in QueueMapping "
-              << queue_mapping.ShortDebugString() << ".";
+          return MAKE_ERROR(ERR_INVALID_PARAM)
+                 << "Invalid queue maximum rate config in QueueMapping "
+                 << queue_mapping.ShortDebugString() << ".";
       }
       // Set guaranteed minimum rate on queue, if requested.
       switch (queue_mapping.min_rate_case()) {
@@ -1467,9 +1470,9 @@ namespace {
               device, sdk_port, queue_mapping.queue_id()));
           break;
         default:
-          RETURN_ERROR(ERR_INVALID_PARAM)
-              << "Invalid queue guaranteed minimum rate config in QueueMapping "
-              << queue_mapping.ShortDebugString() << ".";
+          return MAKE_ERROR(ERR_INVALID_PARAM)
+                 << "Invalid queue guaranteed minimum rate config in "
+                 << "QueueMapping " << queue_mapping.ShortDebugString() << ".";
       }
       if (queue_mapping.enable_color_drop()) {
         RETURN_IF_BFRT_ERROR(
@@ -1510,7 +1513,7 @@ namespace {
 
 ::util::Status BfSdeWrapper::SetPortMtu(int device, int port, int32 mtu) {
   if (mtu < 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
   }
   if (mtu == 0) mtu = kBfDefaultMtu;
   RETURN_IF_BFRT_ERROR(bf_pal_port_mtu_set(
@@ -2121,7 +2124,7 @@ namespace {
     }
   }
 
-  RETURN_ERROR(ERR_TABLE_FULL) << "Could not find free multicast node id.";
+  return MAKE_ERROR(ERR_TABLE_FULL) << "Could not find free multicast node id.";
 }
 
 ::util::StatusOr<uint32> BfSdeWrapper::CreateMulticastNode(
@@ -2709,7 +2712,7 @@ namespace {
     }
   }
 
-  RETURN_ERROR(ERR_INTERNAL) << "Could not find register data field id.";
+  return MAKE_ERROR(ERR_INTERNAL) << "Could not find register data field id.";
 }
 }  // namespace
 
@@ -2833,9 +2836,10 @@ namespace {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported register data type " << static_cast<int>(data_type)
-            << " for register in table " << table_id;
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported register data type "
+               << static_cast<int>(data_type) << " for register in table "
+               << table_id;
     }
   }
 
@@ -3000,9 +3004,9 @@ namespace {
         RETURN_IF_BFRT_ERROR(table_data->getValue(field_id, &pburst));
         pbursts->push_back(pburst);
       } else {
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unknown meter field " << field_name << " in meter with id "
-            << table_id << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unknown meter field " << field_name << " in meter with id "
+               << table_id << ".";
       }
     }
   }

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -314,7 +314,8 @@ std::unique_ptr<BfSwitch> BfSwitch::CreateInstance(
 ::util::StatusOr<PINode*> BfSwitch::GetPINodeFromDevice(int device) const {
   PINode* pi_node = gtl::FindPtrOrNull(device_to_pi_node_, device);
   if (pi_node == nullptr) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Device " << device << " is unknown.";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Device " << device << " is unknown.";
   }
   return pi_node;
 }

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -399,8 +399,9 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
       return bfrt_packetio_manager_->TransmitPacket(req.packet());
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "
-                                      << req.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported StreamMessageRequest " << req.ShortDebugString()
+             << ".";
   }
 }
 
@@ -425,8 +426,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
                                                           act_prof_group);
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported extern entry: " << entry.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported extern entry: " << entry.ShortDebugString() << ".";
   }
 }
 
@@ -452,8 +453,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
           session, act_prof_group, writer);
     }
     default:
-      RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
-          << "Unsupported extern entry: " << entry.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+             << "Unsupported extern entry: " << entry.ShortDebugString() << ".";
   }
 }
 

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -76,9 +76,9 @@ std::unique_ptr<BfrtPacketioManager> BfrtPacketioManager::CreateInstance(
         int ret = pthread_create(&sde_rx_thread_id_, nullptr,
                                  &BfrtPacketioManager::SdeRxThreadFunc, this);
         if (ret != 0) {
-          RETURN_ERROR(ERR_INTERNAL)
-              << "Failed to spawn RX thread for SDE wrapper for device with ID "
-              << device_ << ". Err: " << ret << ".";
+          return MAKE_ERROR(ERR_INTERNAL) << "Failed to spawn RX thread for "
+                                             "SDE wrapper for device with ID "
+                                          << device_ << ". Err: " << ret << ".";
         }
       }
       RETURN_IF_ERROR(bf_sde_interface_->RegisterPacketReceiveWriter(
@@ -292,7 +292,8 @@ class BitBuffer {
     const ::p4::v1::PacketOut& packet) {
   {
     absl::ReaderMutexLock l(&data_lock_);
-    if (!initialized_) RETURN_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    if (!initialized_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
   }
   std::string buf;
   RETURN_IF_ERROR(DeparsePacketOut(packet, &buf));
@@ -307,7 +308,8 @@ class BitBuffer {
   std::unique_ptr<ChannelReader<std::string>> reader;
   {
     absl::ReaderMutexLock l(&data_lock_);
-    if (!initialized_) RETURN_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    if (!initialized_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
     reader = ChannelReader<std::string>::Create(packet_receive_channel_);
   }
 

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
@@ -41,8 +41,8 @@ BfrtPreManager::~BfrtPreManager() = default;
     case PreEntry::kCloneSessionEntry:
       return WriteCloneSessionEntry(session, type, entry.clone_session_entry());
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported PRE entry: " << entry.ShortDebugString();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported PRE entry: " << entry.ShortDebugString();
   }
 }
 
@@ -62,8 +62,8 @@ BfrtPreManager::~BfrtPreManager() = default;
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported PRE entry: " << entry.ShortDebugString();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported PRE entry: " << entry.ShortDebugString();
   }
 
   return ::util::OkStatus();
@@ -158,7 +158,8 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported update type: " << type;
   }
   return ::util::OkStatus();
 }
@@ -276,9 +277,9 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported update type: " << type << " on CloneSessionEntry "
-          << entry.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported update type: " << type << " on CloneSessionEntry "
+             << entry.ShortDebugString() << ".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -357,8 +357,9 @@ BcmNode::~BcmNode() {}
           GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, req.packet());
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "
-                                      << req.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported StreamMessageRequest " << req.ShortDebugString()
+             << ".";
   }
 }
 

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -68,9 +68,9 @@ namespace {
   auto bm_status = dev_mgr->port_add(
       iface_name, static_cast<bm::PortMonitorIface::port_t>(port_id), {});
   if (bm_status != bm::DevMgrIface::ReturnCode::SUCCESS) {
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Error when binding port " << port_id << " to interface "
-        << iface_name << " in node " << node_id << ".";
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Error when binding port " << port_id << " to interface "
+           << iface_name << " in node " << node_id << ".";
   }
   return ::util::OkStatus();
 }
@@ -82,8 +82,8 @@ namespace {
   auto bm_status =
       dev_mgr->port_remove(static_cast<bm::PortMonitorIface::port_t>(port_id));
   if (bm_status != bm::DevMgrIface::ReturnCode::SUCCESS) {
-    RETURN_ERROR(ERR_INTERNAL) << "Error when removing port " << port_id
-                               << " from node " << node_id << ".";
+    return MAKE_ERROR(ERR_INTERNAL) << "Error when removing port " << port_id
+                                    << " from node " << node_id << ".";
   }
   return ::util::OkStatus();
 }
@@ -312,7 +312,7 @@ namespace {
       break;
     }
     default:
-      RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";
   }
   return resp;
 }

--- a/stratum/hal/lib/common/admin_utils.cc
+++ b/stratum/hal/lib/common/admin_utils.cc
@@ -353,8 +353,8 @@ std::string FileSystemHelper::GetHashSum(
   // Return failure if reboot was not successful
   if (reboot_return_val != 0) {
     LOG(ERROR) << "Failed to reboot the system: " << strerror(errno);
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Failed to reboot the system: " << strerror(errno);
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Failed to reboot the system: " << strerror(errno);
   }
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/common/openconfig_converter.cc
+++ b/stratum/hal/lib/common/openconfig_converter.cc
@@ -327,8 +327,8 @@ SingletonPortToInterfaces(const SingletonPort& in) {
           OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_100GB);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "unknown 'speed_bps' " << in.ShortDebugString();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "unknown 'speed_bps' " << in.ShortDebugString();
   }
 
   // SingletonPort.config_params.admin_state
@@ -403,7 +403,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
           OPENCONFIGIFAGGREGATEAGGREGATIONTYPE_STATIC);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "unknown trunk type " << in.type();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "unknown trunk type " << in.type();
   }
 
   std::map<int64, std::string> id_to_name;
@@ -414,8 +415,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
   for (int64 member_id : in.members()) {
     std::string* name = gtl::FindOrNull(id_to_name, member_id);
     if (name == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "unknown 'members' " << in.ShortDebugString();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "unknown 'members' " << in.ShortDebugString();
     }
 
     auto member = trunk->mutable_aggregation()->add_member();
@@ -689,8 +690,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
   }
 
   if (!if_component_key.has_component()) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Cannot find component for interface " << interface_key.name();
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Cannot find component for interface " << interface_key.name();
   }
 
   const auto& if_component = if_component_key.component();
@@ -725,8 +726,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
       to.set_speed_bps(kHundredGigBps);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid interface speed " << interface.ethernet().port_speed();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid interface speed " << interface.ethernet().port_speed();
   }
 
   auto config_params = to.mutable_config_params();

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -451,8 +451,8 @@ uint64 ConvertMHzToHz(const uint64& val) { return val * 1000000; }
     logging_config->first = "0";
     logging_config->second = "2";
   } else {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid severity string \"" << severity_string << "\".";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid severity string \"" << severity_string << "\".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -269,7 +269,7 @@ namespace {
       resp.mutable_sdn_port_id()->set_port_id(request.sdn_port_id().port_id());
       break;
     default:
-      RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";
   }
   return resp;
 }

--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -240,7 +240,7 @@ P4InfoManager::FindRegisterByName(const std::string& register_name) const {
           bit_width = type_spec.bitstring().varbit().max_bitwidth();
           break;
         default:
-          RETURN_ERROR(ERR_UNIMPLEMENTED) << "Not implemented.";
+          return MAKE_ERROR(ERR_UNIMPLEMENTED) << "Not implemented.";
       }
       CHECK_RETURN_IF_FALSE(data.bitstring().size() * 8 <= bit_width);
       break;
@@ -258,9 +258,9 @@ P4InfoManager::FindRegisterByName(const std::string& register_name) const {
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "P4data type " << data.data_case() << " in P4Data "
-          << data.ShortDebugString() << " is not supported.";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "P4data type " << data.data_case() << " in P4Data "
+             << data.ShortDebugString() << " is not supported.";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/p4/p4_table_mapper.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper.cc
@@ -692,10 +692,10 @@ std::string P4TableMapper::GetMapperNameKey(
   auto convert_iter = field_convert_by_table_.find(key);
   if (convert_iter == field_convert_by_table_.end()) {
     // No way to decode fields that don't go with the table.
-    RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
-        << "P4 TableEntry match field ID "
-        << PrintP4ObjectID(match_field.field_id())
-        << " is not recognized in table " << table_p4_info.preamble().name();
+    return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+           << "P4 TableEntry match field ID "
+           << PrintP4ObjectID(match_field.field_id())
+           << " is not recognized in table " << table_p4_info.preamble().name();
   }
 
   const auto& conversion_value = convert_iter->second;

--- a/stratum/hal/lib/phal/datasource.cc
+++ b/stratum/hal/lib/phal/datasource.cc
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/hal/lib/phal/datasource.h"
 
-#include "stratum/glue/status/status.h"
 #include "absl/memory/memory.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "stratum/glue/status/status.h"
 
 namespace stratum {
 namespace hal {
@@ -44,9 +43,7 @@ bool TimedCache::CacheHasExpired() {
   return time - last_cache_time_ > cache_duration_ || time < last_cache_time_;
 }
 
-void TimedCache::CacheUpdated() {
-  last_cache_time_ = absl::Now();
-}
+void TimedCache::CacheUpdated() { last_cache_time_ = absl::Now(); }
 
 FetchOnce::FetchOnce() : should_update_(true) {}
 
@@ -57,25 +54,23 @@ void FetchOnce::CacheUpdated() { should_update_ = false; }
 // Create a new CachePolicy instance
 // note: is passed to DataSource who then manages the deletion
 ::util::StatusOr<CachePolicy*> CachePolicyFactory::CreateInstance(
-    CachePolicyConfig::CachePolicyType cache_type,
-    int32 timed_cache_value) {
-
-    switch (cache_type) {
+    CachePolicyConfig::CachePolicyType cache_type, int32 timed_cache_value) {
+  switch (cache_type) {
     case CachePolicyConfig::NEVER_UPDATE:
-        return new NeverUpdate();
+      return new NeverUpdate();
 
     case CachePolicyConfig::FETCH_ONCE:
-        return new FetchOnce();
+      return new FetchOnce();
 
     case CachePolicyConfig::TIMED_CACHE:
-        return new TimedCache(absl::Seconds(timed_cache_value));
+      return new TimedCache(absl::Seconds(timed_cache_value));
 
     case CachePolicyConfig::NO_CACHE:
-        return new NoCache();
+      return new NoCache();
 
     default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "invalid cache type";
-    }
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "invalid cache type";
+  }
 }
 
 }  // namespace phal

--- a/stratum/hal/lib/phal/onlp/onlp_fan_datasource.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_fan_datasource.cc
@@ -107,7 +107,7 @@ OnlpFanDataSource::OnlpFanDataSource(int fan_id, OnlpInterface* onlp_interface,
   // to squeeze a double into an 'int', with an error if
   // it doesn't fit.
   if (val > SHRT_MAX) {
-    RETURN_ERROR() << "Set Fan RPM bigger than an integer";
+    return MAKE_ERROR() << "Set Fan RPM bigger than an integer";
   }
   int onlp_val = static_cast<int>(val);
   return onlp_stub_->SetFanRpm(fan_oid_, onlp_val);

--- a/stratum/hal/lib/phal/onlp/onlp_sfp_configurator.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_sfp_configurator.cc
@@ -66,7 +66,7 @@ OnlpSfpConfigurator::Make(std::shared_ptr<OnlpSfpDataSource> datasource,
       break;
 
     default:
-      RETURN_ERROR() << "Unknown SFP event state " << state << ".";
+      return MAKE_ERROR() << "Unknown SFP event state " << state << ".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/phal/optics_adapter.cc
+++ b/stratum/hal/lib/phal/optics_adapter.cc
@@ -20,18 +20,15 @@ OpticsAdapter::OpticsAdapter(AttributeDatabaseInterface* attribute_db_interface)
 
 // PhalDb is 0-based indexed, while arguments are 1-based.
 ::util::Status OpticsAdapter::GetOpticalTransceiverInfo(
-    int module, int network_interface,
-    OpticalTransceiverInfo* ot_info) {
+    int module, int network_interface, OpticalTransceiverInfo* ot_info) {
   if (module <= 0 || network_interface <= 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
   }
 
-  std::vector<Path> paths = {
-    {
+  std::vector<Path> paths = {{
       PathEntry("optical_modules", module - 1),
       PathEntry("network_interfaces", network_interface - 1, true, false, true),
-    }
-  };
+  }};
 
   ASSIGN_OR_RETURN(auto phaldb, Get(paths));
 
@@ -40,8 +37,8 @@ OpticsAdapter::OpticsAdapter(AttributeDatabaseInterface* attribute_db_interface)
 
   auto optical_module = phaldb->optical_modules(module - 1);
 
-  CHECK_RETURN_IF_FALSE(
-      optical_module.network_interfaces_size() > network_interface - 1)
+  CHECK_RETURN_IF_FALSE(optical_module.network_interfaces_size() >
+                        network_interface - 1)
       << "optical port in port " << network_interface - 1 << " not found";
 
   auto optical_port = optical_module.network_interfaces(network_interface - 1);
@@ -56,10 +53,9 @@ OpticsAdapter::OpticsAdapter(AttributeDatabaseInterface* attribute_db_interface)
 }
 
 ::util::Status OpticsAdapter::SetOpticalTransceiverInfo(
-    int module, int network_interface,
-    const OpticalTransceiverInfo& ot_info) {
+    int module, int network_interface, const OpticalTransceiverInfo& ot_info) {
   if (module <= 0 || network_interface <= 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
   }
 
   AttributeValueMap attrs;

--- a/stratum/hal/lib/phal/phaldb_service.cc
+++ b/stratum/hal/lib/phal/phaldb_service.cc
@@ -63,7 +63,7 @@ namespace {
 ::util::StatusOr<Path> ToPhalDBPath(PathQuery req_path) {
   // If no path entries return error
   if (req_path.entries_size() == 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "No Path";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "No Path";
   }
 
   // Create Attribute DB Path

--- a/stratum/hal/lib/phal/sfp_adapter.cc
+++ b/stratum/hal/lib/phal/sfp_adapter.cc
@@ -32,7 +32,7 @@ SfpAdapter::~SfpAdapter() {
 ::util::Status SfpAdapter::GetFrontPanelPortInfo(
     int card_id, int port_id, FrontPanelPortInfo* fp_port_info) {
   if (card_id <= 0 || port_id <= 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
   }
 
   std::vector<Path> paths = {
@@ -59,8 +59,8 @@ SfpAdapter::~SfpAdapter() {
 
   // Get the SFP (transceiver)
   if (!phal_port.has_transceiver()) {
-    RETURN_ERROR() << "cards[" << card_id << "]/ports[" << port_id
-                   << "] has no transceiver";
+    return MAKE_ERROR() << "cards[" << card_id << "]/ports[" << port_id
+                        << "] has no transceiver";
   }
   auto sfp = phal_port.transceiver();
 
@@ -83,7 +83,7 @@ SfpAdapter::~SfpAdapter() {
       actual_val = PHYSICAL_PORT_TYPE_QSFP_CAGE;
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid sfptype. ";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid sfptype. ";
   }
   fp_port_info->set_physical_port_type(actual_val);
 

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -148,7 +148,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
+    return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
   CHECK_RETURN_IF_FALSE(results != nullptr)
@@ -164,7 +164,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     std::vector<::util::Status>* details) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
+    return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
@@ -196,7 +196,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
+    return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   return toUtilStatus(device_mgr_->stream_message_request_handle(request));
 }

--- a/stratum/hal/stub/embedded/main.cc
+++ b/stratum/hal/stub/embedded/main.cc
@@ -724,7 +724,7 @@ ABSL_CONST_INIT absl::Mutex HalServiceClient::lock_(absl::kConstInit);
   } else if (FLAGS_start_gnmi_subscription_session) {
     client.StartGnmiSubscriptionSession();
   } else {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid command.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid command.";
   }
 
   return ::util::OkStatus();

--- a/stratum/lib/security/certificate.cc
+++ b/stratum/lib/security/certificate.cc
@@ -38,8 +38,8 @@ util::StatusOr<std::string> GetRSAPrivateKeyAsString(EVP_PKEY* pkey) {
     return std::string(mem->data, mem->length);
   }
 
-  RETURN_ERROR(ERR_INVALID_PARAM)
-      << "Failed to write private key in PEM format.";
+  return MAKE_ERROR(ERR_INVALID_PARAM)
+         << "Failed to write private key in PEM format.";
 }
 
 util::StatusOr<std::string> GetCertAsString(X509* x509) {
@@ -55,8 +55,8 @@ util::StatusOr<std::string> GetCertAsString(X509* x509) {
     return std::string(mem->data, mem->length);
   }
 
-  RETURN_ERROR(ERR_INVALID_PARAM)
-      << "Failed to write certificate in PEM format.";
+  return MAKE_ERROR(ERR_INVALID_PARAM)
+         << "Failed to write certificate in PEM format.";
 }
 
 util::Status GenerateRSAKeyPair(EVP_PKEY* evp, int bits) {
@@ -69,7 +69,7 @@ util::Status GenerateRSAKeyPair(EVP_PKEY* evp, int bits) {
   // It will be freed when EVP is freed, so only free on failure.
   if (!EVP_PKEY_assign_RSA(evp, rsa)) {
     RSA_free(rsa);
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Failed to assign key.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Failed to assign key.";
   }
 
   return util::OkStatus();

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -222,7 +222,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   stratum::InitStratumLogging();
   if (argc < 2) {
     std::cout << kUsage << std::endl;
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid number of arguments.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid number of arguments.";
   }
 
   ::grpc::ClientContext ctx;
@@ -280,8 +280,8 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   }
 
   if (argc < 3) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Missing path for " << cmd << " request.";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Missing path for " << cmd << " request.";
   }
   std::string path = std::string(argv[2]);
 
@@ -327,7 +327,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
     }
     RETURN_IF_GRPC_ERROR(stream_reader_writer->Finish());
   } else {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Unknown command: " << cmd;
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Unknown command: " << cmd;
   }
   LOG(INFO) << "Done.";
 

--- a/stratum/tools/stratum_replay/stratum_replay.cc
+++ b/stratum/tools/stratum_replay/stratum_replay.cc
@@ -53,7 +53,7 @@ using ClientStreamChannelReaderWriter =
 ::util::Status Main(int argc, char** argv) {
   if (argc < 2) {
     LOG(INFO) << kUsage;
-    RETURN_ERROR(ERR_INVALID_PARAM).without_logging() << "";
+    return MAKE_ERROR(ERR_INVALID_PARAM).without_logging() << "";
   }
 
   // Initialize the gRPC channel and P4Runtime service stub
@@ -102,9 +102,9 @@ using ClientStreamChannelReaderWriter =
   std::unique_ptr<ClientStreamChannelReaderWriter> stream =
       stub->StreamChannel(&context);
   if (!stream->Write(stream_req)) {
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Failed to send request '" << stream_req.ShortDebugString()
-        << "' to switch.";
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Failed to send request '" << stream_req.ShortDebugString()
+           << "' to switch.";
   }
 
   // Push the given pipeline config.


### PR DESCRIPTION
This PR replaces the usage of `RETURN_ERROR()` with `return MAKE_ERROR()`. `RETURN_ERROR` seems to be part of an older style of error handling that has not been present in the original Google code drop, other recent Google projects or Abseil. In Stratum, only contributed code reintroduced the macro into code. Replacement is automated and should not change any logic or program behavior.
This change also brings us closer to the Abseil style:
```c++
  // encounter error
  if (error condition) {
    return absl::InvalidArgumentError("bad mode");
  }
```