### PR TITLE
Accept action IDs on `DirectCounterEntry` in Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -629,15 +629,11 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
                        direct_counter_entry, /*to_sdk=*/true));
   // Read table entry first.
   const auto& table_entry = translated_direct_counter_entry.table_entry();
-  RET_CHECK(table_entry.action().action().action_id() == 0)
-      << "Found action on DirectCounterEntry "
-      << translated_direct_counter_entry.ShortDebugString();
   ASSIGN_OR_RETURN(uint32 table_id,
                    bf_sde_interface_->GetBfRtId(table_entry.table_id()));
   ASSIGN_OR_RETURN(auto table_key, bf_sde_interface_->CreateTableKey(table_id));
   ASSIGN_OR_RETURN(auto table_data,
-                   bf_sde_interface_->CreateTableData(
-                       table_id, table_entry.action().action().action_id()));
+                   bf_sde_interface_->CreateTableData(table_id, 0));
 
   absl::ReaderMutexLock l(&lock_);
   RETURN_IF_ERROR(BuildTableKey(table_entry, table_key.get()));
@@ -675,16 +671,11 @@ BfrtTableManager::ReadDirectCounterEntry(
                    bfrt_p4runtime_translator_->TranslateDirectCounterEntry(
                        direct_counter_entry, /*to_sdk=*/true));
   const auto& table_entry = translated_direct_counter_entry.table_entry();
-  RET_CHECK(table_entry.action().action().action_id() == 0)
-      << "Found action on DirectCounterEntry "
-      << translated_direct_counter_entry.ShortDebugString();
-
   ASSIGN_OR_RETURN(uint32 table_id,
                    bf_sde_interface_->GetBfRtId(table_entry.table_id()));
   ASSIGN_OR_RETURN(auto table_key, bf_sde_interface_->CreateTableKey(table_id));
   ASSIGN_OR_RETURN(auto table_data,
-                   bf_sde_interface_->CreateTableData(
-                       table_id, table_entry.action().action().action_id()));
+                   bf_sde_interface_->CreateTableData(table_id, 0));
 
   {
     absl::ReaderMutexLock l(&lock_);

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -185,6 +185,7 @@ TEST_F(BfrtTableManagerTest, WriteDirectCounterEntryTest) {
         field_id: 2
         ternary { value: "\x00" mask: "\x0f\xff" }
       }
+      action { action { action_id: 1 } }
       priority: 10
     }
     data {


### PR DESCRIPTION
Those are still valid and the action field has to be ignored, according to the P4RT spec.