### PR TITLE
Add missing `WORKSPACE` files to Docker build image for Bazel version detection

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -84,6 +84,8 @@ RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
 
 # Bazelisk and Bazel
 ADD .bazelversion .
+ADD BUILD .
+ADD WORKSPACE .
 ARG BAZELISK_VERSION
 RUN wget --quiet https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64 && \
     mv bazelisk-linux-amd64 /usr/local/bin/bazel && \


### PR DESCRIPTION
In the current docker builder image bazel(isk) will not pick the Bazel version from the file, because it does not recognize the folder as a Bazel project. This PR fixes this by adding the necessary `WORKSPACE` and root `BUILD` files into the container.


Logs from CI [run](https://app.circleci.com/pipelines/github/stratum/stratum/4411/workflows/36c5db8c-6049-4af5-93b2-d9c967772bf5/jobs/28755):

```
Step 31/38 : RUN wget --quiet https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64 &&     mv bazelisk-linux-amd64 /usr/local/bin/bazel &&     chmod +x /usr/local/bin/bazel &&     bazel version
 ---> Running in c25f1a199d1e
2022/03/21 17:11:24 Downloading https://releases.bazel.build/5.0.0/release/bazel-5.0.0-linux-x86_64...
Bazelisk version: v1.8.0
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a WORKSPACE file).
Extracting Bazel installation...
Build label: 5.0.0
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Wed Jan 19 14:08:54 2022 (1642601334)
Build timestamp: 1642601334
Build timestamp as int: 1642601334
```