### PR TITLE
Use `large` resource class for CircleCI unit test and coverage jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
   unit_tests:
     docker:
       - image: stratumproject/build:build
+    resource_class: large  # 4 vCPUs, 8GB RAM
     environment:
       - CC: clang
       - CXX: clang++
@@ -121,12 +122,12 @@ jobs:
           command: bazel query '//...'
       - run:
           name: Build Stratum targets
-          command: xargs -a .circleci/build-targets.txt bazel build
+          command: xargs -a .circleci/build-targets.txt bazel build --config=ci-large
       - *analyze_bazel_profile
       - *store_bazel_profile
       - run:
           name: Test Stratum targets
-          command: xargs -a .circleci/test-targets.txt bazel test
+          command: xargs -a .circleci/test-targets.txt bazel test --config=ci-large
       - *clean_bazel_cache
       - *save_bazel_cache
 
@@ -157,6 +158,7 @@ jobs:
   coverage:
     docker:
       - image: stratumproject/build:build
+    resource_class: large  # 4 vCPUs, 8GB RAM
     environment:
       - CC: clang
       - CXX: clang++
@@ -166,7 +168,7 @@ jobs:
       - *set_bazelrc
       - run:
           name: Run test and collect coverage data
-          command: xargs -a .circleci/test-targets.txt bazel coverage
+          command: xargs -a .circleci/test-targets.txt bazel coverage --config=ci-large
       - *analyze_bazel_profile
       - *store_bazel_profile
       - codecov/upload:


### PR DESCRIPTION
Those jobs benefit from the additional resources and complete faster.