### PR TITLE
Replace raw text proto string terminal `PROTO` with `pb`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -336,7 +336,7 @@ TEST_F(BfChassisManagerTest, SetPortLoopback) {
 }
 
 TEST_F(BfChassisManagerTest, ApplyPortShaping) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_port_shaping_config {
         key: 7654321
@@ -353,7 +353,7 @@ TEST_F(BfChassisManagerTest, ApplyPortShaping) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -386,7 +386,7 @@ TEST_F(BfChassisManagerTest, ApplyPortShaping) {
 }
 
 TEST_F(BfChassisManagerTest, ApplyDeflectOnDrop) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -402,7 +402,7 @@ TEST_F(BfChassisManagerTest, ApplyDeflectOnDrop) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -422,7 +422,7 @@ TEST_F(BfChassisManagerTest, ApplyDeflectOnDrop) {
 }
 
 TEST_F(BfChassisManagerTest, ApplyQoSConfig) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_qos_config {
         key: 7654321  # kNodeId
@@ -467,7 +467,7 @@ TEST_F(BfChassisManagerTest, ApplyQoSConfig) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -486,7 +486,7 @@ TEST_F(BfChassisManagerTest, ApplyQoSConfig) {
 }
 
 TEST_F(BfChassisManagerTest, QoSConfigWithSingletonPortsIsTransformed) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_qos_config {
         key: 7654321  # kNodeId
@@ -526,7 +526,7 @@ TEST_F(BfChassisManagerTest, QoSConfigWithSingletonPortsIsTransformed) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -554,7 +554,7 @@ TEST_F(BfChassisManagerTest, QoSConfigWithSingletonPortsIsTransformed) {
 }
 
 TEST_F(BfChassisManagerTest, ReplayPorts) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -584,7 +584,7 @@ TEST_F(BfChassisManagerTest, ReplayPorts) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   constexpr int kCpuPort = 64;
 

--- a/stratum/hal/lib/barefoot/bf_pipeline_utils_test.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils_test.cc
@@ -16,16 +16,16 @@ namespace stratum {
 namespace hal {
 namespace barefoot {
 
-static constexpr char bf_config_1pipe_str[] = R"PROTO(
+static constexpr char bf_config_1pipe_str[] = R"pb(
   p4_name: "prog1"
   bfruntime_info: "{json: true}"
   profiles {
     profile_name: "pipe1"
     context: "{json: true}"
     binary: "<raw bin>"
-  })PROTO";
+  })pb";
 
-static constexpr char bf_config_2pipe_str[] = R"PROTO(
+static constexpr char bf_config_2pipe_str[] = R"pb(
   p4_name: "prog1"
   bfruntime_info: "{json: true}"
   profiles {
@@ -37,7 +37,7 @@ static constexpr char bf_config_2pipe_str[] = R"PROTO(
     profile_name: "pipe2"
     context: "{json: true}"
     binary: "<raw bin>"
-  })PROTO";
+  })pb";
 
 TEST(ExtractBfPipelineTest, ExtractBfPipelineConfigFromProtoSuccess) {
   BfPipelineConfig bf_config;

--- a/stratum/hal/lib/barefoot/bfrt_counter_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_counter_manager_test.cc
@@ -56,7 +56,7 @@ TEST_F(BfrtCounterManagerTest, ModifyIndirectCounterTest) {
   EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kCounterId))
       .WillOnce(Return(kBfRtCounterId));
 
-  const std::string kIndirectCounterEntryText = R"PROTO(
+  const std::string kIndirectCounterEntryText = R"pb(
     counter_id: 55
     index {
       index: 100
@@ -65,7 +65,7 @@ TEST_F(BfrtCounterManagerTest, ModifyIndirectCounterTest) {
       byte_count: 100
       packet_count: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::CounterEntry entry;
   ASSERT_OK(ParseProtoFromString(kIndirectCounterEntryText, &entry));
 

--- a/stratum/hal/lib/barefoot/bfrt_node_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node_test.cc
@@ -202,7 +202,7 @@ class BfrtNodeTest : public ::testing::Test {
   static constexpr int kLogicalPortId = 35;
   static constexpr uint32 kPortId = 941;
   static constexpr uint32 kL2McastGroupId = 20;
-  static constexpr char kBfConfigPipelineString[] = R"PROTO(
+  static constexpr char kBfConfigPipelineString[] = R"pb(
     p4_name: "prog1"
     bfruntime_info: "{json: true}"
     profiles {
@@ -210,8 +210,8 @@ class BfrtNodeTest : public ::testing::Test {
       context: "{json: true}"
       binary: "<raw bin>"
     }
-  )PROTO";
-  static constexpr char kValidP4InfoString[] = R"PROTO(
+  )pb";
+  static constexpr char kValidP4InfoString[] = R"pb(
     pkg_info {
       arch: "tna"
     }
@@ -288,7 +288,7 @@ class BfrtNodeTest : public ::testing::Test {
       }
       size: 500
     }
-  )PROTO";
+  )pb";
 
   std::unique_ptr<BfrtTableManagerMock> bfrt_table_manager_mock_;
   std::unique_ptr<BfrtPacketioManagerMock> bfrt_packetio_manager_mock_;

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator_test.cc
@@ -136,7 +136,7 @@ class BfrtP4RuntimeTranslatorTest : public ::testing::Test {
   static constexpr uint32 kSdkPort2Id = 301;
   static constexpr int32 kPort2 = 2;
 
-  static constexpr char kChassisConfig[] = R"PROTO(
+  static constexpr char kChassisConfig[] = R"pb(
     nodes {
       id: 1
     }
@@ -152,9 +152,9 @@ class BfrtP4RuntimeTranslatorTest : public ::testing::Test {
       port: 2
       channel: 1
     }
-  )PROTO";
+  )pb";
 
-  static constexpr char kP4InfoString[] = R"PROTO(
+  static constexpr char kP4InfoString[] = R"pb(
     pkg_info {
       arch: "tna"
     }
@@ -349,9 +349,9 @@ class BfrtP4RuntimeTranslatorTest : public ::testing::Test {
         }
       }
     }
-  )PROTO";
+  )pb";
 
-  static constexpr char kNoTranslationP4InfoString[] = R"PROTO(
+  static constexpr char kNoTranslationP4InfoString[] = R"pb(
     pkg_info {
       arch: "tna"
     }
@@ -502,7 +502,7 @@ class BfrtP4RuntimeTranslatorTest : public ::testing::Test {
         bitwidth: 9
       }
     }
-  )PROTO";
+  )pb";
 };
 
 constexpr int BfrtP4RuntimeTranslatorTest::kDeviceId;
@@ -604,7 +604,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslateP4Info) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 1
@@ -637,8 +637,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry) {
         params { param_id: 2 value: "\x01" }
       }
     }
-  )PROTO";
-  constexpr char expected_table_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 1
@@ -671,7 +671,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry) {
         params { param_id: 2 value: "\x01" }
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(table_entry_str, expected_table_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateTableEntry);
@@ -680,7 +680,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_ActionProfileActionSet) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     action {
       action_profile_action_set {
@@ -693,8 +693,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_ActionProfileActionSet) {
         }
       }
     }
-  )PROTO";
-  constexpr char expected_table_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_table_entry_str[] = R"pb(
     table_id: 33583783
     action {
       action_profile_action_set {
@@ -707,7 +707,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_ActionProfileActionSet) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(table_entry_str, expected_table_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateTableEntry);
@@ -716,7 +716,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_ActionProfileActionSet) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 1
@@ -750,8 +750,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry) {
       }
     }
 
-  )PROTO";
-  constexpr char expected_table_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 1
@@ -784,7 +784,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry) {
         params { param_id: 2 value: "\x01" }
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(table_entry_str, expected_table_entry_str, false,
                        &BfrtP4RuntimeTranslator::TranslateTableEntry);
@@ -793,7 +793,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry_ActionProfileActionSet) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     action {
       action_profile_action_set {
@@ -806,8 +806,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry_ActionProfileActionSet) {
         }
       }
     }
-  )PROTO";
-  constexpr char expected_table_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_table_entry_str[] = R"pb(
     table_id: 33583783
     action {
       action_profile_action_set {
@@ -820,7 +820,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadTableEntry_ActionProfileActionSet) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(table_entry_str, expected_table_entry_str, false,
                        &BfrtP4RuntimeTranslator::TranslateTableEntry);
@@ -830,13 +830,13 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_InvalidTernary) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
   // mask must be all-one.
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 2
       ternary { value: "\x01" mask: "\xff\xff" }
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::TableEntry table_entry;
   EXPECT_OK(ParseProtoFromString(table_entry_str, &table_entry));
@@ -852,13 +852,13 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_InvalidRange) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
   // low and high must be the same value.
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 3
       range { low: "foo" high: "bar" }
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::TableEntry table_entry;
   EXPECT_OK(ParseProtoFromString(table_entry_str, &table_entry));
@@ -874,13 +874,13 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_InvalidLpm) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
   // prefix must be the same value as bitwidth of the field
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 4
       lpm { value: "\x01" prefix_len: 10 }
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::TableEntry table_entry;
   EXPECT_OK(ParseProtoFromString(table_entry_str, &table_entry));
@@ -896,7 +896,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteTableEntry_InvalidLpm) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteActionProfileMember) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char action_profile_member_str[] = R"PROTO(
+  constexpr char action_profile_member_str[] = R"pb(
     action_profile_id: 1
     member_id: 1
     action {
@@ -904,8 +904,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteActionProfileMember) {
       params { param_id: 1 value: "\x01" }
       params { param_id: 2 value: "\x01" }
     }
-  )PROTO";
-  constexpr char expected_action_profile_member_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_action_profile_member_str[] = R"pb(
     action_profile_id: 1
     member_id: 1
     action {
@@ -913,7 +913,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteActionProfileMember) {
       params { param_id: 1 value: "\x01\x2C" }
       params { param_id: 2 value: "\x01" }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(action_profile_member_str,
                        expected_action_profile_member_str, true,
@@ -923,7 +923,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteActionProfileMember) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadActionProfileMember) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char action_profile_member_str[] = R"PROTO(
+  constexpr char action_profile_member_str[] = R"pb(
     action_profile_id: 1
     member_id: 1
     action {
@@ -931,8 +931,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadActionProfileMember) {
       params { param_id: 1 value: "\x01\x2C" }
       params { param_id: 2 value: "\x01" }
     }
-  )PROTO";
-  constexpr char expected_action_profile_member_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_action_profile_member_str[] = R"pb(
     action_profile_id: 1
     member_id: 1
     action {
@@ -940,7 +940,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadActionProfileMember) {
       params { param_id: 1 value: "\x01" }
       params { param_id: 2 value: "\x01" }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(action_profile_member_str,
                        expected_action_profile_member_str, false,
@@ -951,7 +951,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadActionProfileMember) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_MulticastGroup) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char pre_entry_str[] = R"PROTO(
+  constexpr char pre_entry_str[] = R"pb(
     multicast_group_entry {
       multicast_group_id: 1
       replicas {
@@ -963,8 +963,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_MulticastGroup) {
         instance: 1
       }
     }
-  )PROTO";
-  constexpr char expected_pre_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_pre_entry_str[] = R"pb(
     multicast_group_entry {
       multicast_group_id: 1
       replicas {
@@ -976,7 +976,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_MulticastGroup) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(
       pre_entry_str, expected_pre_entry_str, true,
@@ -986,7 +986,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_MulticastGroup) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_MulticastGroup) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char pre_entry_str[] = R"PROTO(
+  constexpr char pre_entry_str[] = R"pb(
     multicast_group_entry {
       multicast_group_id: 1
       replicas {
@@ -998,8 +998,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_MulticastGroup) {
         instance: 1
       }
     }
