### PR TITLE
Handle errors without details from switch interface on P4 writes and reads

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -210,13 +210,19 @@ namespace {
 
 // Helper to facilitate logging the write requests to the desired log file.
 void LogWriteRequest(uint64 node_id, const ::p4::v1::WriteRequest& req,
-                     const ::util::Status& status,
                      const std::vector<::util::Status>& results,
                      const absl::Time timestamp) {
   if (FLAGS_write_req_log_file.empty()) {
     return;
   }
-  if (!results.empty() && results.size() != req.updates_size()) {
+  if (results.empty()) {
+    // Nothing to log as the switch interface did not fill in any error details.
+    // TODO(max): Consider logging the requests with the overall status in this
+    //            case. But keep in mind that LogReadRequest will not be called
+    //            for auth errors or invalid device IDs.
+    return;
+  }
+  if (results.size() != req.updates_size()) {
     LOG(ERROR) << "Size mismatch: " << results.size()
                << " != " << req.updates_size() << ". Did not log anything!";
     return;
@@ -224,29 +230,34 @@ void LogWriteRequest(uint64 node_id, const ::p4::v1::WriteRequest& req,
   std::string msg = "";
   std::string ts =
       absl::FormatTime("%Y-%m-%d %H:%M:%E6S", timestamp, absl::LocalTimeZone());
-  for (size_t i = 0; i < req.updates_size(); ++i) {
-    absl::StrAppend(
-        &msg, ts, ";", node_id, ";", req.updates(i).ShortDebugString(), ";",
-        results.empty() ? status.error_message() : results[i].error_message(),
-        "\n");
+  for (size_t i = 0; i < results.size(); ++i) {
+    absl::StrAppend(&msg, ts, ";", node_id, ";",
+                    req.updates(i).ShortDebugString(), ";",
+                    results[i].error_message(), "\n");
   }
-  ::util::Status ret =
+  ::util::Status status =
       WriteStringToFile(msg, FLAGS_write_req_log_file, /*append=*/true);
-  if (!ret.ok()) {
+  if (!status.ok()) {
     LOG_EVERY_N(ERROR, 50) << "Failed to log the write request: "
-                           << ret.error_message();
+                           << status.error_message();
   }
 }
 
 // Helper to facilitate logging the read requests to the desired log file.
 void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
-                    const ::util::Status& status,
                     const std::vector<::util::Status>& results,
                     const absl::Time timestamp) {
   if (FLAGS_read_req_log_file.empty()) {
     return;
   }
-  if (!results.empty() && results.size() != req.entities_size()) {
+  if (results.empty()) {
+    // Nothing to log as the switch interface did not fill in any error details.
+    // TODO(max): Consider logging the requests with the overall status in this
+    //            case. But keep in mind that LogReadRequest will not be called
+    //            for auth errors or invalid device IDs.
+    return;
+  }
+  if (results.size() != req.entities_size()) {
     LOG(ERROR) << "Size mismatch: " << results.size()
                << " != " << req.entities_size() << ". Did not log anything!";
     return;
@@ -254,17 +265,16 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   std::string msg = "";
   std::string ts =
       absl::FormatTime("%Y-%m-%d %H:%M:%E6S", timestamp, absl::LocalTimeZone());
-  for (size_t i = 0; i < req.entities_size(); ++i) {
-    absl::StrAppend(
-        &msg, ts, ";", node_id, ";", req.entities(i).ShortDebugString(), ";",
-        results.empty() ? status.error_message() : results[i].error_message(),
-        "\n");
+  for (size_t i = 0; i < results.size(); ++i) {
+    absl::StrAppend(&msg, ts, ";", node_id, ";",
+                    req.entities(i).ShortDebugString(), ";",
+                    results[i].error_message(), "\n");
   }
-  ::util::Status ret =
+  ::util::Status status =
       WriteStringToFile(msg, FLAGS_read_req_log_file, /*append=*/true);
-  if (!ret.ok()) {
+  if (!status.ok()) {
     LOG_EVERY_N(ERROR, 50) << "Failed to log the read request: "
-                           << ret.error_message();
+                           << status.error_message();
   }
 }
 
@@ -322,7 +332,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   }
 
   // Log debug info for future debugging.
-  LogWriteRequest(node_id, *req, status, results, timestamp);
+  LogWriteRequest(node_id, *req, results, timestamp);
 
   return ToGrpcStatus(status, results);
 }
@@ -349,7 +359,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   }
 
   // Log debug info for future debugging.
-  LogReadRequest(req->device_id(), *req, status, details, timestamp);
+  LogReadRequest(req->device_id(), *req, details, timestamp);
 
   return ToGrpcStatus(status, details);
 }

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -218,7 +218,7 @@ void LogWriteRequest(uint64 node_id, const ::p4::v1::WriteRequest& req,
   if (results.empty()) {
     // Nothing to log as the switch interface did not fill in any error details.
     // TODO(max): Consider logging the requests with the overall status in this
-    //            case. But keep in mind that LogReadRequest will not be called
+    //            case. But keep in mind that LogWriteRequest will not be called
     //            for auth errors or invalid device IDs.
     return;
   }

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -769,8 +769,8 @@ TEST_P(P4ServiceTest, WriteFailureWhenSwitchNotInitializedError) {
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, status.error_code());
   EXPECT_THAT(status.error_message(), HasSubstr(kAggrErrorMsg));
-  // TODO(max): P4Runtime spec says error_details should be empty in not flow
-  // entry related failures.
+  // TODO(max): P4Runtime spec says error_details should be empty for failures
+  // not related to the supplied flow entries.
   // EXPECT_TRUE(status.error_details().empty());
 }
 

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -745,6 +745,38 @@ TEST_P(P4ServiceTest, WriteFailureForAuthError) {
   EXPECT_TRUE(status.error_details().empty());
 }
 
+TEST_P(P4ServiceTest, WriteFailureWhenSwitchNotInitializedError) {
+  ::grpc::ClientContext context;
+  ::p4::v1::WriteRequest req;
+  ::p4::v1::WriteResponse resp;
+  req.set_device_id(kNodeId1);
+  req.mutable_election_id()->set_high(absl::Uint128High64(kElectionId1));
+  req.mutable_election_id()->set_low(absl::Uint128Low64(kElectionId1));
+  req.add_updates()->set_type(::p4::v1::Update::INSERT);
+  AddFakeMasterController(kNodeId1, 1, kElectionId1, "some uri");
+
+  EXPECT_CALL(*auth_policy_checker_mock_, Authorize("P4Service", "Write", _))
+      .WillOnce(Return(::util::OkStatus()));
+  const std::vector<::util::Status> kExpectedResults = {};
+  EXPECT_CALL(*switch_mock_, WriteForwardingEntries(EqualsProto(req), _))
+      .WillOnce(
+          DoAll(SetArgPointee<1>(kExpectedResults),
+                Return(::util::Status(StratumErrorSpace(), ERR_NOT_INITIALIZED,
+                                      kAggrErrorMsg))));
+
+  // Invoke the RPC and validate the results.
+  ::grpc::Status status = stub_->Write(&context, req, &resp);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, status.error_code());
+  EXPECT_THAT(status.error_message(), HasSubstr(kAggrErrorMsg));
+  // TODO(max): P4Runtime spec says error_details should be empty in not flow
+  // entry related failures.
+  // EXPECT_TRUE(status.error_details().empty());
+  std::string s;
+  ASSERT_OK(ReadFileToString(FLAGS_write_req_log_file, &s));
+  EXPECT_THAT(s, HasSubstr(req.updates(0).ShortDebugString()));
+}
+
 TEST_P(P4ServiceTest, ReadSuccess) {
   ::grpc::ClientContext context;
   ::p4::v1::ReadRequest req;

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -772,9 +772,6 @@ TEST_P(P4ServiceTest, WriteFailureWhenSwitchNotInitializedError) {
   // TODO(max): P4Runtime spec says error_details should be empty in not flow
   // entry related failures.
   // EXPECT_TRUE(status.error_details().empty());
-  std::string s;
-  ASSERT_OK(ReadFileToString(FLAGS_write_req_log_file, &s));
-  EXPECT_THAT(s, HasSubstr(req.updates(0).ShortDebugString()));
 }
 
 TEST_P(P4ServiceTest, ReadSuccess) {


### PR DESCRIPTION
When no pipeline has been pushed, switch interface implementations will return `ERR_NOT_INITIALIZED` on P4 reads and writes. This trips up the request logging logic in `P4Service` which currently expects one status for every p4 entity.

Implementations are not required to, and many currently don't, actually populate the results vector:
https://github.com/stratum/stratum/blob/e13ca1a4914429f9729946f7a741121a5fb4a298/stratum/hal/lib/common/switch_interface.h#L129-L132

The only guarantee given is that `results` will either be empty or 1 for 1.

I also don't find it sensible to change this and fix all implementations. Most implementations perform pre-checks that would need to be significantly more complicated.

https://github.com/stratum/stratum/blob/e13ca1a4914429f9729946f7a741121a5fb4a298/stratum/hal/lib/barefoot/bfrt_node.cc#L189-L197

Instead, I'd add a check in `LogWriteRequest`/`LogReadRequest` to cover the empty case and skip logging in those cases. Alternatively we log the overall error, i.e. `ERR_NOT_INITIALIZED`.


Example log:
```
E20220221 11:30:53.749909    50 bfrt_node.cc:189] StratumErrorSpace::ERR_NOT_INITIALIZED: Not initialized!
E20220221 11:30:53.750008    50 p4_service.cc:316] Failed to write forwarding entries to node 1: Not initialized!
E20220221 11:30:53.750037    50 p4_service.cc:219] Size mismatch: 0 != 1. Did not log anything!
```