### PR TITLE
Only log P4RT arbitration events if mastership changes

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -793,9 +793,10 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
     }
   }
 
-  LOG(INFO) << "Controller " << controller.Name() << " is connected as "
-            << (is_master ? "MASTER" : "SLAVE")
-            << " for node (aka device) with ID " << node_id << ".";
+  LOG_IF(INFO, is_master != was_master)
+      << "Controller " << controller.Name() << " is now connected as "
+      << (is_master ? "MASTER" : "SLAVE") << " for node (aka device) with ID "
+      << node_id << ".";
 
   return ::util::OkStatus();
 }


### PR DESCRIPTION
In Aether ONOS re-asserts mastership every minute. We got a complaint that these mastership log messages pollute the log file. This change reduces the amount of messages by only logging if the mastership has actually changed. Thus keeping the log useful, while reducing the amount.