-  )PROTO";
-  constexpr char expected_pre_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_pre_entry_str[] = R"pb(
     multicast_group_entry {
       multicast_group_id: 1
       replicas {
@@ -1011,7 +1011,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_MulticastGroup) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(
       pre_entry_str, expected_pre_entry_str, false,
@@ -1021,7 +1021,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_MulticastGroup) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_CloneSession) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char pre_entry_str[] = R"PROTO(
+  constexpr char pre_entry_str[] = R"pb(
     clone_session_entry {
       session_id: 1
       replicas {
@@ -1053,8 +1053,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_CloneSession) {
         instance: 1
       }
     }
-  )PROTO";
-  constexpr char expected_pre_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_pre_entry_str[] = R"pb(
     clone_session_entry {
       session_id: 1
       replicas {
@@ -1086,7 +1086,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_CloneSession) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(
       pre_entry_str, expected_pre_entry_str, true,
@@ -1096,7 +1096,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_CloneSession) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_CloneSession) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char pre_entry_str[] = R"PROTO(
+  constexpr char pre_entry_str[] = R"pb(
     clone_session_entry {
       session_id: 1
       replicas {
@@ -1128,8 +1128,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_CloneSession) {
         instance: 1
       }
     }
-  )PROTO";
-  constexpr char expected_pre_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_pre_entry_str[] = R"pb(
     clone_session_entry {
       session_id: 1
       replicas {
@@ -1161,7 +1161,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_CloneSession) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(
       pre_entry_str, expected_pre_entry_str, false,
@@ -1171,7 +1171,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadPRE_CloneSession) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_InvalidPort) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char pre_entry_str[] = R"PROTO(
+  constexpr char pre_entry_str[] = R"pb(
     multicast_group_entry {
       multicast_group_id: 1
       replicas {
@@ -1179,7 +1179,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_InvalidPort) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::PacketReplicationEngineEntry pre_entry;
   EXPECT_OK(ParseProtoFromString(pre_entry_str, &pre_entry));
@@ -1196,7 +1196,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WritePRE_InvalidPort) {
 TEST_F(BfrtP4RuntimeTranslatorTest, PacketOut) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  char packet_out_str[] = R"PROTO(
+  char packet_out_str[] = R"pb(
     payload: "<raw packet>"
     metadata {
       metadata_id: 1
@@ -1206,8 +1206,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, PacketOut) {
       metadata_id: 2
       value: "\x01" # egress port
     }
-  )PROTO";
-  char expected_packet_out_str[] = R"PROTO(
+  )pb";
+  char expected_packet_out_str[] = R"pb(
     payload: "<raw packet>"
     metadata {
       metadata_id: 1
@@ -1217,7 +1217,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, PacketOut) {
       metadata_id: 2
       value: "\x01\x2C" # egress port
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(packet_out_str, expected_packet_out_str,
                        &BfrtP4RuntimeTranslator::TranslatePacketOut);
@@ -1226,7 +1226,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, PacketOut) {
 TEST_F(BfrtP4RuntimeTranslatorTest, PacketIn) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  char packet_in_str[] = R"PROTO(
+  char packet_in_str[] = R"pb(
     payload: "<raw packet>"
     metadata {
       metadata_id: 1
@@ -1236,8 +1236,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, PacketIn) {
       metadata_id: 2
       value: "\x00" # padding
     }
-  )PROTO";
-  char expected_packet_in_str[] = R"PROTO(
+  )pb";
+  char expected_packet_in_str[] = R"pb(
     payload: "<raw packet>"
     metadata {
       metadata_id: 1
@@ -1247,7 +1247,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, PacketIn) {
       metadata_id: 2
       value: "\x00" # padding
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(packet_in_str, expected_packet_in_str,
                        &BfrtP4RuntimeTranslator::TranslatePacketIn);
@@ -1257,7 +1257,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, PacketIn) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteCounterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char counter_entry_str[] = R"PROTO(
+  constexpr char counter_entry_str[] = R"pb(
     counter_id: 318814845
     index {
       index: 1
@@ -1266,8 +1266,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
-  constexpr char expected_counter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_counter_entry_str[] = R"pb(
     counter_id: 318814845
     index {
       index: 300
@@ -1276,7 +1276,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(counter_entry_str, expected_counter_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateCounterEntry);
@@ -1285,7 +1285,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteCounterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadCounterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char counter_entry_str[] = R"PROTO(
+  constexpr char counter_entry_str[] = R"pb(
     counter_id: 318814845
     index {
       index: 300
@@ -1294,8 +1294,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
-  constexpr char expected_counter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_counter_entry_str[] = R"pb(
     counter_id: 318814845
     index {
       index: 1
@@ -1304,7 +1304,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(counter_entry_str, expected_counter_entry_str, false,
                        &BfrtP4RuntimeTranslator::TranslateCounterEntry);
 }
@@ -1313,7 +1313,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadCounterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectCounterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char direct_counter_entry_str[] = R"PROTO(
+  constexpr char direct_counter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1352,8 +1352,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
-  constexpr char expected_direct_counter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_direct_counter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1392,7 +1392,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(direct_counter_entry_str,
                        expected_direct_counter_entry_str, true,
@@ -1402,7 +1402,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectCounterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectCounterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char direct_counter_entry_str[] = R"PROTO(
+  constexpr char direct_counter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1441,8 +1441,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
-  constexpr char expected_direct_counter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_direct_counter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1481,7 +1481,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectCounterEntry) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(direct_counter_entry_str,
                        expected_direct_counter_entry_str, false,
@@ -1492,7 +1492,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectCounterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteMeterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char meter_entry_str[] = R"PROTO(
+  constexpr char meter_entry_str[] = R"pb(
     meter_id: 55555
     index {
       index: 1
@@ -1501,8 +1501,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
-  constexpr char expected_meter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_meter_entry_str[] = R"pb(
     meter_id: 55555
     index {
       index: 300
@@ -1511,7 +1511,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(meter_entry_str, expected_meter_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateMeterEntry);
@@ -1520,7 +1520,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteMeterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadMeterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char meter_entry_str[] = R"PROTO(
+  constexpr char meter_entry_str[] = R"pb(
     meter_id: 55555
     index {
       index: 300
@@ -1529,8 +1529,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
-  constexpr char expected_meter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_meter_entry_str[] = R"pb(
     meter_id: 55555
     index {
       index: 1
@@ -1539,7 +1539,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(meter_entry_str, expected_meter_entry_str, false,
                        &BfrtP4RuntimeTranslator::TranslateMeterEntry);
@@ -1549,7 +1549,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadMeterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectMeterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char direct_meter_entry_str[] = R"PROTO(
+  constexpr char direct_meter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1588,8 +1588,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
-  constexpr char expected_direct_meter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_direct_meter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1628,7 +1628,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(direct_meter_entry_str, expected_direct_meter_entry_str,
                        true,
@@ -1638,7 +1638,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteDirectMeterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectMeterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char direct_meter_entry_str[] = R"PROTO(
+  constexpr char direct_meter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1677,8 +1677,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
-  constexpr char expected_direct_meter_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_direct_meter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1717,7 +1717,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectMeterEntry) {
       cir: 1
       pir: 1
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(direct_meter_entry_str, expected_direct_meter_entry_str,
                        false,
@@ -1728,7 +1728,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadDirectMeterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, WriteRegisterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char register_entry_str[] = R"PROTO(
+  constexpr char register_entry_str[] = R"pb(
     register_id: 66666
     index {
       index: 1
@@ -1736,8 +1736,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteRegisterEntry) {
     data {
       bitstring: "\x00"
     }
-  )PROTO";
-  constexpr char expected_register_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_register_entry_str[] = R"pb(
     register_id: 66666
     index {
       index: 300
@@ -1745,7 +1745,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteRegisterEntry) {
     data {
       bitstring: "\x00"
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(register_entry_str, expected_register_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateRegisterEntry);
@@ -1754,7 +1754,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, WriteRegisterEntry) {
 TEST_F(BfrtP4RuntimeTranslatorTest, ReadRegisterEntry) {
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char register_entry_str[] = R"PROTO(
+  constexpr char register_entry_str[] = R"pb(
     register_id: 66666
     index {
       index: 300
@@ -1762,8 +1762,8 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadRegisterEntry) {
     data {
       bitstring: "\x00"
     }
-  )PROTO";
-  constexpr char expected_register_entry_str[] = R"PROTO(
+  )pb";
+  constexpr char expected_register_entry_str[] = R"pb(
     register_id: 66666
     index {
       index: 1
@@ -1771,7 +1771,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, ReadRegisterEntry) {
     data {
       bitstring: "\x00"
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(register_entry_str, expected_register_entry_str, false,
                        &BfrtP4RuntimeTranslator::TranslateRegisterEntry);
@@ -1783,7 +1783,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       /*translation_enabled=*/false, bf_sde_mock_.get(), kDeviceId);
   EXPECT_OK(PushChassisConfig());
   EXPECT_OK(PushForwardingPipelineConfig());
-  constexpr char table_entry_str[] = R"PROTO(
+  constexpr char table_entry_str[] = R"pb(
     table_id: 33583783
     match {
       field_id: 1
@@ -1795,12 +1795,12 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
         params { param_id: 1 value: "\x01" }
       }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(table_entry_str, table_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateTableEntry);
 
-  constexpr char action_profile_member_str[] = R"PROTO(
+  constexpr char action_profile_member_str[] = R"pb(
     action_profile_id: 1
     member_id: 1
     action {
@@ -1808,13 +1808,13 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       params { param_id: 1 value: "\x01" }
       params { param_id: 2 value: "\x01" }
     }
-  )PROTO";
+  )pb";
 
   TestEntryTranslation(action_profile_member_str, action_profile_member_str,
                        true,
                        &BfrtP4RuntimeTranslator::TranslateActionProfileMember);
 
-  constexpr char direct_meter_entry_str[] = R"PROTO(
+  constexpr char direct_meter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1853,11 +1853,11 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       cir: 1
       pir: 1
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(direct_meter_entry_str, direct_meter_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateDirectMeterEntry);
 
-  constexpr char meter_entry_str[] = R"PROTO(
+  constexpr char meter_entry_str[] = R"pb(
     meter_id: 55555
     index {
       index: 1
@@ -1866,11 +1866,11 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       cir: 1
       pir: 1
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(meter_entry_str, meter_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateMeterEntry);
 
-  constexpr char counter_entry_str[] = R"PROTO(
+  constexpr char counter_entry_str[] = R"pb(
     counter_id: 318814845
     index {
       index: 1
@@ -1879,11 +1879,11 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(counter_entry_str, counter_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateCounterEntry);
 
-  constexpr char direct_counter_entry_str[] = R"PROTO(
+  constexpr char direct_counter_entry_str[] = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -1922,11 +1922,11 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       byte_count: 1
       packet_count: 1
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(direct_counter_entry_str, direct_counter_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateDirectCounterEntry);
 
-  constexpr char pre_entry_str[] = R"PROTO(
+  constexpr char pre_entry_str[] = R"pb(
     multicast_group_entry {
       multicast_group_id: 1
       replicas {
@@ -1938,12 +1938,12 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(
       pre_entry_str, pre_entry_str, true,
       &BfrtP4RuntimeTranslator::TranslatePacketReplicationEngineEntry);
 
-  char packet_out_str[] = R"PROTO(
+  char packet_out_str[] = R"pb(
     payload: "<raw packet>"
     metadata {
       metadata_id: 1
@@ -1953,11 +1953,11 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       metadata_id: 2
       value: "\x01" # egress port
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(packet_out_str, packet_out_str,
                        &BfrtP4RuntimeTranslator::TranslatePacketOut);
 
-  char packet_in_str[] = R"PROTO(
+  char packet_in_str[] = R"pb(
     payload: "<raw packet>"
     metadata {
       metadata_id: 1
@@ -1967,11 +1967,11 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
       metadata_id: 2
       value: "\x00" # padding
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(packet_in_str, packet_in_str,
                        &BfrtP4RuntimeTranslator::TranslatePacketIn);
 
-  constexpr char register_entry_str[] = R"PROTO(
+  constexpr char register_entry_str[] = R"pb(
     register_id: 66666
     index {
       index: 300
@@ -1979,7 +1979,7 @@ TEST_F(BfrtP4RuntimeTranslatorTest, TranslationDisabled) {
     data {
       bitstring: "\x00"
     }
-  )PROTO";
+  )pb";
   TestEntryTranslation(register_entry_str, register_entry_str, true,
                        &BfrtP4RuntimeTranslator::TranslateRegisterEntry);
 

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
@@ -58,7 +58,7 @@ TEST_F(BfrtPreManagerTest, PushForwardingPipelineConfigSuccess) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertMulticastGroupSuccess) {
-  const std::string kMulticastGroupEntryText = R"PROTO(
+  const std::string kMulticastGroupEntryText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
       replicas {
@@ -74,7 +74,7 @@ TEST_F(BfrtPreManagerTest, InsertMulticastGroupSuccess) {
         instance: 654
       }
     }
-  )PROTO";
+  )pb";
   constexpr int kGroupId = 55;
   const std::vector<uint32> egress_ports_group1 = {1, 2};
   const std::vector<uint32> egress_ports_group2 = {3};
@@ -108,7 +108,7 @@ TEST_F(BfrtPreManagerTest, InsertMulticastGroupSuccess) {
 }
 
 TEST_F(BfrtPreManagerTest, ModifyMulticastGroupSuccess) {
-  const std::string kMulticastGroupEntryText = R"PROTO(
+  const std::string kMulticastGroupEntryText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
       replicas {
@@ -124,7 +124,7 @@ TEST_F(BfrtPreManagerTest, ModifyMulticastGroupSuccess) {
         instance: 987
       }
     }
-  )PROTO";
+  )pb";
   constexpr int kGroupId = 55;
   const std::vector<uint32> egress_ports_group1 = {5, 6};
   const std::vector<uint32> egress_ports_group2 = {7};
@@ -166,11 +166,11 @@ TEST_F(BfrtPreManagerTest, ModifyMulticastGroupSuccess) {
 }
 
 TEST_F(BfrtPreManagerTest, DeleteMulticastGroupSuccess) {
-  const std::string kMulticastGroupEntryText = R"PROTO(
+  const std::string kMulticastGroupEntryText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
     }
-  )PROTO";
+  )pb";
   constexpr int kGroupId = 55;
   const std::vector<uint32> nodes = {1, 2, 3};
   auto session_mock = std::make_shared<SessionMock>();
@@ -199,12 +199,12 @@ TEST_F(BfrtPreManagerTest, DeleteMulticastGroupSuccess) {
 TEST_F(BfrtPreManagerTest, ReadMulticastGroupSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
-  const std::string kMulticastGroupRequestText = R"PROTO(
+  const std::string kMulticastGroupRequestText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
     }
-  )PROTO";
-  const std::string kMulticastGroupResponseText = R"PROTO(
+  )pb";
+  const std::string kMulticastGroupResponseText = R"pb(
     entities {
       packet_replication_engine_entry {
         multicast_group_entry {
@@ -228,7 +228,7 @@ TEST_F(BfrtPreManagerTest, ReadMulticastGroupSuccess) {
         }
       }
     }
-  )PROTO";
+  )pb";
   const int kMcNodeId1 = 100;
   const int kReplicationId1 = 111;
   const std::vector<uint32> kLagIds1 = {0, 0};
@@ -285,12 +285,12 @@ TEST_F(BfrtPreManagerTest, ReadMulticastGroupSuccess) {
 TEST_F(BfrtPreManagerTest, ReadMulticastGroupWildcardSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
-  const std::string kMulticastGroupRequestText = R"PROTO(
+  const std::string kMulticastGroupRequestText = R"pb(
     multicast_group_entry {
       multicast_group_id: 0
     }
-  )PROTO";
-  const std::string kMulticastGroupResponseText = R"PROTO(
+  )pb";
+  const std::string kMulticastGroupResponseText = R"pb(
     entities {
       packet_replication_engine_entry {
         multicast_group_entry {
@@ -321,7 +321,7 @@ TEST_F(BfrtPreManagerTest, ReadMulticastGroupWildcardSuccess) {
         }
       }
     }
-  )PROTO";
+  )pb";
   const int kMcNodeId1 = 100;
   const int kReplicationId1 = 111;
   const std::vector<uint32> kLagIds1 = {0, 0};
@@ -378,7 +378,7 @@ TEST_F(BfrtPreManagerTest, ReadMulticastGroupWildcardSuccess) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionSuccess) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
@@ -388,7 +388,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionSuccess) {
       class_of_service: 2
       packet_length_bytes: 1500
     }
-  )PROTO";
+  )pb";
   constexpr uint32 kSessionId = 55;
   constexpr int kEgressPort = 123;
   constexpr int kCos = 2;
@@ -413,14 +413,14 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionSuccess) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidSessionIdFail) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 1016
       replicas {
         egress_port: 123
       }
     }
-  )PROTO";
+  )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
   ::p4::v1::PacketReplicationEngineEntry entry;
