### PR TITLE
Fix workspace status script for out-of-git builds

### DIFF
--- a/.circleci/workspace_status.sh
+++ b/.circleci/workspace_status.sh
@@ -18,6 +18,11 @@
 # and the output will be discarded.
 set -e -o pipefail
 
+# If not building from a git repository, we can't generate any stamping info.
+if [ ! -d ".git" ]; then
+  exit 0
+fi
+
 # The upstream git URL
 git_url=$(git config --get remote.origin.url)
 echo "GIT_URL ${git_url}"

--- a/.circleci/workspace_status.sh
+++ b/.circleci/workspace_status.sh
@@ -18,7 +18,7 @@
 # and the output will be discarded.
 set -e -o pipefail
 
-# If not building from a git repository, we can't generate any stamping info.
+# When building outside the git repository we can't generate any stamping info.
 if [ ! -d ".git" ]; then
   exit 0
 fi


### PR DESCRIPTION
When building from non-git source code, e.g. release tars, the `.git` directory is not present. This causes any bazel command to fail as the workspace status script exits with non-zero code. We fix this by checking for this condition and not emitting any stamping info in that case.

Fixes #949