### PR TITLE
Allow zero burst sizes in P4 `MeterConfig`

### DIFF
--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -124,13 +124,14 @@ std::string ByteStringToP4RuntimeByteString(std::string bytes) {
   RET_CHECK(meter_config.pir() >= 0)
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: peak rate cannot be less than zero.";
-  RET_CHECK(meter_config.cburst() > 0)
+  // Note that we're deviating from the spec here, as we're allowing burst sizes
+  // equal to zero, while the spec mandates strictly greater than zero.
+  RET_CHECK(meter_config.cburst() >= 0)
       << "Meter configuration " << meter_config.ShortDebugString()
-      << " is invalid: committed burst size cannot be less than or equal to"
-      << " zero.";
-  RET_CHECK(meter_config.pburst() > 0)
+      << " is invalid: committed burst size cannot be less than zero.";
+  RET_CHECK(meter_config.pburst() >= 0)
       << "Meter configuration " << meter_config.ShortDebugString()
-      << " is invalid: peak burst size cannot be less than or equal to zero.";
+      << " is invalid: peak burst size cannot be less than zero.";
   RET_CHECK(meter_config.pir() >= meter_config.cir())
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: committed rate cannot be greater than peak rate.";

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -90,18 +90,18 @@ TEST(ByteStringTest, ByteStringToP4RuntimeByteStringCorrect) {
                                         "\x00\x00\x00\x00\xab", 5)));
 }
 
-TEST(ValidMeterConfigTest, IsValidMeterConfigEmptyInvalid) {
+TEST(ValidMeterConfigTest, IsValidMeterConfigEmptyValid) {
   constexpr char kInvalidMeterConfigText[] = R"PROTO(
     # Empty MeterConfig, all fields zero.
   )PROTO";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
-  EXPECT_FALSE(IsValidMeterConfig(config).ok());
+  EXPECT_OK(IsValidMeterConfig(config));
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigZeroBurstInvalid) {
   constexpr char kInvalidMeterConfigText[] = R"PROTO(
-    # Invalid, empty burst sizes.
+    # Zero burst sizes.
     cir: 100
     pir: 200
     cburst: 0
@@ -109,7 +109,7 @@ TEST(ValidMeterConfigTest, IsValidMeterConfigZeroBurstInvalid) {
   )PROTO";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
-  EXPECT_FALSE(IsValidMeterConfig(config).ok());
+  EXPECT_OK(IsValidMeterConfig(config));
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigRatesInvalid) {


### PR DESCRIPTION
In Aether we have a use case for setting the meter burst sizes to 0. While the various meter _rates_ can already be 0, effectively implementing a packet drop, the initial bucket is still filled with `burst_size` bytes, potentially marking a few packets in an undesirable way.
This change deviates from the trTCM spec by allowing zero burst sizes in P4 `MeterConfig`s.