### PR TITLE
Use `small` resource class on CircleCI for lint jobs

### DIFF
--- a/.circleci/bazelrc
+++ b/.circleci/bazelrc
@@ -7,11 +7,23 @@ build --disk_cache=/tmp/bazel-disk-cache
 # Set convenient location for Bazel files to cache
 startup --output_user_root=/tmp/bazel-cache/output-root
 
-# Bazel doesn't calculate resource ceiling correctly when running under Docker.
-# Memory, CPU cores, disk I/O
+# Resource limits for different CI server sizes.
+# Memory, CPU cores, disk I/O.
+# Bazel doesn't calculate resource ceiling correctly when running under Docker,
+# that's why we set both `jobs`` and `local_cpu_resources`.
+# See: https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+# Default config for medium. 
 build --local_cpu_resources=1
 build --local_ram_resources=3072
 build --jobs=1
+
+build:ci-small --local_cpu_resources=1
+build:ci-small --local_ram_resources=1500
+build:ci-small --jobs=1
+
+build:ci-large --local_cpu_resources=4
+build:ci-large --jobs=4
+build:ci-large --local_ram_resources=7196
 
 # Also limit memory allocated to the JVM
 startup --host_jvm_args=-Xmx3g --host_jvm_args=-Xms2g

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ jobs:
   cdlang_tests:
     docker:
       - image: stratumproject/build:build
+    resource_class: small  # 1 vCPU, 2GB RAM
     environment:
       - CC: clang
       - CXX: clang++
@@ -143,12 +144,12 @@ jobs:
       - *set_bazelrc
       - run:
           name: Build CDLang targets
-          command: xargs -a .circleci/cdlang-targets.txt bazel build
+          command: xargs -a .circleci/cdlang-targets.txt bazel build --config=ci-small
       - *analyze_bazel_profile
       - *store_bazel_profile
       - run:
           name: Test CDLang targets
-          command: xargs -a .circleci/cdlang-targets.txt bazel test
+          command: xargs -a .circleci/cdlang-targets.txt bazel test --config=ci-small
       - *clean_bazel_cache
       - *save_bazel_cache
 
@@ -361,6 +362,7 @@ jobs:
   lint-and-style-checks:
     docker:
       - image: stratumproject/build:build
+    resource_class: small  # 1 vCPU, 2GB RAM
     steps:
       - checkout
       # We always continue with all steps, even on failures, to get the most
@@ -381,6 +383,7 @@ jobs:
   license-check:
     docker:
       - image: fsfe/reuse:latest
+    resource_class: small  # 1 vCPU, 2GB RAM
     steps:
       - checkout
       - run:


### PR DESCRIPTION
These smaller and faster jobs don't need 2 CPUs. We can save some credits by switching to the `small` resource class.