### PR TITLE
Use "public view" DockerHub URLs in docs

### DIFF
--- a/stratum/hal/bin/barefoot/README.pipeline.md
+++ b/stratum/hal/bin/barefoot/README.pipeline.md
@@ -26,7 +26,7 @@ bazel run //stratum/hal/bin/barefoot:bf_pipeline_builder -- \
     -bf_pipeline_config_binary_file=$PWD/device_config.pb.bin
 ```
 
-The tool is also available as part of the Stratum-tools [Docker image](https://hub.docker.com/repository/docker/stratumproject/stratum-tools):
+The tool is also available as part of the Stratum-tools [Docker image](https://hub.docker.com/r/stratumproject/stratum-tools/tags):
 
 ```bash
 cd </path/to/bf-p4c/compiler/output>

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -19,7 +19,7 @@ You can find Debian packages and Docker containers on the
 ### Nightly version
 
 You can pull a nightly version of this container image from
-[Dockerhub](https://hub.docker.com/repository/docker/stratumproject/stratum-bf/tags)
+[Dockerhub](https://hub.docker.com/r/stratumproject/stratum-bfrt/tags)
 
 ```bash
 $ docker pull stratumproject/stratum-bfrt:latest-[SDE version]

--- a/stratum/hal/bin/bcm/standalone/README.md
+++ b/stratum/hal/bin/bcm/standalone/README.md
@@ -48,7 +48,7 @@ x86-64-<vendor-name>-<box-name>-32x-r0
 
 Stratum for Broadcom switches can be run inside Docker on the switch itself.
 Follow their instructions on how to setup [Docker](https://docs.docker.com/engine/install/).
-As part of CI, we publish Stratum with a pre-compiled binary and a set of default configuration files as a [Docker container](https://hub.docker.com/repository/docker/stratumproject/stratum-bcm).
+As part of CI, we publish Stratum with a pre-compiled binary and a set of default configuration files as a [Docker container](https://hub.docker.com/r/stratumproject/stratum-bcm).
 There are two versions, one for SDKLT (`:sdklt`) and one for OpenNSA (`:openNSA`).
 
 ```bash

--- a/stratum/pipelines/main/README.md
+++ b/stratum/pipelines/main/README.md
@@ -23,7 +23,7 @@ The output tarball can be located by running: `bazel aquery //stratum/pipelines/
 
 ## Docker `p4c-fpm`
 
-We also publish the `p4c-fpm` compiler as a [Docker container](https://hub.docker.com/repository/docker/stratumproject/p4c-fpm). Have a look at the code of our ONF Connect 2019 [demo](https://github.com/opennetworkinglab/stratum-onos-demo/blob/b709e579592f5c7b3293357376c811690e0bec34/p4src/Makefile#L63-L80).
+We also publish the `p4c-fpm` compiler as a [Docker container](https://hub.docker.com/r/stratumproject/p4c-fpm). Have a look at the code of our ONF Connect 2019 [demo](https://github.com/opennetworkinglab/stratum-onos-demo/blob/b709e579592f5c7b3293357376c811690e0bec34/p4src/Makefile#L63-L80).
 
 ## Debian package
 


### PR DESCRIPTION
I noticed that the DockerHub links we use in docs require login. This PR replaces them with their "public view" versions.