@@ -439,7 +439,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidSessionIdFail) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidPacketLengthFail) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
@@ -447,7 +447,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidPacketLengthFail) {
       }
       packet_length_bytes: 65536
     }
-  )PROTO";
+  )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
   ::p4::v1::PacketReplicationEngineEntry entry;
@@ -467,7 +467,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidPacketLengthFail) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionMultipleReplicasFail) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
@@ -477,7 +477,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionMultipleReplicasFail) {
         egress_port: 456
       }
     }
-  )PROTO";
+  )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
   ::p4::v1::PacketReplicationEngineEntry entry;
@@ -497,7 +497,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionMultipleReplicasFail) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInstanceSetFail) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
@@ -505,7 +505,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInstanceSetFail) {
         instance: 1
       }
     }
-  )PROTO";
+  )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
   ::p4::v1::PacketReplicationEngineEntry entry;
@@ -525,14 +525,14 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInstanceSetFail) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidEgressPortFail) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
         egress_port: 0
       }
     }
-  )PROTO";
+  )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
   ::p4::v1::PacketReplicationEngineEntry entry;
@@ -551,7 +551,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidEgressPortFail) {
 }
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidCosFail) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
@@ -559,7 +559,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidCosFail) {
       }
       class_of_service: 9
     }
-  )PROTO";
+  )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
   ::p4::v1::PacketReplicationEngineEntry entry;
@@ -579,7 +579,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidCosFail) {
 }
 
 TEST_F(BfrtPreManagerTest, ModifyCloneSessionSuccess) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
       replicas {
@@ -589,7 +589,7 @@ TEST_F(BfrtPreManagerTest, ModifyCloneSessionSuccess) {
       class_of_service: 4
       packet_length_bytes: 510
     }
-  )PROTO";
+  )pb";
   constexpr uint32 kSessionId = 55;
   constexpr int kEgressPort = 654;
   constexpr int kCos = 4;
@@ -614,11 +614,11 @@ TEST_F(BfrtPreManagerTest, ModifyCloneSessionSuccess) {
 }
 
 TEST_F(BfrtPreManagerTest, DeleteCloneSessionSuccess) {
-  const std::string kCloneSessionEntryText = R"PROTO(
+  const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
     }
-  )PROTO";
+  )pb";
   constexpr uint32 kSessionId = 55;
   auto session_mock = std::make_shared<SessionMock>();
 
@@ -641,12 +641,12 @@ TEST_F(BfrtPreManagerTest, DeleteCloneSessionSuccess) {
 TEST_F(BfrtPreManagerTest, ReadCloneSessionSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
-  const std::string kCloneSessionEntryRequestText = R"PROTO(
+  const std::string kCloneSessionEntryRequestText = R"pb(
     clone_session_entry {
       session_id: 55
     }
-  )PROTO";
-  const std::string kCloneSessionEntryResponseText = R"PROTO(
+  )pb";
+  const std::string kCloneSessionEntryResponseText = R"pb(
     entities {
       packet_replication_engine_entry {
         clone_session_entry {
@@ -660,7 +660,7 @@ TEST_F(BfrtPreManagerTest, ReadCloneSessionSuccess) {
         }
       }
     }
-  )PROTO";
+  )pb";
   const int kSessionId = 55;
   std::vector<uint32> session_ids = {kSessionId};
   std::vector<int> egress_ports = {123};
@@ -700,12 +700,12 @@ TEST_F(BfrtPreManagerTest, ReadCloneSessionSuccess) {
 TEST_F(BfrtPreManagerTest, ReadCloneSessionWildcardSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
-  const std::string kCloneSessionEntryRequestText = R"PROTO(
+  const std::string kCloneSessionEntryRequestText = R"pb(
     clone_session_entry {
       session_id: 0
     }
-  )PROTO";
-  const std::string kCloneSessionEntryResponseText = R"PROTO(
+  )pb";
+  const std::string kCloneSessionEntryResponseText = R"pb(
     entities {
       packet_replication_engine_entry {
         clone_session_entry {
@@ -732,7 +732,7 @@ TEST_F(BfrtPreManagerTest, ReadCloneSessionWildcardSuccess) {
         }
       }
     }
-  )PROTO";
+  )pb";
   const int kSessionId1 = 55;
   const int kSessionId2 = 88;
   std::vector<uint32> session_ids = {kSessionId1, kSessionId2};

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -48,7 +48,7 @@ class BfrtTableManagerTest : public ::testing::Test {
   }
 
   ::util::Status PushTestConfig() {
-    const std::string kSamplePipelineText = R"PROTO(
+    const std::string kSamplePipelineText = R"pb(
       programs {
         name: "test pipeline config",
         p4info {
@@ -130,7 +130,7 @@ class BfrtTableManagerTest : public ::testing::Test {
           }
         }
       }
-    )PROTO";
+    )pb";
     BfrtDeviceConfig config;
     RETURN_IF_ERROR(ParseProtoFromString(kSamplePipelineText, &config));
     return bfrt_table_manager_->PushForwardingPipelineConfig(config);
@@ -174,7 +174,7 @@ TEST_F(BfrtTableManagerTest, WriteDirectCounterEntryTest) {
           ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableDataInterface>>(
               std::move(table_data_mock)))));
 
-  const std::string kDirectCounterEntryText = R"PROTO(
+  const std::string kDirectCounterEntryText = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -192,7 +192,7 @@ TEST_F(BfrtTableManagerTest, WriteDirectCounterEntryTest) {
       byte_count: 200
       packet_count: 100
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::DirectCounterEntry entry;
   ASSERT_OK(ParseProtoFromString(kDirectCounterEntryText, &entry));
@@ -219,7 +219,7 @@ TEST_F(BfrtTableManagerTest, WriteIndirectMeterEntryTest) {
                                  Optional(kMeterIndex), false, 1, 100, 2, 200))
       .WillOnce(Return(::util::OkStatus()));
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
@@ -230,7 +230,7 @@ TEST_F(BfrtTableManagerTest, WriteIndirectMeterEntryTest) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -258,12 +258,12 @@ TEST_F(BfrtTableManagerTest, ResetIndirectMeterEntryTest) {
                   kUnsetMeterThresholdReset, kUnsetMeterThresholdReset))
       .WillOnce(Return(::util::OkStatus()));
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -278,7 +278,7 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 0
     index {
       index: 12345
@@ -289,7 +289,7 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -307,7 +307,7 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryInsertDelete) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
@@ -318,7 +318,7 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryInsertDelete) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -361,7 +361,7 @@ TEST_F(BfrtTableManagerTest, ReadSingleIndirectMeterEntryTest) {
                         SetArgPointee<8>(pbursts), SetArgPointee<9>(in_pps),
                         Return(::util::OkStatus())));
 
