### PR TITLE
Make `BfrtP4RuntimeTranslator` canonical bytestring aware

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -14,6 +14,8 @@
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/error.pb.h"
 
+DECLARE_bool(incompatible_enable_bfrt_legacy_bytestring_responses);
+
 namespace stratum {
 namespace hal {
 namespace barefoot {
@@ -694,6 +696,9 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
     const uint32 port_id = sdk_port_to_singleton_port_[sdk_port_id];
     std::string port_id_bytes = P4RuntimeByteStringToPaddedByteString(
         Uint32ToByteStream(port_id), NumBitsToNumBytes(bit_width));
+    if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+      port_id_bytes = ByteStringToP4RuntimeByteString(port_id_bytes);
+    }
     return port_id_bytes;
   }
 }


### PR DESCRIPTION
The `BfrtP4RuntimeTranslator` should respect the feature flag (`incompatible_enable_bfrt_legacy_bytestring_responses`) and return canonical byte strings after translation, if requested.