### PR TITLE
Make Bf Pipeline Readme clearer on which pipeline formats are supported

### DIFF
--- a/stratum/hal/bin/barefoot/README.pipeline.md
+++ b/stratum/hal/bin/barefoot/README.pipeline.md
@@ -7,16 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 
 # P4Runtime p4_device_config formats
 
-Stratum supports a few different device configuration formats for pushing the P4
-pipeline over P4Runtime for Barefoot Tofino devices, including
-the older binary packing used by [PI](https://github.com/p4lang/PI)
-and a newer more flexible protobuf based format ([bf.proto](/stratum/hal/lib/barefoot/bf.proto)).
+Stratum-bfrt uses a protobuf based format ([bf.proto](/stratum/hal/lib/barefoot/bf.proto))
+to push a pipeline over P4Runtime for Barefoot Tofino devices. Use the
+`BfPipelineBuilder` tool to generate it.
 
-*Note: The older PI format does not work with `stratum_bfrt`.*
+For legacy reasons, Stratum-bf supports both the older binary packing used by
+[PI](https://github.com/p4lang/PI) and the new protobuf based format also
+supported in Stratum-bfrt.
 
 ## Stratum BfPipelineConfig format and the BfPipelineBuilder
 
-You can use the device config builder to generate the protobuf based format:
+You can use the device config builder to generate the protobuf based format
+directly from the `bf-p4c` compiler output:
 
 ```bash
 bazel run //stratum/hal/bin/barefoot:bf_pipeline_builder -- \

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -758,11 +758,10 @@ E20201207 20:44:53.612030 18416 error_buffer.cc:30] (p4_service.cc:422): Failed 
 
 This error occurs when the binary pipeline is not in the correct format.
 Make sure the pipeline config binary has been packed correctly for PI node, like
-so: [bf_pipeline_builder](stratum/hal/bin/barefoot/bf_pipeline_builder.cc).
-You cannot push the compiler output (e.g. `tofino.bin`) directly.
-
-Also, consider moving to the newer [protobuf](README.pipeline.md) based pipeline
-format.
+described in the [Bf Pipeline README](README.pipeline.md).
+You cannot push the compiler output (e.g. `tofino.bin`) directly. Also, consider
+moving to the newer [protobuf](/stratum/hal/lib/barefoot/bf.proto) based
+pipeline format.
 
 ### Checking the Switch or ASIC revision number
 


### PR DESCRIPTION
Some links where broken and Startum-bfrt is now the recommended version for Tofino.