-    const std::string kMeterResponseText = R"PROTO(
+    const std::string kMeterResponseText = R"pb(
       entities {
         meter_entry {
           meter_id: 55555
@@ -376,7 +376,7 @@ TEST_F(BfrtTableManagerTest, ReadSingleIndirectMeterEntryTest) {
           }
         }
       }
-    )PROTO";
+    )pb";
     ::p4::v1::ReadResponse resp;
     ASSERT_OK(ParseProtoFromString(kMeterResponseText, &resp));
     const auto& entry = resp.entities(0).meter_entry();
@@ -386,12 +386,12 @@ TEST_F(BfrtTableManagerTest, ReadSingleIndirectMeterEntryTest) {
     EXPECT_CALL(writer_mock, Write(EqualsProto(resp))).WillOnce(Return(true));
   }
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -407,7 +407,7 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryReadWithoutId) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 0
     index {
       index: 12345
@@ -418,7 +418,7 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryReadWithoutId) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -451,14 +451,14 @@ TEST_F(BfrtTableManagerTest, RejectTableEntryWithDontCareRangeMatch) {
           ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableDataInterface>>(
               std::move(table_data_mock)))));
 
-  const std::string kTableEntryText = R"PROTO(
+  const std::string kTableEntryText = R"pb(
     table_id: 33583783
     match {
       field_id: 3
       range { low: "\000\000" high: "\x7f\xff" }
     }
     priority: 10
-  )PROTO";
+  )pb";
   ::p4::v1::TableEntry entry;
   ASSERT_OK(ParseProtoFromString(kTableEntryText, &entry));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,

--- a/stratum/hal/lib/bcm/acl_table_test.cc
+++ b/stratum/hal/lib/bcm/acl_table_test.cc
@@ -28,13 +28,13 @@ using testing::HasSubstr;
 using testing::UnorderedElementsAre;
 using testing::UnorderedElementsAreArray;
 
-constexpr char kDefaultP4Table[] = R"PROTO(
+constexpr char kDefaultP4Table[] = R"pb(
   preamble { id: 1 name: "table_1" }
   match_fields { id: 100 }
   match_fields { id: 200 }
   match_fields { id: 300 }
   size: 10
-)PROTO";
+)pb";
 
 ::p4::config::v1::Table DefaultP4Table() {
   ::p4::config::v1::Table p4_table;

--- a/stratum/hal/lib/bcm/bcm_acl_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_acl_manager_test.cc
@@ -65,7 +65,7 @@ using StageToTablesMap =
 using StageToControlBlockMap =
     std::map<P4Annotation::PipelineStage, P4ControlBlock>;
 
-constexpr char kDefaultBcmHardwareSpecsText[] = R"PROTO(
+constexpr char kDefaultBcmHardwareSpecsText[] = R"pb(
   chip_specs {
     chip_type: UNKNOWN
     acl {
@@ -83,7 +83,7 @@ constexpr char kDefaultBcmHardwareSpecsText[] = R"PROTO(
     }
     udf { chunk_bits: 16 chunks_per_set: 8 set_count: 2 }
   }
-)PROTO";
+)pb";
 
 // *****************************************************************************
 // Matchers (and supporting functions)
@@ -305,70 +305,70 @@ const std::map<int, ::p4::config::v1::Table>& DefaultP4Tables() {
   static const auto* tables = []() {
     auto* tables = new std::map<int, ::p4::config::v1::Table>();
     ::p4::config::v1::Table table;
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 1 name: "table_1" }
       match_fields { id: 1 name: "P4_FIELD_TYPE_ETH_SRC" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(1, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 2 name: "table_2" }
       match_fields { id: 2 name: "P4_FIELD_TYPE_ETH_DST" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(2, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 3 name: "table_3" }
       match_fields { id: 3 name: "P4_FIELD_TYPE_ETH_TYPE" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(3, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 4 name: "table_4" }
       match_fields { id: 4 name: "P4_FIELD_TYPE_IPV4_SRC" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(4, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 5 name: "table_5" }
       match_fields { id: 5 name: "P4_FIELD_TYPE_IPV4_DST" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(5, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 6 name: "table_6" }
       match_fields { id: 6 name: "P4_FIELD_TYPE_IPV6_SRC" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(6, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 7 name: "table_7" }
       match_fields { id: 7 name: "P4_FIELD_TYPE_IPV6_DST" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(7, table));
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 8 name: "table_8" }
       match_fields { id: 1 name: "P4_FIELD_TYPE_ETH_SRC" match_type: TERNARY }
       match_fields { id: 2 name: "P4_FIELD_TYPE_ETH_DST" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(8, table));
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 9 name: "table_9" }
       match_fields { id: 4 name: "P4_FIELD_TYPE_IPV4_SRC" match_type: TERNARY }
       match_fields { id: 5 name: "P4_FIELD_TYPE_IPV4_DST" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(9, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       preamble { id: 10 name: "table_10" }
       match_fields { id: 6 name: "P4_FIELD_TYPE_IPV6_SRC" match_type: TERNARY }
       match_fields { id: 7 name: "P4_FIELD_TYPE_IPV6_DST" match_type: TERNARY }
       size: 10
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(10, table));
     return tables;
   }();
@@ -394,42 +394,42 @@ const std::map<int, BcmAclTable>& DefaultBcmAclTables() {
   static const auto* tables = []() {
     auto tables = new std::map<int, BcmAclTable>();
     BcmAclTable table;
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: ETH_SRC })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: ETH_SRC })pb", &table));
     tables->insert(std::make_pair(1, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: ETH_DST })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: ETH_DST })pb", &table));
     tables->insert(std::make_pair(2, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: ETH_TYPE })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: ETH_TYPE })pb", &table));
     tables->insert(std::make_pair(3, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: IPV4_SRC })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: IPV4_SRC })pb", &table));
     tables->insert(std::make_pair(4, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: IPV4_DST })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: IPV4_DST })pb", &table));
     tables->insert(std::make_pair(5, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: IPV6_SRC_UPPER_64 })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: IPV6_SRC_UPPER_64 })pb", &table));
     tables->insert(std::make_pair(6, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
-      fields { type: IPV6_DST_UPPER_64 })PROTO", &table));
+    CHECK_OK(ParseProtoFromString(R"pb(
+      fields { type: IPV6_DST_UPPER_64 })pb", &table));
     tables->insert(std::make_pair(7, table));
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       fields { type: ETH_SRC }
       fields { type: ETH_DST }
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(8, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       fields { type: IPV4_SRC }
       fields { type: IPV4_DST }
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(9, table));
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       fields { type: IPV6_SRC_UPPER_64 }
       fields { type: IPV6_DST_UPPER_64 }
-    )PROTO", &table));
+    )pb", &table));
     tables->insert(std::make_pair(10, table));
     return tables;
   }();
@@ -1815,17 +1815,17 @@ TEST_F(BcmAclManagerTest, TestUpdateTableEntryMeterBcmFailure) {
 
 TEST_F(BcmAclManagerTest, TestInstallPhysicalTableWithConstConditions) {
   std::vector<std::string> table_strings = {
-      R"PROTO(
+      R"pb(
         preamble { id: 1 name: "table_1" }
         match_fields { id: 1 name: "P4_FIELD_TYPE_ETH_SRC" match_type: TERNARY }
         size: 10
-      )PROTO",
-      R"PROTO(
+      )pb",
+      R"pb(
         preamble { id: 2 name: "table_2" }
         match_fields { id: 1 name: "P4_FIELD_TYPE_ETH_DST" match_type: TERNARY }
         size: 10
-      )PROTO",
-      R"PROTO(
+      )pb",
+      R"pb(
         preamble { id: 3 name: "table_3" }
         match_fields {
           id: 1
@@ -1833,7 +1833,7 @@ TEST_F(BcmAclManagerTest, TestInstallPhysicalTableWithConstConditions) {
           match_type: TERNARY
         }
         size: 10
-      )PROTO"};
+      )pb"};
 
   std::vector<::p4::config::v1::Table> tables;
   for (const std::string& table_string : table_strings) {
@@ -1853,9 +1853,9 @@ TEST_F(BcmAclManagerTest, TestInstallPhysicalTableWithConstConditions) {
           .Build();
 
   std::vector<std::string> bcm_table_strings = {
-      R"PROTO(fields { type: ETH_SRC })PROTO",
-      R"PROTO(fields { type: ETH_DST } fields { type: IP_TYPE })PROTO",
-      R"PROTO(fields { type: IPV4_SRC } fields { type: IP_TYPE })PROTO",
+      R"pb(fields { type: ETH_SRC })pb",
+      R"pb(fields { type: ETH_DST } fields { type: IP_TYPE })pb",
+      R"pb(fields { type: IPV4_SRC } fields { type: IP_TYPE })pb",
   };
   std::vector<BcmAclTable> expected_bcm_tables;
   for (const std::string& table_string : bcm_table_strings) {
@@ -1882,11 +1882,11 @@ TEST_F(BcmAclManagerTest, TestInstallPhysicalTableWithConstConditions) {
 
 TEST_F(BcmAclManagerTest, TestInsertTableEntryWithConstConditions) {
   ::p4::config::v1::Table table;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     preamble { id: 2 name: "table_2" }
     match_fields { id: 1 name: "P4_FIELD_TYPE_ETH_DST" match_type: TERNARY }
     size: 10
-  )PROTO", &table));
+  )pb", &table));
 
   P4ControlBlock control_block;
   *control_block.add_statements() =
@@ -1896,18 +1896,18 @@ TEST_F(BcmAclManagerTest, TestInsertTableEntryWithConstConditions) {
           .Build();
 
   ::p4::v1::TableEntry table_entry;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 2
     match { field_id: 1 ternary { value: "\00A" } }
     priority: 15
-  )PROTO", &table_entry));
+  )pb", &table_entry));
 
   BcmFlowEntry bcm_flow_entry;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     bcm_table_type: BCM_TABLE_ACL
     fields { type: ETH_DST value { u32: 10 } }
     fields { type: IP_TYPE value { u32: 0x800 } }
-  )PROTO", &bcm_flow_entry));
+  )pb", &bcm_flow_entry));
 
   ASSERT_OK(SetUpTables({table}, control_block));
   EXPECT_CALL(*bcm_table_manager_mock_, FillBcmFlowEntry(_, _, _))

