### PR TITLE
[SDFAB-942] Support P4Runtime translation - PacketIO

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -287,7 +287,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   }
   ASSIGN_OR_RETURN(const auto& request,
                    p4runtime_bfrt_translator_->TranslateReadRequest(req));
-  P4RuntimeBfrtTranslationWriterWrapper writer_wrapper(
+  P4RuntimeBfrtTranslator::ReadResponseWriterWrapper writer_wrapper(
       writer, p4runtime_bfrt_translator_);
   writer = &writer_wrapper;
   ::p4::v1::ReadResponse resp;
@@ -390,10 +390,13 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
+  auto translator_wrapper = std::make_shared<
+      P4RuntimeBfrtTranslator::StreamMessageResponseWriterWrapper>(
+      writer, p4runtime_bfrt_translator_);
   auto packet_in_writer =
       std::make_shared<ProtoOneofWriterWrapper<::p4::v1::StreamMessageResponse,
                                                ::p4::v1::PacketIn>>(
-          writer, &::p4::v1::StreamMessageResponse::mutable_packet);
+          translator_wrapper, &::p4::v1::StreamMessageResponse::mutable_packet);
 
   return bfrt_packetio_manager_->RegisterPacketReceiveWriter(packet_in_writer);
 }

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -416,7 +416,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(const auto& translated_req,
+  ASSIGN_OR_RETURN(
+      const auto& translated_req,
       p4runtime_bfrt_translator_->TranslateStreamMessageRequest(req));
 
   switch (translated_req.update_case()) {
@@ -425,8 +426,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
     }
     default:
       return MAKE_ERROR(ERR_UNIMPLEMENTED)
-             << "Unsupported StreamMessageRequest " << translated_req.ShortDebugString()
-             << ".";
+             << "Unsupported StreamMessageRequest "
+             << translated_req.ShortDebugString() << ".";
   }
 }
 

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -416,14 +416,16 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
+  ASSIGN_OR_RETURN(const auto& translated_req,
+      p4runtime_bfrt_translator_->TranslateStreamMessageRequest(req));
 
-  switch (req.update_case()) {
+  switch (translated_req.update_case()) {
     case ::p4::v1::StreamMessageRequest::kPacket: {
-      return bfrt_packetio_manager_->TransmitPacket(req.packet());
+      return bfrt_packetio_manager_->TransmitPacket(translated_req.packet());
     }
     default:
       return MAKE_ERROR(ERR_UNIMPLEMENTED)
-             << "Unsupported StreamMessageRequest " << req.ShortDebugString()
+             << "Unsupported StreamMessageRequest " << translated_req.ShortDebugString()
              << ".";
   }
 }

--- a/stratum/hal/lib/barefoot/bfrt_node_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node_test.cc
@@ -130,8 +130,6 @@ class BfrtNodeTest : public ::testing::Test {
       EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
                   PushChassisConfig(EqualsProto(config), kNodeId))
           .WillOnce(Return(::util::OkStatus()));
-      EXPECT_CALL(*p4runtime_bfrt_translator_mock_, GetLowLevelP4INfo())
-          .WillOnce(Return(::util::StatusOr<::p4::config::v1::P4Info>(config)));
       // EXPECT_CALL(*bfrt_pre_manager_mock_,
       //             PushChassisConfig(EqualsProto(config), kNodeId))
       //     .WillOnce(Return(::util::OkStatus()));
@@ -153,6 +151,12 @@ class BfrtNodeTest : public ::testing::Test {
           .WillOnce(Return(::util::OkStatus()));
       EXPECT_CALL(*bf_sde_mock_, AddDevice(kDeviceId, _))
           .WillOnce(Return(::util::OkStatus()));
+      EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
+                  PushForwardingPipelineConfig(_))
+          .WillOnce(Return(::util::OkStatus()));
+      EXPECT_CALL(*p4runtime_bfrt_translator_mock_, GetLowLevelP4Info())
+          .WillOnce(Return(
+              ::util::StatusOr<::p4::config::v1::P4Info>(config.p4info())));
       EXPECT_CALL(*bfrt_packetio_manager_mock_, PushForwardingPipelineConfig(_))
           .WillOnce(Return(::util::OkStatus()));
       EXPECT_CALL(*bfrt_table_manager_mock_, PushForwardingPipelineConfig(_))
@@ -160,9 +164,6 @@ class BfrtNodeTest : public ::testing::Test {
       EXPECT_CALL(*bfrt_pre_manager_mock_, PushForwardingPipelineConfig(_))
           .WillOnce(Return(::util::OkStatus()));
       EXPECT_CALL(*bfrt_counter_manager_mock_, PushForwardingPipelineConfig(_))
-          .WillOnce(Return(::util::OkStatus()));
-      EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
-                  PushForwardingPipelineConfig(_))
           .WillOnce(Return(::util::OkStatus()));
     }
     EXPECT_OK(PushForwardingPipelineConfig(config));

