### PR TITLE
Do not expect or emit padded byte strings in BFRT P4Runtime translator

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -678,8 +678,7 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
     // id(uint32) -> sdk port id(1 or 2 bytes)
     const uint32 port_id = ByteStreamToUint<uint32>(value);
     RET_CHECK(singleton_port_to_sdk_port_.count(port_id));
-    const uint32 sdk_port_id = singleton_port_to_sdk_port_[port_id];
-    return Uint32ToByteStream(sdk_port_id);
+    return Uint32ToByteStream(singleton_port_to_sdk_port_[port_id]);
   } else {
     // sdk port id(1 or 2 bytes) -> sdk port id(uint32) -> singleton port
     // id(uint32)

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -690,7 +690,7 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
     std::string port_id_bytes = Uint32ToByteStream(port_id);
     if (FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
       port_id_bytes = P4RuntimeByteStringToPaddedByteString(
-        Uint32ToByteStream(port_id), NumBitsToNumBytes(bit_width));
+          port_id_bytes, NumBitsToNumBytes(bit_width));
     }
     return port_id_bytes;
   }

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -681,7 +681,8 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
     const uint32 sdk_port_id = singleton_port_to_sdk_port_[port_id];
     return Uint32ToByteStream(sdk_port_id);
   } else {
-    // sdk port id(1 or 2 bytes) -> sdk port id(uint32) -> singleton port id(uint32)
+    // sdk port id(1 or 2 bytes) -> sdk port id(uint32) -> singleton port
+    // id(uint32)
     // -> singleton port id(N-byte)
     RET_CHECK(value.size() <= NumBitsToNumBytes(kTnaPortIdBitWidth));
     const uint32 sdk_port_id = ByteStreamToUint<uint32>(value);

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -687,10 +687,10 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
     const uint32 sdk_port_id = ByteStreamToUint<uint32>(value);
     RET_CHECK(sdk_port_to_singleton_port_.count(sdk_port_id));
     const uint32 port_id = sdk_port_to_singleton_port_[sdk_port_id];
-    std::string port_id_bytes = P4RuntimeByteStringToPaddedByteString(
+    std::string port_id_bytes = Uint32ToByteStream(port_id);
+    if (FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
+      port_id_bytes = P4RuntimeByteStringToPaddedByteString(
         Uint32ToByteStream(port_id), NumBitsToNumBytes(bit_width));
-    if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-      port_id_bytes = ByteStringToP4RuntimeByteString(port_id_bytes);
     }
     return port_id_bytes;
   }

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -675,17 +675,15 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
   // Translate type "tna/PortId_t"
   if (to_sdk) {
     // singleton port id(N-byte) -> singleton port id(uint32) -> sdk port
-    // id(uint32) -> sdk port id(2-byte)
+    // id(uint32) -> sdk port id(1 or 2 bytes)
     const uint32 port_id = ByteStreamToUint<uint32>(value);
     RET_CHECK(singleton_port_to_sdk_port_.count(port_id));
     const uint32 sdk_port_id = singleton_port_to_sdk_port_[port_id];
-    std::string sdk_port_id_bytes = P4RuntimeByteStringToPaddedByteString(
-        Uint32ToByteStream(sdk_port_id), NumBitsToNumBytes(bit_width));
-    return sdk_port_id_bytes;
+    return Uint32ToByteStream(sdk_port_id);
   } else {
-    // sdk port id(2-byte) -> sdk port id(uint32) -> singleton port id(uint32)
+    // sdk port id(1 or 2 bytes) -> sdk port id(uint32) -> singleton port id(uint32)
     // -> singleton port id(N-byte)
-    RET_CHECK(value.size() == NumBitsToNumBytes(kTnaPortIdBitWidth));
+    RET_CHECK(value.size() <= NumBitsToNumBytes(kTnaPortIdBitWidth));
     const uint32 sdk_port_id = ByteStreamToUint<uint32>(value);
     RET_CHECK(sdk_port_to_singleton_port_.count(sdk_port_id));
     const uint32 port_id = sdk_port_to_singleton_port_[sdk_port_id];

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator_test.cc
@@ -543,7 +543,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslateValue_InvalidSize) {
                   .status(),
               DerivedFromStatus(::util::Status(
                   StratumErrorSpace(), ERR_INVALID_PARAM,
-                  "'value.size() == "
+                  "'value.size() <= "
                   "NumBitsToNumBytes(kTnaPortIdBitWidth)' is false.")));
 }
 


### PR DESCRIPTION
 - No need to add padding zeros when writing through the SDE wrapper since it will help add zeros before writing to the SDE
 - Values from SDE wrapper for port number can be 1 or 2 bytes when we set `incompatible_enable_bfrt_legacy_bytestring_responses` to false