--- a/stratum/hal/lib/bcm/bcm_flow_table_test.cc
+++ b/stratum/hal/lib/bcm/bcm_flow_table_test.cc
@@ -20,7 +20,7 @@ namespace {
 using test_utils::EqualsProto;
 using test_utils::IsOkAndHolds;
 
-constexpr char kMockTableEntry[] = R"PROTO(
+constexpr char kMockTableEntry[] = R"pb(
     table_id: 1
     match {
       field_id: 1
@@ -43,7 +43,7 @@ constexpr char kMockTableEntry[] = R"PROTO(
     priority: 10
     action {
       action_profile_member_id: 11
-    })PROTO";
+    })pb";
 
 const ::p4::v1::TableEntry& MockTableEntry() {
   static const ::p4::v1::TableEntry* entry = []() {

--- a/stratum/hal/lib/bcm/bcm_table_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_table_manager_test.cc
@@ -418,38 +418,38 @@ const std::vector<std::pair<MappedField, BcmField>>& P4ToBcmFields() {
     // P4_FIELD_TYPE_UNKNOWN: No conversion.
     // P4_FIELD_TYPE_ANNOTATED: No conversion.
     //
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_SRC
       value { u64: 11111111111111 }
       mask { u64: 99999999999999 }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_DST
       value { u64: 22222222222222 }
       mask { u64: 99999999999999 }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
     // P4_FIELD_TYPE_ETH_TYPE: No currentf conversion.
     // P4_FIELD_TYPE_VLAN_VID: No current conversion.
     // P4_FIELD_TYPE_VLAN_PCP: No current conversion.
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV4_SRC
       value { u32: 11111111 }
       mask { u32: 99999999 }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV4_DST
       value { u32: 22222222 }
       mask { u32: 99999999 }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
 
@@ -457,30 +457,30 @@ const std::vector<std::pair<MappedField, BcmField>>& P4ToBcmFields() {
     // P4_FIELD_TYPE_IPV4_DIFFSERV: No current conversion.
     // P4_FIELD_TYPE_NW_TTL: No current conversion.
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV6_SRC
       value { b: "\x00\x01\x02\x03\x04\x05" }
       mask { b: "\xaf\xaf\xaf\xaf\xaf\xaf" }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     // IPV6_SRC translated to IPV6_SRC_UPPER_64.
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: IPV6_SRC_UPPER_64
       value { b: "\x00\x01\x02\x03\x04\x05" }
       mask { b: "\xaf\xaf\xaf\xaf\xaf\xaf" }
-    )PROTO", &bcm_field));
+    )pb", &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV6_DST
       value { b: "\x10\x11\x12\x13\x14\x15" }
       mask { b: "\xcf\xcf\xcf\xcf\xcf\xcf" }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     // IPV6_DST translated to IPV6_SRC_UPPER_64.
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: IPV6_DST_UPPER_64
       value { b: "\x10\x11\x12\x13\x14\x15" }
       mask { b: "\xcf\xcf\xcf\xcf\xcf\xcf" }
-    )PROTO", &bcm_field));
+    )pb", &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
 
     // P4_FIELD_TYPE_IPV6_NEXT_HDR: No current conversion.
@@ -490,10 +490,10 @@ const std::vector<std::pair<MappedField, BcmField>>& P4ToBcmFields() {
     // P4_FIELD_TYPE_L4_DST_PORT: No current conversion.
     // P4_FIELD_TYPE_ARP_TPA: No current conversion.
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_VRF
       value { u32: 1234 }
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_field));
     field_map->push_back(std::make_pair(p4_field, bcm_field));
 
@@ -565,44 +565,44 @@ P4ToBcmActions() {
     // P4_FIELD_TYPE_UNKNOWN: No conversion.
     // P4_FIELD_TYPE_ANNOTATED: No conversion.
     //
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_SRC
       u64: 11111111111111
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_DST
       u64: 22222222222222
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
     // P4_FIELD_TYPE_ETH_TYPE: No current conversion.
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_VLAN_VID u32: 22
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_VLAN_PCP u32: 22
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV4_SRC
       u32: 11111111
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV4_DST
       u32: 22222222
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
@@ -610,17 +610,17 @@ P4ToBcmActions() {
     // P4_FIELD_TYPE_IPV4_DIFFSERV: No current conversion.
     // P4_FIELD_TYPE_NW_TTL: No current conversion.
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV6_SRC
       b: "\x00\x01\x02\x03\x04\x05"
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_IPV6_DST
       b: "\x10\x11\x12\x13\x14\x15"
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
@@ -631,16 +631,16 @@ P4ToBcmActions() {
     // P4_FIELD_TYPE_L4_DST_PORT: No current conversion.
     // P4_FIELD_TYPE_ARP_TPA: No current conversion.
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_VRF u32: 1234
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
 
-    EXPECT_OK(ParseProtoFromString(R"PROTO(
+    EXPECT_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_CLASS_ID
       u32: 1234
-    )PROTO", &p4_field));
+    )pb", &p4_field));
     EXPECT_TRUE(StripFieldTypeAndCopyToBcm(p4_field, &bcm_action));
     field_map->push_back(std::make_pair(p4_field, bcm_action));
     // P4_FIELD_TYPE_COLOR: No current conversion.
@@ -1648,11 +1648,11 @@ TEST_F(BcmTableManagerTest,
 
   // Setup the DST IP field.
   MappedField* ip_field = source.add_fields();
-  ASSERT_OK(ParseProtoFromString(R"PROTO(
+  ASSERT_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_IPV4_DST
     value { u32: 1 }
     mask { u32: 0xffffffff }
-  )PROTO", ip_field));
+  )pb", ip_field));
 
   ASSERT_NO_FATAL_FAILURE(PushTestConfig());
 
@@ -1660,11 +1660,11 @@ TEST_F(BcmTableManagerTest,
 
   // VRF fields cannot have a mask.
   MappedField* vrf_field = source.add_fields();
-  ASSERT_OK(ParseProtoFromString(R"PROTO(
+  ASSERT_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_VRF
     value { u32: 1 }
     mask { u32: 1 }
-  )PROTO", vrf_field));
+  )pb", vrf_field));
   ::util::Status status = bcm_table_manager_->CommonFlowEntryToBcmFlowEntry(
       source, ::p4::v1::Update::INSERT, &actual);
   EXPECT_FALSE(status.ok());
@@ -1672,10 +1672,10 @@ TEST_F(BcmTableManagerTest,
               HasSubstr("VRF match fields do not accept a mask value."));
 
   // VRF fields cannot have an out-of-range value.
-  ASSERT_OK(ParseProtoFromString(R"PROTO(
+  ASSERT_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_VRF
     value { u32: 99999999 }
-  )PROTO", vrf_field));
+  )pb", vrf_field));
   status = bcm_table_manager_->CommonFlowEntryToBcmFlowEntry(
       source, ::p4::v1::Update::INSERT, &actual);
   EXPECT_FALSE(status.ok());
@@ -1687,11 +1687,11 @@ TEST_F(BcmTableManagerTest,
        CommonFlowEntryToBcmFlowEntry_Insert_InvalidLpmFlowFields_NoVrfForIpv4) {
   CommonFlowEntry source;
 
-  ASSERT_OK(ParseProtoFromString(R"PROTO(
+  ASSERT_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_IPV4_DST
     value { u32: 22 }
     mask { u32: 99 }
-  )PROTO", source.add_fields()));
+  )pb", source.add_fields()));
 
   // Setup table type and stage.
   source.mutable_table_info()->set_type(P4_TABLE_L3_IP);
@@ -1716,11 +1716,11 @@ TEST_F(BcmTableManagerTest,
        CommonFlowEntryToBcmFlowEntry_Insert_InvalidLpmFlowFields_NoVrfForIpv6) {
   CommonFlowEntry source;
 
-  ASSERT_OK(ParseProtoFromString(R"PROTO(
+  ASSERT_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_IPV6_DST
     value { b: "\x22\x23" }
     mask { b: "\xff\xff" }
-  )PROTO", source.add_fields()));
+  )pb", source.add_fields()));
 
   // Setup table type and stage.
   source.mutable_table_info()->set_type(P4_TABLE_L3_IP);
@@ -4413,20 +4413,20 @@ TEST_F(BcmTableManagerTest,
 
   // Set up the input CommonFlowEntry. This does not have const condition data.
   CommonFlowEntry source;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_info { id: 100 name: "test_table" pipeline_stage: INGRESS_ACL }
     fields { type: P4_FIELD_TYPE_ETH_TYPE value { u32: 10 } }
     action { type: P4_ACTION_TYPE_FUNCTION }
     priority: 10
-  )PROTO", &source));
+  )pb", &source));
 
   BcmFlowEntry expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     bcm_table_type: BCM_TABLE_ACL
     bcm_acl_table_id: 1
     fields { type: ETH_TYPE value { u32: 10 } }
     acl_stage: BCM_ACL_STAGE_IFP
-  )PROTO", &expected));
+  )pb", &expected));
   // FIXME: No priority shift in SDKLT
   // expected.set_priority((20 << 16) + 10);
   expected.set_priority(10);
@@ -4454,22 +4454,22 @@ TEST_F(BcmTableManagerTest,
 
   // Set up the input CommonFlowEntry. This does not have const condition data.
   CommonFlowEntry source;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_info { id: 100 name: "test_table" pipeline_stage: INGRESS_ACL }
     fields { type: P4_FIELD_TYPE_ETH_TYPE value { u32: 10 } }
     action { type: P4_ACTION_TYPE_FUNCTION }
     priority: 10
-  )PROTO", &source));
+  )pb", &source));
 
   BcmFlowEntry expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     bcm_table_type: BCM_TABLE_ACL
     bcm_acl_table_id: 1
     fields { type: ETH_TYPE value { u32: 10 } }
     fields { type: IP_TYPE value { u32: 0x86dd } }
     fields { type: IP_PROTO_NEXT_HDR value { u32: 58 } }
     acl_stage: BCM_ACL_STAGE_IFP
-  )PROTO", &expected));
+  )pb", &expected));
   // FIXME: No priority shift in SDKLT
   // expected.set_priority((20 << 16) + 10);
   expected.set_priority(10);
@@ -4495,12 +4495,12 @@ TEST_F(BcmTableManagerTest,
 
   // Set up the input CommonFlowEntry. This does not have const condition data.
   CommonFlowEntry source;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_info { id: 100 name: "test_table" pipeline_stage: INGRESS_ACL }
     fields { type: P4_FIELD_TYPE_ETH_TYPE value { u32: 10 } }
     action { type: P4_ACTION_TYPE_FUNCTION }
     priority: 10
-  )PROTO", &source));
+  )pb", &source));
 
   BcmFlowEntry actual;
   EXPECT_THAT(bcm_table_manager_->CommonFlowEntryToBcmFlowEntry(
@@ -4528,20 +4528,20 @@ TEST_P(ConstConditionTest,
 
   // Set up the input CommonFlowEntry. This does not have const condition data.
   CommonFlowEntry source;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_info { id: 100 name: "test_table" pipeline_stage: INGRESS_ACL }
     fields { type: P4_FIELD_TYPE_ETH_TYPE value { u32: 10 } }
     action { type: P4_ACTION_TYPE_FUNCTION }
     priority: 10
-  )PROTO", &source));
+  )pb", &source));
 
   BcmFlowEntry expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     bcm_table_type: BCM_TABLE_ACL
     bcm_acl_table_id: 1
     fields { type: ETH_TYPE value { u32: 10 } }
     acl_stage: BCM_ACL_STAGE_IFP
-  )PROTO", &expected));
+  )pb", &expected));
   // FIXME: No priority shift in SDKLT
   // expected.set_priority((20 << 16) + 10);
   expected.set_priority(10);

--- a/stratum/hal/lib/bcm/bcm_udf_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_udf_manager_test.cc
@@ -218,65 +218,65 @@ const MappedField& MappedFieldByType(P4FieldType type) {
     auto* field_map = new absl::flat_hash_map<P4FieldType, MappedField,
                                               EnumHash<P4FieldType>>();
     MappedField mapped_field;
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ARP_TPA
       bit_offset: 192
       bit_width: 32
       header_type: P4_HEADER_ARP
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_DST
       bit_offset: 0
       bit_width: 48
       header_type: P4_HEADER_ETHERNET
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_SRC
       bit_offset: 48
       bit_width: 48
       header_type: P4_HEADER_ETHERNET
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_ETH_TYPE
       bit_offset: 96
       bit_width: 16
       header_type: P4_HEADER_ETHERNET
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_GRE_CHECKSUM_BIT
       bit_offset: 0
       bit_width: 1
       header_type: P4_HEADER_GRE
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_GRE_FLAGS
       bit_offset: 8
       bit_width: 5
       header_type: P4_HEADER_GRE
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_GRE_RECURSION
       bit_offset: 5
       bit_width: 3
       header_type: P4_HEADER_GRE
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       type: P4_FIELD_TYPE_COLOR
-    )PROTO", &mapped_field));
+    )pb", &mapped_field));
     field_map->emplace(mapped_field.type(), mapped_field);
 
     return field_map;