--- a/stratum/hal/lib/barefoot/bfrt_node_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node_test.cc
@@ -1507,6 +1507,11 @@ TEST_F(BfrtNodeTest, HandleStreamMessageRequest_PacketOut) {
   ::p4::v1::StreamMessageRequest req;
   auto* packet = req.mutable_packet();
 
+  EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
+              TranslateStreamMessageRequest(EqualsProto(req)))
+      .Times(2)
+      .WillRepeatedly(
+          Return(::util::StatusOr<::p4::v1::StreamMessageRequest>(req)));
   EXPECT_CALL(*bfrt_packetio_manager_mock_,
               TransmitPacket(EqualsProto(*packet)))
       .WillOnce(Return(::util::OkStatus()))
@@ -1522,6 +1527,9 @@ TEST_F(BfrtNodeTest, HandleStreamMessageRequest_Invalid) {
   ASSERT_NO_FATAL_FAILURE(PushChassisConfigWithCheck());
   ::p4::v1::StreamMessageRequest req;
 
+  EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
+              TranslateStreamMessageRequest(EqualsProto(req)))
+      .WillOnce(Return(::util::StatusOr<::p4::v1::StreamMessageRequest>(req)));
   EXPECT_THAT(HandleStreamMessageRequest(req),
               DerivedFromStatus(::util::Status(
                   StratumErrorSpace(), ERR_UNIMPLEMENTED, "Unsupported")));
@@ -1534,6 +1542,9 @@ TEST_F(BfrtNodeTest, HandleStreamMessageRequest_DigestAck) {
   ::p4::v1::StreamMessageRequest req;
   req.mutable_digest_ack();
 
+  EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
+              TranslateStreamMessageRequest(EqualsProto(req)))
+      .WillOnce(Return(::util::StatusOr<::p4::v1::StreamMessageRequest>(req)));
   EXPECT_THAT(HandleStreamMessageRequest(req),
               DerivedFromStatus(::util::Status(
                   StratumErrorSpace(), ERR_UNIMPLEMENTED, "Unsupported")));
@@ -1546,6 +1557,9 @@ TEST_F(BfrtNodeTest, HandleStreamMessageRequest_Arbitration) {
   ::p4::v1::StreamMessageRequest req;
   req.mutable_arbitration();
 
+  EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
+              TranslateStreamMessageRequest(EqualsProto(req)))
+      .WillOnce(Return(::util::StatusOr<::p4::v1::StreamMessageRequest>(req)));
   EXPECT_THAT(HandleStreamMessageRequest(req),
               DerivedFromStatus(::util::Status(
                   StratumErrorSpace(), ERR_UNIMPLEMENTED, "Unsupported")));

--- a/stratum/hal/lib/barefoot/bfrt_node_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node_test.cc
@@ -130,6 +130,8 @@ class BfrtNodeTest : public ::testing::Test {
       EXPECT_CALL(*p4runtime_bfrt_translator_mock_,
                   PushChassisConfig(EqualsProto(config), kNodeId))
           .WillOnce(Return(::util::OkStatus()));
+      EXPECT_CALL(*p4runtime_bfrt_translator_mock_, GetLowLevelP4INfo())
+          .WillOnce(Return(::util::StatusOr<::p4::config::v1::P4Info>(config)));
       // EXPECT_CALL(*bfrt_pre_manager_mock_,
       //             PushChassisConfig(EqualsProto(config), kNodeId))
       //     .WillOnce(Return(::util::OkStatus()));

--- a/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.cc
+++ b/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.cc
@@ -622,6 +622,7 @@ P4RuntimeBfrtTranslator::TranslateStreamMessageRequest(
   }
   return translated_request;
 }
