### PR TITLE
Use `latest-<SDK version>` Docker tag consistently

### DIFF
--- a/stratum/hal/bin/barefoot/README.build.md
+++ b/stratum/hal/bin/barefoot/README.build.md
@@ -186,7 +186,7 @@ If you want to create a Docker image from the Debian package,
 ```bash
 export SDE_VERSION=9.5.2
 export STRATUM_TARGET=stratum_bfrt
-docker build -t stratumproject/stratum-bfrt:$SDE_VERSION \
+docker build -t stratumproject/stratum-bfrt:latest-$SDE_VERSION \
   --build-arg STRATUM_TARGET="$STRATUM_TARGET" \
   -f stratum/hal/bin/barefoot/docker/Dockerfile \
   bazel-bin/stratum/hal/bin/barefoot

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -22,11 +22,11 @@ You can pull a nightly version of this container image from
 [Dockerhub](https://hub.docker.com/repository/docker/stratumproject/stratum-bf/tags)
 
 ```bash
-$ docker pull stratumproject/stratum-bfrt:[SDE version]
+$ docker pull stratumproject/stratum-bfrt:latest-[SDE version]
 ```
 
 For example, the container with BF SDE 9.5.2: <br/>
-`stratumproject/stratum-bfrt:9.5.2`
+`stratumproject/stratum-bfrt:latest-9.5.2`
 
 These containers include kernel modules for OpenNetworkLinux.
 
@@ -60,8 +60,8 @@ docker save [Image Name] -o [Tarball Name]
 
 For example,
 ```bash
-docker pull stratumproject/stratum-bfrt:9.5.2
-docker save stratumproject/stratum-bfrt:9.5.2 -o stratum-bfrt-9.5.2-docker.tar
+docker pull stratumproject/stratum-bfrt:latest-9.5.2
+docker save stratumproject/stratum-bfrt:latest-9.5.2 -o stratum-bfrt-9.5.2-docker.tar
 ```
 
 Then, deploy the tarball to the device via scp, rsync, http, USB stick, etc.
@@ -119,7 +119,7 @@ CHASSIS_CONFIG    # Override the default chassis config file.
 LOG_DIR           # The directory for logging, default: `/var/log/`.
 SDE_VERSION       # The SDE version
 DOCKER_IMAGE      # The container image name, default: stratumproject/stratum-bfrt
-DOCKER_IMAGE_TAG  # The container image tag, default: $SDE_VERSION
+DOCKER_IMAGE_TAG  # The container image tag, default: latest-$SDE_VERSION
 PLATFORM          # Use specific platform port map
 ```
 

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -169,7 +169,7 @@ popd
 
 # Build Stratum BF runtime Docker image
 STRATUM_NAME=$(echo $STRATUM_TARGET | sed 's/_/-/')
-RUNTIME_IMAGE=stratumproject/$STRATUM_NAME:$SDE_VERSION
+RUNTIME_IMAGE=stratumproject/$STRATUM_NAME:latest-$SDE_VERSION
 echo "Building Stratum runtime image: $RUNTIME_IMAGE"
 set -x
 docker build \

--- a/stratum/hal/bin/barefoot/docker/build-tofino-model-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-tofino-model-container.sh
@@ -37,7 +37,7 @@ if [ "$(docker version -f '{{.Server.Experimental}}')" = "true" ]; then
   DOCKER_BUILD_OPTS+="--squash "
 fi
 
-MODEL_IMAGE=stratumproject/tofino-model:$SDE_VERSION
+MODEL_IMAGE=stratumproject/tofino-model:latest-$SDE_VERSION
 echo "Building Tofino model runtime image: $RUNTIME_IMAGE"
 set -x
 docker build \

--- a/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
+++ b/stratum/hal/bin/barefoot/docker/start-stratum-container.sh
@@ -6,7 +6,7 @@ set -e
 LOG_DIR=${LOG_DIR:-/var/log}
 SDE_VERSION=${SDE_VERSION:-9.5.2}
 DOCKER_IMAGE=${DOCKER_IMAGE:-stratumproject/stratum-bfrt}
-DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-$SDE_VERSION}
+DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-latest-$SDE_VERSION}
 
 # Try to load the platform string if not already set.
 if [[ -z "$PLATFORM" ]] && [[ -f "/etc/onl/platform" ]]; then

--- a/stratum/hal/bin/bcm/standalone/README.md
+++ b/stratum/hal/bin/bcm/standalone/README.md
@@ -52,7 +52,7 @@ As part of CI, we publish Stratum with a pre-compiled binary and a set of defaul
 There are two versions, one for SDKLT (`:sdklt`) and one for OpenNSA (`:openNSA`).
 
 ```bash
-docker pull stratumproject/stratum-bcm:sdklt  # or :opennsa, to update the image
+docker pull stratumproject/stratum-bcm:latest-sdklt  # or :latest-opennsa, to update the image
 cd stratum/hal/bin/bcm/standalone/docker
 DOCKER_IMAGE_TAG=sdklt ./start-stratum-container.sh  # or =opennsa
 ```

--- a/tools/release-stratum.sh
+++ b/tools/release-stratum.sh
@@ -142,7 +142,6 @@ for target in ${BCM_TARGETS[@]}; do
   docker tag stratumproject/stratum-bcm_$target_short:latest stratumproject/stratum-bcm:$target_short
   docker push stratumproject/stratum-bcm:${VERSION}-$target_short
   docker push stratumproject/stratum-bcm:latest-$target_short
-  docker push stratumproject/stratum-bcm:$target_short
   clean_up_after_build
   set +x
 done
@@ -167,7 +166,7 @@ for sde_version in ${BF_SDE_VERSIONS[@]}; do
     mv -f ${target}_deb.deb $RELEASE_DIR/$target_dash-${VERSION}-$sde_version-amd64.deb
     docker tag stratumproject/$target_dash:$sde_version stratumproject/$target_dash:${VERSION}-$sde_version
     docker push stratumproject/$target_dash:${VERSION}-$sde_version
-    docker push stratumproject/$target_dash:$sde_version
+    docker push stratumproject/$target_dash:latest-$sde_version
     clean_up_after_build
     set +x
   done


### PR DESCRIPTION
This leaves us with two types of tags: `release-<SDK version>` and `latest-<SDK version>`