@@ -296,36 +296,36 @@ const BcmUdfSet& UdfSetByType(P4FieldType type) {
     auto* udf_map = new absl::flat_hash_map<P4FieldType, BcmUdfSet,
                                             EnumHash<P4FieldType>>();
     BcmUdfSet udf_set;
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       chunks { layer: L3_HEADER offset: 24 }
       chunks { layer: L3_HEADER offset: 26 }
-    )PROTO", &udf_set));
+    )pb", &udf_set));
     udf_map->emplace(P4_FIELD_TYPE_ARP_TPA, udf_set);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       chunks { layer: L2_HEADER offset: 0 }
       chunks { layer: L2_HEADER offset: 2 }
       chunks { layer: L2_HEADER offset: 4 }
-    )PROTO", &udf_set));
+    )pb", &udf_set));
     udf_map->emplace(P4_FIELD_TYPE_ETH_DST, udf_set);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       chunks { layer: L2_HEADER offset: 6 }
       chunks { layer: L2_HEADER offset: 8 }
       chunks { layer: L2_HEADER offset: 10 }
-    )PROTO", &udf_set));
+    )pb", &udf_set));
     udf_map->emplace(P4_FIELD_TYPE_ETH_SRC, udf_set);
 
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       chunks { layer: L2_HEADER offset: 12 }
-    )PROTO", &udf_set));
+    )pb", &udf_set));
     udf_map->emplace(P4_FIELD_TYPE_ETH_TYPE, udf_set);
 
     // GRE checksum, flags, and recursion are all within the first 16-bits of
     // the GRE header.
-    CHECK_OK(ParseProtoFromString(R"PROTO(
+    CHECK_OK(ParseProtoFromString(R"pb(
       chunks { layer: L4_HEADER offset: 0 }
-    )PROTO", &udf_set));
+    )pb", &udf_set));
     udf_map->emplace(P4_FIELD_TYPE_GRE_CHECKSUM_BIT, udf_set);
     udf_map->emplace(P4_FIELD_TYPE_GRE_FLAGS, udf_set);
     udf_map->emplace(P4_FIELD_TYPE_GRE_RECURSION, udf_set);
@@ -583,12 +583,12 @@ TEST(BcmUdfManagerTest, SetUpStaticUdfs_OffBoundaryChunks) {
   // This field is normally 2-chunks wide (at 2-byte chunks). Since the offset
   // is not on a chunk-boundary, it will need an extra chunk.
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 19
     bit_width: 32
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables;
   acl_tables.push_back(
@@ -681,12 +681,12 @@ TEST_P(MappedFieldToBcmFieldsTest, U32) {
 
   // Set up the mapped field.
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 32
     bit_width: 32
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
   mapped_field.set_bit_offset(mapped_field.bit_offset() - kShift);
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables({AclTableBuilder(&p4_table_mapper, 1)
@@ -695,11 +695,11 @@ TEST_P(MappedFieldToBcmFieldsTest, U32) {
 
   // Set up the static UDFs.
   UdfSpec udf_spec;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     chunk_bits: 16
     chunks_per_set: 3
     set_count: 1
-  )PROTO", &udf_spec));
+  )pb", &udf_spec));
   BcmSdkMock bcm_sdk_interface;
   ASSERT_OK_AND_ASSIGN(
       auto bcm_udf_manager,
@@ -756,12 +756,12 @@ TEST_P(MappedFieldToBcmFieldsTest, U64) {
 
   // Set up the mapped field.
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 64
     bit_width: 64
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
   mapped_field.set_bit_offset(mapped_field.bit_offset() - kShift);
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables({AclTableBuilder(&p4_table_mapper, 1)
@@ -770,11 +770,11 @@ TEST_P(MappedFieldToBcmFieldsTest, U64) {
 
   // Set up the static UDFs.
   UdfSpec udf_spec;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     chunk_bits: 16
     chunks_per_set: 5
     set_count: 1
-  )PROTO", &udf_spec));
+  )pb", &udf_spec));
   BcmSdkMock bcm_sdk_interface;
   ASSERT_OK_AND_ASSIGN(
       auto bcm_udf_manager,
@@ -856,12 +856,12 @@ TEST_P(MappedFieldToBcmFieldsTest, U64Partial) {
 
   // Set up the mapped field.
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 64
     bit_width: 52
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
   mapped_field.set_bit_offset(mapped_field.bit_offset() - kShift);
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables({AclTableBuilder(&p4_table_mapper, 1)
@@ -870,11 +870,11 @@ TEST_P(MappedFieldToBcmFieldsTest, U64Partial) {
 
   // Set up the static UDFs.
   UdfSpec udf_spec;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     chunk_bits: 16
     chunks_per_set: 5
     set_count: 1
-  )PROTO", &udf_spec));
+  )pb", &udf_spec));
   BcmSdkMock bcm_sdk_interface;
   ASSERT_OK_AND_ASSIGN(
       auto bcm_udf_manager,
@@ -951,12 +951,12 @@ TEST_P(MappedFieldToBcmFieldsTest, B) {
 
   // Set up the mapped field.
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 32
     bit_width: 32
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
   mapped_field.set_bit_offset(mapped_field.bit_offset() - kShift);
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables({AclTableBuilder(&p4_table_mapper, 1)
@@ -965,11 +965,11 @@ TEST_P(MappedFieldToBcmFieldsTest, B) {
 
   // Set up the static UDFs.
   UdfSpec udf_spec;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     chunk_bits: 16
     chunks_per_set: 3
     set_count: 1
-  )PROTO", &udf_spec));
+  )pb", &udf_spec));
   BcmSdkMock bcm_sdk_interface;
   ASSERT_OK_AND_ASSIGN(
       auto bcm_udf_manager,
@@ -1029,12 +1029,12 @@ INSTANTIATE_TEST_SUITE_P(BcmUdfManagerTest, MappedFieldToBcmFieldsTest,
 TEST(BcmUdfManagerTest, SetUpStaticUdfs_NoStaticSets) {
   // This field requires 2 bytes (1 UDF chunks at 2-byte chunks).
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 192
     bit_width: 16
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
 
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables;
@@ -1070,9 +1070,9 @@ TEST(BcmUdfManagerTest, SetUpStaticUdfs_NoStaticSets) {
 // requested on a non-UDF-convertible match field.
 TEST(BcmUdfManagerTest, SetUpStaticUdfs_NonConvertibleMatchField) {
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_COLOR
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
 
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables;
@@ -1101,12 +1101,12 @@ TEST(BcmUdfManagerTest, SetUpStaticUdfs_MatchFieldIsTooBig) {
   // Each This field requires 8 bytes (4 UDF chunks at 2-byte chunks). This test
   // uses 3-chunk sets.
   MappedField mapped_field;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 192
     bit_width: 64
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field));
+  )pb", &mapped_field));
 
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables;
@@ -1134,20 +1134,20 @@ TEST(BcmUdfManagerTest, SetUpStaticUdfs_AclTableWithTooManyChunks) {
   // Each field requires 4 bytes (2 UDF chunks at 2-byte chunks). This test uses
   // 3 chunks per set.
   MappedField mapped_field_1;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 192
     bit_width: 32
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field_1));
+  )pb", &mapped_field_1));
 
   MappedField mapped_field_2;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ETH_DST
     bit_offset: 0
     bit_width: 32
     header_type: P4_HEADER_ETHERNET
-  )PROTO", &mapped_field_2));
+  )pb", &mapped_field_2));
 
   P4TableMapperMock p4_table_mapper;
   std::vector<AclTable> acl_tables;
@@ -1177,20 +1177,20 @@ TEST(BcmUdfManagerTest, SetUpStaticUdfs_MultipleAclTablesWithTooManyChunks) {
   // Each field requires 4 bytes (2 UDF chunks at 2-byte chunks). This test uses
   // a single 3-chunk set.
   MappedField mapped_field_1;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ARP_TPA
     bit_offset: 192
     bit_width: 32
     header_type: P4_HEADER_ARP
-  )PROTO", &mapped_field_1));
+  )pb", &mapped_field_1));
 
   MappedField mapped_field_2;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     type: P4_FIELD_TYPE_ETH_DST
     bit_offset: 0
     bit_width: 32
     header_type: P4_HEADER_ETHERNET
-  )PROTO", &mapped_field_2));
+  )pb", &mapped_field_2));
 
   // The first table will fit. The second table will not fit on top of the first
   // table.

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -116,7 +116,7 @@ class ConfigMonitoringServiceTest
     return config_monitoring_service_->DoCapabilities(context, req, resp);
   }
 
-  static constexpr char kChassisConfigTemplate[] = R"PROTO(
+  static constexpr char kChassisConfigTemplate[] = R"pb(
       description: "Sample test config."
       nodes {
         id:  $0
@@ -142,7 +142,7 @@ class ConfigMonitoringServiceTest
         port: 2
         speed_bps: 100000000000
       }
-  )PROTO";
+  )pb";
   static constexpr char kErrorMsg[] = "Some error";
   static constexpr uint64 kNodeId1 = 123123123;
   static constexpr uint64 kNodeId2 = 456456456;
@@ -346,7 +346,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathSuccess) {
 
   // Build a stream subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -358,7 +358,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathSuccess) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -383,7 +383,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathFail) {
 
   // Build a stream subscription request for subtree that is not supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -394,7 +394,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -430,7 +430,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathPassFail) {
 
   // Build a stream subscription request for subtree that is not supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -449,7 +449,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathPassFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -486,7 +486,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeAndPollSuccess) {
 
   // Build a poll subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req1;
-  constexpr char kReq1[] = R"PROTO(
+  constexpr char kReq1[] = R"pb(
   subscribe {
     mode: POLL
     subscription {
@@ -496,16 +496,16 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeAndPollSuccess) {
       }
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq1, &req1))
       << "Failed to parse proto from the following string: " << kReq1;
 
   // Build actual poll request.
   ::gnmi::SubscribeRequest req2;
-  constexpr char kReq2[] = R"PROTO(
+  constexpr char kReq2[] = R"pb(
   poll {
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq2, &req2))
       << "Failed to parse proto from the following string: " << kReq2;
 
@@ -536,7 +536,7 @@ TEST_P(ConfigMonitoringServiceTest, DoubleSubscribeFail) {
 
   // Build a stream subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -548,7 +548,7 @@ TEST_P(ConfigMonitoringServiceTest, DoubleSubscribeFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -586,7 +586,7 @@ TEST_P(ConfigMonitoringServiceTest, DuplicateSubscribeFail) {
   // Build a stream subscription request for subtree that is supported.
   // Add another request for the same path. This is illeagal combination.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -606,7 +606,7 @@ TEST_P(ConfigMonitoringServiceTest, DuplicateSubscribeFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -648,7 +648,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeOnChangeWithInitialValueSuccess) {
 
   // Build a on_change subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -659,7 +659,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeOnChangeWithInitialValueSuccess) {
       mode: ON_CHANGE
    }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -707,7 +707,7 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
   // This subscription request will be changed into an ON_CHANGE subscription
   // request.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -718,7 +718,7 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
       mode: TARGET_DEFINED
    }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -771,12 +771,12 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
 TEST_P(ConfigMonitoringServiceTest, GnmiGetRootConfigBeforePush) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -798,12 +798,12 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootNonConfig) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: STATE
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -825,12 +825,12 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootNonProto) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: CONFIG
   encoding: JSON
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -852,12 +852,12 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootConfig) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -882,7 +882,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetBlah) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
     elem { name: "interfaces" }
     elem { name: "interface"
@@ -893,7 +893,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetBlah) {
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -916,7 +916,7 @@ TEST_P(ConfigMonitoringServiceTest,
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
     elem { name: "interfaces" }
     elem { name: "interface"
@@ -927,7 +927,7 @@ TEST_P(ConfigMonitoringServiceTest,
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -1003,9 +1003,9 @@ TEST_P(ConfigMonitoringServiceTest, GnmiSetRootReplace) {
 //
 //  // Prepare a SET request.
 //  ::gnmi::SetRequest req;
-//  constexpr char kReq[] = R"PROTO(
+//  constexpr char kReq[] = R"pb(
 //    update { val { bytes_val: "" } }
-//  )PROTO";
+//  )pb";
 //  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
 //      << "Failed to parse proto from the following string: " << kReq;
 //
@@ -1039,7 +1039,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiSetRootReplace) {
 //
 //  // Prepare a GET request.
 //  ::gnmi::SetRequest req;
-//  constexpr char kReq[] = R"PROTO(
+//  constexpr char kReq[] = R"pb(
 //    update {
 //      path {
 //        elem { name: "interfaces" }
@@ -1052,7 +1052,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiSetRootReplace) {
 //      }
 //      val { string_val: "BAD" }
 //    }
-//  )PROTO";
+//  )pb";
 //  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
 //      << "Failed to parse proto from the following string: " << kReq;
 //
@@ -1091,7 +1091,7 @@ TEST_P(ConfigMonitoringServiceTest,
 
   // Prepare a GET request.
   ::gnmi::SetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
     replace {
       path {
         elem { name: "interfaces" }
@@ -1104,7 +1104,7 @@ TEST_P(ConfigMonitoringServiceTest,
       }
       val { string_val: "BAD" }
     }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -1142,7 +1142,7 @@ TEST_P(ConfigMonitoringServiceTest,
 
   // Prepare a GET request.
   ::gnmi::SetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
     delete {
       elem { name: "interfaces" }
       elem {
@@ -1152,7 +1152,7 @@ TEST_P(ConfigMonitoringServiceTest,
       elem { name: "state" }
       elem { name: "health-indicator" }
     }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 

--- a/stratum/hal/lib/common/gnmi_publisher_test.cc
+++ b/stratum/hal/lib/common/gnmi_publisher_test.cc
@@ -49,7 +49,7 @@ class SubscriptionTestBase {
   virtual ~SubscriptionTestBase() {}
 
   void GetSampleHalConfig() {
-    constexpr char kHalConfig[] = R"proto(
+    constexpr char kHalConfig[] = R"pb(
       description: "Sample Generic Tomahawk config with 2x100G ports."
       chassis { platform: PLT_GENERIC_TOMAHAWK name: "device1.domain.net.com" }
       nodes {
@@ -83,7 +83,7 @@ class SubscriptionTestBase {
         port: 2
         speed_bps: 100000000000
         node: 1
-      })proto";
+      })pb";
     ASSERT_OK(ParseProtoFromString(kHalConfig, &hal_config_));
   }
 

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -91,73 +91,73 @@ TEST(ByteStringTest, ByteStringToP4RuntimeByteStringCorrect) {
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigEmptyValid) {
-  constexpr char kInvalidMeterConfigText[] = R"PROTO(
+  constexpr char kInvalidMeterConfigText[] = R"pb(
     # Empty MeterConfig, all fields zero.
-  )PROTO";
+  )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
   EXPECT_OK(IsValidMeterConfig(config));
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigZeroBurstInvalid) {
-  constexpr char kInvalidMeterConfigText[] = R"PROTO(
+  constexpr char kInvalidMeterConfigText[] = R"pb(
     # Zero burst sizes.
     cir: 100
     pir: 200
     cburst: 0
     pburst: 0
-  )PROTO";
+  )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
   EXPECT_OK(IsValidMeterConfig(config));
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigRatesInvalid) {
-  constexpr char kInvalidMeterConfigText[] = R"PROTO(
+  constexpr char kInvalidMeterConfigText[] = R"pb(
     # Commited rate greater peak rate.
     cir: 500
     pir: 400
     cburst: 100
     pburst: 100
-  )PROTO";
+  )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
   EXPECT_FALSE(IsValidMeterConfig(config).ok());
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigValid) {
-  constexpr char kValidMeterConfigText[] = R"PROTO(
+  constexpr char kValidMeterConfigText[] = R"pb(
     cir: 50
     pir: 100
     cburst: 400
     pburst: 800
-  )PROTO";
+  )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kValidMeterConfigText, &config));
   EXPECT_OK(IsValidMeterConfig(config));
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigBurstsValid) {
-  constexpr char kValidMeterConfigText[] = R"PROTO(
+  constexpr char kValidMeterConfigText[] = R"pb(
     # Commited burst size is allowed to be greater than peak burst size.
     cir: 1000
     pir: 2000
     cburst: 800
     pburst: 400
-  )PROTO";
+  )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kValidMeterConfigText, &config));
   EXPECT_OK(IsValidMeterConfig(config));
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigZeroRateValid) {
-  constexpr char kValidMeterConfigText[] = R"PROTO(
+  constexpr char kValidMeterConfigText[] = R"pb(
     # Zero rates are allowed.
     cir: 0
     pir: 0
     cburst: 400
     pburst: 800
-  )PROTO";
+  )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kValidMeterConfigText, &config));
   EXPECT_OK(IsValidMeterConfig(config));