+
 ::util::StatusOr<::p4::v1::StreamMessageResponse>
 P4RuntimeBfrtTranslator::TranslateStreamMessageResponse(
     const ::p4::v1::StreamMessageResponse& response) {

--- a/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.h
+++ b/stratum/hal/lib/barefoot/p4runtime_bfrt_translator.h
@@ -43,6 +43,8 @@ class P4RuntimeBfrtTranslator {
   virtual ::util::StatusOr<::p4::v1::StreamMessageResponse>
   TranslateStreamMessageResponse(
       const ::p4::v1::StreamMessageResponse& response) LOCKS_EXCLUDED(lock_);
+  virtual ::util::StatusOr<::p4::config::v1::P4Info> GetLowLevelP4Info()
+      LOCKS_EXCLUDED(lock_);
   static std::unique_ptr<P4RuntimeBfrtTranslator> CreateInstance(
       BfSdeInterface* bf_sde_interface, int device_id,
       bool translation_enabled) {
@@ -149,6 +151,10 @@ class P4RuntimeBfrtTranslator {
   absl::flat_hash_map<uint32, int32> counter_to_bit_width_ GUARDED_BY(lock_);
   absl::flat_hash_map<uint32, int32> meter_to_bit_width_ GUARDED_BY(lock_);
   absl::flat_hash_map<uint32, int32> register_to_bit_width_ GUARDED_BY(lock_);
+
+  // This P4Info contains field information without P4Runtime translation
+  // which is useful for low level managers.
+  ::p4::config::v1::P4Info low_level_p4info_;
 
   friend class P4RuntimeBfrtTranslatorTest;
 };

--- a/stratum/hal/lib/barefoot/p4runtime_bfrt_translator_mock.h
+++ b/stratum/hal/lib/barefoot/p4runtime_bfrt_translator_mock.h
@@ -33,6 +33,7 @@ class P4RuntimeBfrtTranslatorMock : public P4RuntimeBfrtTranslator {
   MOCK_METHOD1(TranslateStreamMessageResponse,
                ::util::StatusOr<::p4::v1::StreamMessageResponse>(
                    const ::p4::v1::StreamMessageResponse& response));
+  MOCK_METHOD0(GetLowLevelP4Info, ::util::StatusOr<::p4::config::v1::P4Info>());
 };
 
 }  // namespace barefoot

--- a/stratum/hal/lib/barefoot/p4runtime_bfrt_translator_test.cc
+++ b/stratum/hal/lib/barefoot/p4runtime_bfrt_translator_test.cc
@@ -350,6 +350,121 @@ TEST_F(P4RuntimeBfrtTranslatorTest, TranslateValue_FromSdk) {
   EXPECT_EQ(expected_value, actual_value);
 }
 
+TEST_F(P4RuntimeBfrtTranslatorTest, GetLowLevelP4Info) {
+  EXPECT_OK(PushChassisConfig());
+  EXPECT_OK(PushForwardingPipelineConfig());
+  const char expect_low_level_p4info_str[] = R"PROTO(
+    pkg_info {
+      arch: "tna"
+    }
+    tables {
+      preamble {
+        id: 33583783
+        name: "Ingress.control.table1"
+      }
+      match_fields {
+        id: 1
+        name: "field1"
+        bitwidth: 9
+        match_type: EXACT
+      }
+      match_fields {
+        id: 2
+        name: "field2"
+        bitwidth: 9
+        match_type: TERNARY
+      }
+      match_fields {
+        id: 3
+        name: "field3"
+        bitwidth: 9
+        match_type: RANGE
+      }
+      match_fields {
+        id: 4
+        name: "field4"
+        bitwidth: 9
+        match_type: LPM
+      }
+      match_fields {
+        id: 5
+        name: "field5"
+        bitwidth: 9
+        match_type: OPTIONAL
+      }
+      match_fields {
+        id: 6
+        name: "field6"
+        bitwidth: 32
+        match_type: EXACT
+      }
+      action_refs {
+        id: 16794911
+      }
+      const_default_action_id: 16836487
+      size: 1024
+    }
+    actions {
+      preamble {
+        id: 16794911
+        name: "Ingress.control.action1"
+      }
+      params {
+        id: 1
+        name: "port_id"
+        bitwidth: 9
+      }
+      params {
+        id: 2
+        name: "don't translate"
+        bitwidth: 32
+      }
+    }
+    counters {
+      preamble {
+        id: 318814845
+        name: "Ingress.control.counter1"
+      }
+      spec {
+        unit: BOTH
+      }
+    }
+    meters {
+      preamble {
+        id: 55555
+        name: "Ingress.control.meter_bytes"
+        alias: "meter_bytes"
+      }
+      spec {
+        unit: BYTES
+      }
+      size: 500
+    }
+    registers {
+      preamble {
+        id: 66666
+        name: "Ingress.control.my_register"
+        alias: "my_register"
+      }
+      type_spec {
+        bitstring {
+          bit {
+            bitwidth: 32
+          }
+        }
+      }
+      size: 10
+    }
+  )PROTO";
+  ::p4::config::v1::P4Info expected_low_level_p4info;
+  EXPECT_OK(ParseProtoFromString(expect_low_level_p4info_str,
+                                 &expected_low_level_p4info));
+  const auto& statusor = p4rt_bfrt_translator_->GetLowLevelP4Info();
+  EXPECT_OK(statusor.status());
+  const auto& low_level_p4info = statusor.ValueOrDie();
+  EXPECT_THAT(low_level_p4info, EqualsProto(expected_low_level_p4info));
+}
+
 // Table entry
 TEST_F(P4RuntimeBfrtTranslatorTest, WriteTableEntryRequest) {
   EXPECT_OK(PushChassisConfig());
@@ -1401,7 +1516,6 @@ TEST_F(P4RuntimeBfrtTranslatorTest, WritePacketReplicationRequest_InvalidPort) {
 }
 
 // TODO(Yi Tseng): Will support these tests in other PRs.
-// PacketIO
 // Meter entry (translate index)
 // Direct meter entry (translate index)
 // Counter entry (translate index)


### PR DESCRIPTION
Add P4Runtime translation support for packet-io

Also, include the following changes:

- Preprocess P4Info before pushing it to other BfRt managers, since managers need to use the original bit width value from the P4 source code. (also, add a new test for this)
- Move `P4RuntimeBfrtTranslationWritterWraper` to `P4RuntimeBfrtTranslator` class and rename to `ReadResponseWriterWrapper`
- Add `StreamMessageResponseWriterWrapper`
