### PR TITLE
[SDFAB-920] Upport P4Runtime translation for PRE

### DIFF
--- a/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.cc
+++ b/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.cc
@@ -490,11 +490,44 @@ P4RuntimeBfrtTranslator::TranslateRegisterEntry(
   // TODO(Yi Tseng): Will support this in another PR.
   return entry;
 }
+
+::util::StatusOr<::p4::v1::Replica> P4RuntimeBfrtTranslator::TranslateReplica(const ::p4::v1::Replica& replica, bool to_sdk) {
+  ::p4::v1::Replica translated_replica(replica);
+  // Since we know we are always translating the port number, we can simply
+  // use the port map here.
+  if (to_sdk) {
+    CHECK_RETURN_IF_FALSE(singleton_port_to_sdk_port_.count(replica.egress_port()));
+    translated_replica.set_egress_port(singleton_port_to_sdk_port_[replica.egress_port()]);
+  } else {
+    CHECK_RETURN_IF_FALSE(sdk_port_to_singleton_port_.count(replica.egress_port()));
+    translated_replica.set_egress_port(sdk_port_to_singleton_port_[replica.egress_port()]);
+  }
+  return translated_replica;
+}
+
 ::util::StatusOr<::p4::v1::PacketReplicationEngineEntry>
 P4RuntimeBfrtTranslator::TranslatePacketReplicationEngineEntry(
     const ::p4::v1::PacketReplicationEngineEntry& entry, bool to_sdk) {
-  // TODO(Yi Tseng): Will support this in another PR.
-  return entry;
+  ::p4::v1::PacketReplicationEngineEntry translated_entry(entry);
+  switch (translated_entry.type_case()) {
+    case ::p4::v1::PacketReplicationEngineEntry::kMulticastGroupEntry: {
+      auto* multicast_group_entry = translated_entry.mutable_multicast_group_entry();
+      for (::p4::v1::Replica& replica : *multicast_group_entry->mutable_replicas()) {
+        ASSIGN_OR_RETURN(replica, TranslateReplica(replica, to_sdk));
+      }
+      break;
+    }
+    case ::p4::v1::PacketReplicationEngineEntry::kCloneSessionEntry: {
+      auto* clone_session_entry = translated_entry.mutable_clone_session_entry();
+      for (::p4::v1::Replica& replica : *clone_session_entry->mutable_replicas()) {
+        ASSIGN_OR_RETURN(replica, TranslateReplica(replica, to_sdk));
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return translated_entry;
 }
 
 ::util::StatusOr<::p4::v1::StreamMessageRequest>

--- a/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.h
+++ b/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.h
@@ -94,6 +94,7 @@ class P4RuntimeBfrtTranslator {
   TranslatePacketReplicationEngineEntry(
       const ::p4::v1::PacketReplicationEngineEntry& entry, bool to_sdk)
       SHARED_LOCKS_REQUIRED(lock_);
+  virtual ::util::StatusOr<::p4::v1::Replica> TranslateReplica(const ::p4::v1::Replica& replica, bool to_sdk) SHARED_LOCKS_REQUIRED(lock_);
   virtual ::util::StatusOr<std::string> TranslateValue(const std::string& value,
                                                        const std::string& uri,
                                                        bool to_sdk,


### PR DESCRIPTION
Add support P4Runtime translation for PRE entries.
Note that the translation logic doesn't depend on the P4Info since we we know we are always translating the port numbers.