--- a/stratum/hal/lib/phal/onlp/onlp_switch_configurator_test.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_switch_configurator_test.cc
@@ -54,7 +54,7 @@ class OnlpSwitchConfiguratorTest : public ::testing::Test {
     return ::util::OkStatus();
   }
 
-  static constexpr char kPhalInitConfig[] = R"PROTO(
+  static constexpr char kPhalInitConfig[] = R"pb(
     cards {
       slot: 1
       ports { port: 1 physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE }
@@ -84,7 +84,7 @@ class OnlpSwitchConfiguratorTest : public ::testing::Test {
         cache_policy { type: TIMED_CACHE timed_value: 2 }
       }
     }
-  )PROTO";
+  )pb";
 };
 
 constexpr char OnlpSwitchConfiguratorTest::kPhalInitConfig[];

--- a/stratum/hal/lib/phal/optics_adapter_test.cc
+++ b/stratum/hal/lib/phal/optics_adapter_test.cc
@@ -34,7 +34,7 @@ class OpticsAdapterTest : public ::testing::Test {
   std::unique_ptr<OpticsAdapter> optics_adapter_;
 };
 
-constexpr char phaldb_get_response_proto[] = R"PROTO(
+constexpr char phaldb_get_response_proto[] = R"pb(
   optical_modules {
     id: 0
     network_interfaces {
@@ -46,7 +46,7 @@ constexpr char phaldb_get_response_proto[] = R"PROTO(
       operational_mode: 1
     }
   }
-)PROTO";
+)pb";
 
 // Settable atrributes paths.
 const Path frequency_path = {PathEntry("optical_modules", 0),

--- a/stratum/hal/lib/phal/phaldb_service_test.cc
+++ b/stratum/hal/lib/phal/phaldb_service_test.cc
@@ -77,7 +77,7 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
   std::unique_ptr<PhalMock> phal_mock_;
   std::unique_ptr<AttributeDatabaseMock> database_mock_;
 
-  const std::string valid_request_path_proto = R"PROTO(
+  const std::string valid_request_path_proto = R"pb(
     entries {
       name: "cards"
       index: 0
@@ -92,17 +92,17 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
       name: "transceiver"
       terminal_group: true
     }
-  )PROTO";
+  )pb";
 
-  const std::string invalid_request_path_proto = R"PROTO(
+  const std::string invalid_request_path_proto = R"pb(
     entries {
       name: "does_not_exists"
       index: 0
       indexed: true
     }
-  )PROTO";
+  )pb";
 
-  const std::string phaldb_get_response_proto = R"PROTO(
+  const std::string phaldb_get_response_proto = R"pb(
     cards {
       ports {
         physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
@@ -121,7 +121,7 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
         }
       }
     }
-  )PROTO";
+  )pb";
 };
 
 TEST_P(PhalDbServiceTest, SetupWarm) {

--- a/stratum/hal/lib/phal/sfp_adapter_test.cc
+++ b/stratum/hal/lib/phal/sfp_adapter_test.cc
@@ -47,7 +47,7 @@ class SfpAdapterTest : public ::testing::Test {
   std::unique_ptr<AttributeDatabaseMock> database_;
   std::unique_ptr<SfpAdapter> sfp_adapter_;
 
-  const std::string phaldb_get_response_proto = R"PROTO(
+  const std::string phaldb_get_response_proto = R"pb(
     cards {
       ports {
         physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
@@ -66,7 +66,7 @@ class SfpAdapterTest : public ::testing::Test {
         }
       }
     }
-  )PROTO";
+  )pb";
 };
 
 namespace {

--- a/stratum/lib/test_utils/p4_proto_builders_test.cc
+++ b/stratum/lib/test_utils/p4_proto_builders_test.cc
@@ -23,21 +23,21 @@ TEST(P4ProtoBuildersTest, Table) {
   P4ControlTableRef expected;
   CHECK_OK(
       ParseProtoFromString(
-          R"PROTO(table_id: 1234
+          R"pb(table_id: 1234
                   table_name: "table_1234"
-                  pipeline_stage: EGRESS_ACL)PROTO", &expected));
+                  pipeline_stage: EGRESS_ACL)pb", &expected));
   EXPECT_THAT(Table(1234, P4Annotation::EGRESS_ACL), EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, ApplyTable_FromId) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         apply {
           table_id: 1234
           table_name: "table_1234"
           pipeline_stage: EGRESS_ACL
-        })PROTO", &expected));
+        })pb", &expected));
   EXPECT_THAT(ApplyTable(1234, P4Annotation::EGRESS_ACL),
               EqualsProto(expected));
 }
@@ -45,40 +45,40 @@ TEST(P4ProtoBuildersTest, ApplyTable_FromId) {
 TEST(P4ProtoBuildersTest, ApplyTable_FromTable) {
   ::p4::config::v1::Table table;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(preamble { id: 1234 name: "HelloWorld" })PROTO", &table));
+      R"pb(preamble { id: 1234 name: "HelloWorld" })pb", &table));
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         apply {
           table_id: 1234
           table_name: "HelloWorld"
           pipeline_stage: EGRESS_ACL
-        })PROTO", &expected));
+        })pb", &expected));
   EXPECT_THAT(ApplyTable(table, P4Annotation::EGRESS_ACL),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, ApplyTable_FromPreamble) {
   ::p4::config::v1::Preamble preamble;
-  CHECK_OK(ParseProtoFromString(R"PROTO(id: 1234 name: "HelloWorld")PROTO",
+  CHECK_OK(ParseProtoFromString(R"pb(id: 1234 name: "HelloWorld")pb",
                                 &preamble));
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         apply {
           table_id: 1234
           table_name: "HelloWorld"
           pipeline_stage: EGRESS_ACL
-        })PROTO", &expected));
+        })pb", &expected));
   EXPECT_THAT(ApplyTable(preamble, P4Annotation::EGRESS_ACL),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
   std::vector<std::string> table_strings = {
-    R"PROTO(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)PROTO",
+    R"pb(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)pb",
   };
   std::vector<hal::P4ControlTableRef> tables;
   for (const std::string& table_string : table_strings) {
@@ -90,7 +90,7 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
   P4ControlBlock expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             statements { apply { $0 } }
             statements {
               branch {
@@ -106,7 +106,7 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
                 }
               }
             }
-          )PROTO", table_strings[0], table_strings[1], table_strings[2]),
+          )pb", table_strings[0], table_strings[1], table_strings[2]),
       &expected));
 
   EXPECT_THAT(ApplyNested(tables), EqualsProto(expected));
