### PR TITLE
Add instructions on how to push a pipeline to Stratum-bfrt

### DIFF
--- a/stratum/hal/bin/barefoot/README.pipeline.md
+++ b/stratum/hal/bin/barefoot/README.pipeline.md
@@ -39,6 +39,8 @@ docker run --rm -v $PWD:$PWD -w $PWD stratumproject/stratum-tools:latest \
 The output goes into the `p4_device_config` field of the P4Runtime
 `ForwardingPipelineConfig` message as usual.
 
+### Unpacking
+
 To inspect a `BfPipelineConfig` message, the tool provides an unpacking mode,
 which recreates the original compiler output files:
 
@@ -47,3 +49,17 @@ bazel run //stratum/hal/bin/barefoot:bf_pipeline_builder -- \
     -bf_pipeline_config_binary_file=$PWD/device_config.pb.bin \
     -unpack_dir=$PWD
 ```
+
+## Pushing the Pipeline with p4_pipeline_pusher
+
+Once the pipeline has been packed into the aforementioned format, it can be
+pushed to Stratum over P4Runtime with the `p4_pipeline_pusher` tool. It is part
+of the same tools [Docker image](https://hub.docker.com/r/stratumproject/stratum-tools/tags).
+
+```bash
+docker run --rm -v $PWD:$PWD -w $PWD stratumproject/stratum-tools:latest \
+    p4_pipeline_pusher --help
+```
+
+For more advanced use cases, consider [p4runtime-shell](https://github.com/p4lang/p4runtime-shell)
+or a full SDN controller like [ONOS](https://github.com/opennetworkinglab/onos/).

--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -151,6 +151,8 @@ You can safely ignore warnings like this:
 ```
 
 For more details on additional options, see [below](#stratum-runtime-options).
+Otherwise, continue with the [pipeline README](/stratum/hal/bin/barefoot/README.pipeline.md)
+on how to load a P4 pipeline into Stratum.
 
 ### Managing Stratum with systemd
 


### PR DESCRIPTION
This PR adds basic instructions on how to push a pipeline to Stratum-bfrt with the supplied `p4_pipeline_pusher` tool.