### PR TITLE
Add step to remove corrupted Bazel installation from CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ store_bazel_profile: &store_bazel_profile
 set_bazelrc: &set_bazelrc
   run:
     name: Set bazelrc
+    # Temporary workaround, see: https://github.com/stratum/stratum/pull/952
     command: |
       cat .circleci/bazelrc >> .bazelrc
       rm -rf /tmp/bazel-cache/output-root/install/64841bf12de13c7518c7ada0994bafe2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ store_bazel_profile: &store_bazel_profile
 set_bazelrc: &set_bazelrc
   run:
     name: Set bazelrc
-    command: cat .circleci/bazelrc >> .bazelrc
+    command: |
+      cat .circleci/bazelrc >> .bazelrc
+      rm -rf /tmp/bazel-cache/output-root/install/64841bf12de13c7518c7ada0994bafe2
 
 # Convenience anchors to update published Docker images. Images are first pulled
 # to allow for layer cache hits and reduce build times.


### PR DESCRIPTION
Currently, all CI jobs fail with this Bazel error:

```
2022/04/12 23:15:09 Downloading https://releases.bazel.build/4.2.2/release/bazel-4.2.2-linux-x86_64...
FATAL: corrupt installation: file '/tmp/bazel-cache/output-root/install/64841bf12de13c7518c7ada0994bafe2/A-server.jar' is missing or modified.  Please remove '/tmp/bazel-cache/output-root/install/64841bf12de13c7518c7ada0994bafe2' and try again.

Exited with code exit status 36
```

This PR fixes this by removing the listed folder.

See also:
https://groups.google.com/g/bazel-discuss/c/1NSPPwV7ejY
https://github.com/bazelbuild/bazel/issues/471
https://github.com/bazelbuild/bazel/issues/14355