@@ -114,9 +114,9 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
 
 TEST(P4ProtoBuildersTest, ApplyNested_FromTables) {
   std::vector<std::string> table_strings = {
-      R"PROTO(preamble { id: 1 name: "t1" })PROTO",
-      R"PROTO(preamble { id: 2 name: "t2" })PROTO",
-      R"PROTO(preamble { id: 3 name: "t3" })PROTO",
+      R"pb(preamble { id: 1 name: "t1" })pb",
+      R"pb(preamble { id: 2 name: "t2" })pb",
+      R"pb(preamble { id: 3 name: "t3" })pb",
   };
   std::vector<::p4::config::v1::Table> tables;
   for (const std::string& table_string : table_strings) {
@@ -126,15 +126,15 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromTables) {
   }
 
   std::vector<std::string> ref_strings = {
-    R"PROTO(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)PROTO",
+    R"pb(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)pb",
   };
 
   P4ControlBlock expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             statements { apply { $0 } }
             statements {
               branch {
@@ -150,7 +150,7 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromTables) {
                 }
               }
             }
-          )PROTO", ref_strings[0], ref_strings[1], ref_strings[2]),
+          )pb", ref_strings[0], ref_strings[1], ref_strings[2]),
       &expected));
 
   EXPECT_THAT(ApplyNested(tables, P4Annotation::VLAN_ACL),
@@ -164,15 +164,15 @@ TEST(P4ProtoBuildersTest, ApplyNested_Empty) {
 
 TEST(P4ProtoBuildersTest, ApplyNested_SingleTable) {
   std::string table_string =
-      R"PROTO(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)PROTO";
+      R"pb(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)pb";
   hal::P4ControlTableRef table;
   CHECK_OK(ParseProtoFromString(table_string, &table));
 
   P4ControlBlock expected;
   CHECK_OK(ParseProtoFromString(absl::Substitute(
-                                    R"PROTO(
+                                    R"pb(
                                       statements { apply { $0 } }
-                                    )PROTO", table_string),
+                                    )pb", table_string),
                                 &expected));
 
   EXPECT_THAT(ApplyNested({table}), EqualsProto(expected));
@@ -212,26 +212,26 @@ TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderStage) {
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromPreamble) {
   P4ControlTableRef expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(table_id: 1234 table_name: "table")PROTO", &expected));
+      R"pb(table_id: 1234 table_name: "table")pb", &expected));
 
   ::p4::config::v1::Preamble preamble;
   CHECK_OK(
-      ParseProtoFromString(R"PROTO(id: 1234 name: "table")PROTO", &preamble));
+      ParseProtoFromString(R"pb(id: 1234 name: "table")pb", &preamble));
   EXPECT_THAT(P4ControlTableRefBuilder(preamble).Build(),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromPreambleAndStage) {
   P4ControlTableRef expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 1234
     table_name: "table"
     pipeline_stage: VLAN_ACL
-  )PROTO", &expected));
+  )pb", &expected));
 
   ::p4::config::v1::Preamble preamble;
   CHECK_OK(
-      ParseProtoFromString(R"PROTO(id: 1234 name: "table")PROTO", &preamble));
+      ParseProtoFromString(R"pb(id: 1234 name: "table")pb", &preamble));
   EXPECT_THAT(
       P4ControlTableRefBuilder(preamble, P4Annotation::VLAN_ACL).Build(),
       EqualsProto(expected));
@@ -240,35 +240,35 @@ TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromPreambleAndStage) {
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromTable) {
   P4ControlTableRef expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(table_id: 1234 table_name: "table")PROTO", &expected));
+      R"pb(table_id: 1234 table_name: "table")pb", &expected));
 
   ::p4::config::v1::Table table;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(preamble { id: 1234 name: "table" })PROTO", &table));
+      R"pb(preamble { id: 1234 name: "table" })pb", &table));
   EXPECT_THAT(P4ControlTableRefBuilder(table).Build(), EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromTableAndStage) {
   P4ControlTableRef expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 1234
     table_name: "table"
     pipeline_stage: VLAN_ACL
-  )PROTO", &expected));
+  )pb", &expected));
 
   ::p4::config::v1::Table table;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(preamble { id: 1234 name: "table" })PROTO", &table));
+      R"pb(preamble { id: 1234 name: "table" })pb", &table));
   EXPECT_THAT(P4ControlTableRefBuilder(table, P4Annotation::VLAN_ACL).Build(),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderMixed) {
   P4ControlTableRef expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 1234
     table_name: "table"
-    pipeline_stage: VLAN_ACL)PROTO", &expected));
+    pipeline_stage: VLAN_ACL)pb", &expected));
 
   EXPECT_THAT(P4ControlTableRefBuilder()
                   .Id(1234)
@@ -289,9 +289,9 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHit) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch { condition { hit { $0 } } true_block { statements { $1 } } }
-          )PROTO", Table(1).ShortDebugString().c_str(),
+          )pb", Table(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -302,12 +302,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHit) {
 TEST(P4ProtoBuildersTest, HitBuilderOnHitUseFalse) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: true hit { $0 } }
           false_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -318,12 +318,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHitUseFalse) {
 TEST(P4ProtoBuildersTest, HitBuilderOnMiss) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: true hit { $0 } }
           true_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -334,12 +334,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnMiss) {
 TEST(P4ProtoBuildersTest, HitBuilderOnMissUseFalse) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: false hit { $0 } }
           false_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -351,12 +351,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnMissUseFalse) {
 TEST(P4ProtoBuildersTest, HitBuilderOnMissOverwritesOnHit) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: false hit { $0 } }
           false_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -373,9 +373,9 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHitOverwritesOnMiss) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch { condition { hit { $0 } } true_block { statements { $1 } } }
-          )PROTO", Table(1).ShortDebugString().c_str(),
+          )pb", Table(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -388,9 +388,9 @@ TEST(P4ProtoBuildersTest, HitBuilderControlBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch { condition { hit { $0 } } true_block { statements { $1 } } }
-          )PROTO", Table(1).ShortDebugString().c_str(),
+          )pb", Table(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -403,12 +403,12 @@ TEST(P4ProtoBuildersTest, HitBuilderControlBlock) {
 TEST(P4ProtoBuildersTest, HitBuilderMultipleActions) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: true hit { $0 } }
           true_block { statements { $1 } statements { $2 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str(),
                        ApplyTable(3).ShortDebugString().c_str()),
       &expected));
@@ -421,7 +421,7 @@ TEST(P4ProtoBuildersTest, HitBuilderMultipleActions) {
 // IsValidBuilder tests.
 TEST(P4ProtoBuildersTest, IsValidBuilderEmpty) {
   P4ControlStatement expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     branch {
       condition {
         is_valid {
@@ -430,7 +430,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderEmpty) {
         }
       }
     }
-  )PROTO", &expected));
+  )pb", &expected));
 
   EXPECT_THAT(IsValidBuilder().Build(), EqualsProto(expected));
 }
@@ -439,7 +439,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderEmpty) {
 TEST(P4ProtoBuildersTest, IsValidBuilderValidControlBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -449,7 +449,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderValidControlBlock) {
           }
           true_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   hal::P4ControlBlock control_block;
   *control_block.add_statements() = ApplyTable(1);
   EXPECT_THAT(IsValidBuilder().ValidControlBlock(control_block).Build(),
@@ -459,7 +459,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderValidControlBlock) {
 TEST(P4ProtoBuildersTest, IsValidBuilderInvalidControlBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -469,7 +469,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderInvalidControlBlock) {
           }
           false_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   hal::P4ControlBlock control_block;
   *control_block.add_statements() = ApplyTable(1);
   EXPECT_THAT(IsValidBuilder().InvalidControlBlock(control_block).Build(),
@@ -479,7 +479,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderInvalidControlBlock) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Statement) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -489,7 +489,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Statement) {
           }
           true_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().DoIfValid(ApplyTable(1)).Build(),
               EqualsProto(expected));
 }
@@ -501,7 +501,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Block) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch {
               condition {
                 is_valid {
@@ -511,7 +511,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Block) {
               }
               true_block { statements { $0 } statements { $1 } }
             }
-          )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+          )pb", ApplyTable(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(
@@ -522,7 +522,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Block) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Statement) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -532,7 +532,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Statement) {
           }
           false_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().DoIfInvalid(ApplyTable(1)).Build(),
               EqualsProto(expected));
 }
@@ -544,7 +544,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Block) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch {
               condition {
                 is_valid {
@@ -554,7 +554,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Block) {
               }
               false_block { statements { $0 } statements { $1 } }
             }
-          )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+          )pb", ApplyTable(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(
@@ -565,7 +565,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Block) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidMultipleActions) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -575,7 +575,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidMultipleActions) {
           }
           true_block { statements { $0 } statements { $1 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+      )pb", ApplyTable(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(IsValidBuilder()
@@ -588,7 +588,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidMultipleActions) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidMultipleActions) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -598,7 +598,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidMultipleActions) {
           }
           false_block { statements { $0 } statements { $1 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+      )pb", ApplyTable(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(IsValidBuilder()
@@ -611,7 +611,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidMultipleActions) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidUseNot) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             not_operator: true
@@ -622,7 +622,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidUseNot) {
           }
           false_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().UseNot().DoIfValid(ApplyTable(1)).Build(),
               EqualsProto(expected));
 }
@@ -630,7 +630,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidUseNot) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidUseNot) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             not_operator: true
@@ -641,7 +641,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidUseNot) {
           }
           true_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().DoIfInvalid(ApplyTable(1)).UseNot().Build(),
               EqualsProto(expected));
 }
@@ -649,7 +649,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidUseNot) {
 TEST(P4ProtoBuildersTest, IsValidBuilderHeader) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         branch {
           condition {
             is_valid {
@@ -658,7 +658,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderHeader) {
             }
           }
         }
-      )PROTO", &expected));
+      )pb", &expected));
   EXPECT_THAT(IsValidBuilder().Header(P4_HEADER_IPV4).Build(),
               EqualsProto(expected));
 }
@@ -666,7 +666,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderHeader) {
 TEST(P4ProtoBuildersTest, IsValidBuilderComplexBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             not_operator: true
@@ -678,7 +678,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderComplexBlock) {
           true_block { statements { $0 } statements { $1 } }
           false_block { statements { $2 } statements { $3 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+      )pb", ApplyTable(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str(),
                        ApplyTable(3).ShortDebugString().c_str(),
                        ApplyTable(4).ShortDebugString().c_str()),

--- a/stratum/testing/scenarios/lib.cc.tmpl
+++ b/stratum/testing/scenarios/lib.cc.tmpl
@@ -65,9 +65,9 @@
   {{- $txtp:=.Protobuf.GetTextproto}}
   {{- range $i, $s := $txtp}}
   {{$.Protobuf.Namespace}}::{{if $s.Meta}}{{$s.Meta.Type}}{{else}}{{$.Protobuf.TypeName}}{{end}} req_{{$i}};
-  std::string kReq_{{$i}} = R"proto(
+  std::string kReq_{{$i}} = R"pb(
    {{$s.Text}}
-  )proto";
+  )pb";
 
   {{- range $.Protobuf.Vars}}
   // Replace `${{.Name}}` with contents of variable `{{.Name}}`.


### PR DESCRIPTION
Starting with clang-13 this is the enforced terminal. This change should make the eventual update easier.