### PR TITLE
Add WriteTableEntry test in bfrt_table_manage_test

### DIFF
--- a/stratum/glue/net_util/ipaddress.cc
+++ b/stratum/glue/net_util/ipaddress.cc
@@ -406,9 +406,7 @@ bool IPAddressOrdering::operator()(const IPAddress& lhs,
       // Unspecified address families are considered equal.
       return false;
     }
-    default: {
-      LOG(FATAL) << "Unknown address family " << lhs.address_family_;
-    }
+    default: { LOG(FATAL) << "Unknown address family " << lhs.address_family_; }
   }
 }
 
@@ -668,9 +666,7 @@ SocketAddress::SocketAddress(const struct sockaddr& saddr) {
       port_ = 0;
       break;
     }
-    default: {
-      LOG(FATAL) << "Unknown address family " << saddr.sa_family;
-    }
+    default: { LOG(FATAL) << "Unknown address family " << saddr.sa_family; }
   }
 }
 
@@ -699,9 +695,7 @@ SocketAddress::SocketAddress(const struct sockaddr_storage& saddr) {
       port_ = 0;
       break;
     }
-    default: {
-      LOG(FATAL) << "Unknown address family " << saddr.ss_family;
-    }
+    default: { LOG(FATAL) << "Unknown address family " << saddr.ss_family; }
   }
 }
 

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -337,22 +337,16 @@ TEST_F(BfChassisManagerTest, SetPortLoopback) {
 
 TEST_F(BfChassisManagerTest, ApplyPortShaping) {
   const std::string kVendorConfigText = R"pb(
-    tofino_config {
-      node_id_to_port_shaping_config {
-        key: 7654321
-        value {
-          per_port_shaping_configs {
-            key: 12345
-            value {
-              byte_shaping {
-                rate_bps: 10000000000 # 10G
-                burst_bytes: 16384 # 2x jumbo frame
-              }
-            }
-          }
-        }
-      }
-    }
+    tofino_config {node_id_to_port_shaping_config {
+      key: 7654321
+      value {per_port_shaping_configs {
+        key: 12345
+        value {byte_shaping {
+          rate_bps: 10000000000  # 10G
+          burst_bytes: 16384     # 2x jumbo frame
+        }}
+      }}
+    }}
   )pb";
 
   VendorConfig vendor_config;
@@ -387,21 +381,11 @@ TEST_F(BfChassisManagerTest, ApplyPortShaping) {
 
 TEST_F(BfChassisManagerTest, ApplyDeflectOnDrop) {
   const std::string kVendorConfigText = R"pb(
-    tofino_config {
-      node_id_to_deflect_on_drop_configs {
-        key: 7654321
-        value {
-          drop_targets {
-            port: 12345
-            queue: 4
-          }
-          drop_targets {
-            sdk_port: 56789
-            queue: 1
-          }
-        }
-      }
-    }
+    tofino_config {node_id_to_deflect_on_drop_configs {
+      key: 7654321
+      value {drop_targets {port: 12345 queue: 4}
+             drop_targets {sdk_port: 56789 queue: 1}}
+    }}
   )pb";
 
   VendorConfig vendor_config;
@@ -423,50 +407,40 @@ TEST_F(BfChassisManagerTest, ApplyDeflectOnDrop) {
 
 TEST_F(BfChassisManagerTest, ApplyQoSConfig) {
   const std::string kVendorConfigText = R"pb(
-    tofino_config {
-      node_id_to_qos_config {
-        key: 7654321  # kNodeId
-        value {
-          pool_configs {
-            pool: INGRESS_APP_POOL_0
-            pool_size: 30000
-            enable_color_drop: false
-          }
-          ppg_configs {
-            sdk_port: 912345
-            is_default_ppg: true
-            minimum_guaranteed_cells: 200
-            pool: INGRESS_APP_POOL_0
-            base_use_limit: 400
-            baf: BAF_80_PERCENT
-            hysteresis: 50
-            ingress_drop_limit: 4000
-            icos_bitmap: 0xfd
-          }
-          queue_configs {
-            sdk_port: 912345
-            queue_mapping {
-              queue_id: 0
-              priority: PRIO_0
-              weight: 1
-              minimum_guaranteed_cells: 100
-              pool: EGRESS_APP_POOL_0
-              base_use_limit: 200
-              baf: BAF_80_PERCENT
-              hysteresis: 50
-              max_rate_bytes {
-                rate_bps: 100000000
-                burst_bytes: 9000
-              }
-              min_rate_bytes {
-                rate_bps: 1000000
-                burst_bytes: 4500
-              }
-            }
-          }
-        }
+    tofino_config {node_id_to_qos_config {
+      key: 7654321  # kNodeId
+      value {pool_configs {
+        pool: INGRESS_APP_POOL_0
+        pool_size: 30000
+        enable_color_drop: false
       }
-    }
+             ppg_configs {
+               sdk_port: 912345
+               is_default_ppg: true
+               minimum_guaranteed_cells: 200
+               pool: INGRESS_APP_POOL_0
+               base_use_limit: 400
+               baf: BAF_80_PERCENT
+               hysteresis: 50
+               ingress_drop_limit: 4000
+               icos_bitmap: 0xfd
+             }
+             queue_configs {
+               sdk_port: 912345
+               queue_mapping {
+                 queue_id: 0
+                 priority: PRIO_0
+                 weight: 1
+                 minimum_guaranteed_cells: 100
+                 pool: EGRESS_APP_POOL_0
+                 base_use_limit: 200
+                 baf: BAF_80_PERCENT
+                 hysteresis: 50
+                 max_rate_bytes {rate_bps: 100000000 burst_bytes: 9000}
+                 min_rate_bytes {rate_bps: 1000000 burst_bytes: 4500}
+               }
+             }}
+    }}
   )pb";
 
   VendorConfig vendor_config;
@@ -487,45 +461,35 @@ TEST_F(BfChassisManagerTest, ApplyQoSConfig) {
 
 TEST_F(BfChassisManagerTest, QoSConfigWithSingletonPortsIsTransformed) {
   const std::string kVendorConfigText = R"pb(
-    tofino_config {
-      node_id_to_qos_config {
-        key: 7654321  # kNodeId
-        value {
-          ppg_configs {
-            port: 12345  # kPortId
-            is_default_ppg: true
-            minimum_guaranteed_cells: 200
-            pool: INGRESS_APP_POOL_0
-            base_use_limit: 400
-            baf: BAF_80_PERCENT
-            hysteresis: 50
-            ingress_drop_limit: 4000
-            icos_bitmap: 0xfd
-          }
-          queue_configs {
-            port: 12345  # kPortId
-            queue_mapping {
-              queue_id: 0
-              priority: PRIO_0
-              weight: 1
-              minimum_guaranteed_cells: 100
-              pool: EGRESS_APP_POOL_0
-              base_use_limit: 200
-              baf: BAF_80_PERCENT
-              hysteresis: 50
-              max_rate_bytes {
-                rate_bps: 100000000
-                burst_bytes: 9000
-              }
-              min_rate_bytes {
-                rate_bps: 1000000
-                burst_bytes: 4500
-              }
-            }
-          }
-        }
+    tofino_config {node_id_to_qos_config {
+      key: 7654321  # kNodeId
+      value {ppg_configs {
+        port: 12345  # kPortId
+        is_default_ppg: true
+        minimum_guaranteed_cells: 200
+        pool: INGRESS_APP_POOL_0
+        base_use_limit: 400
+        baf: BAF_80_PERCENT
+        hysteresis: 50
+        ingress_drop_limit: 4000
+        icos_bitmap: 0xfd
       }
-    }
+             queue_configs {
+               port: 12345  # kPortId
+               queue_mapping {
+                 queue_id: 0
+                 priority: PRIO_0
+                 weight: 1
+                 minimum_guaranteed_cells: 100
+                 pool: EGRESS_APP_POOL_0
+                 base_use_limit: 200
+                 baf: BAF_80_PERCENT
+                 hysteresis: 50
+                 max_rate_bytes {rate_bps: 100000000 burst_bytes: 9000}
+                 min_rate_bytes {rate_bps: 1000000 burst_bytes: 4500}
+               }
+             }}
+    }}
   )pb";
 
   VendorConfig vendor_config;
@@ -556,34 +520,18 @@ TEST_F(BfChassisManagerTest, QoSConfigWithSingletonPortsIsTransformed) {
 TEST_F(BfChassisManagerTest, ReplayPorts) {
   const std::string kVendorConfigText = R"pb(
     tofino_config {
-      node_id_to_deflect_on_drop_configs {
-        key: 7654321
-        value {
-          drop_targets {
-            port: 12345
-            queue: 4
-          }
-          drop_targets {
-            sdk_port: 56789
-            queue: 1
-          }
+        node_id_to_deflect_on_drop_configs {
+          key: 7654321
+          value {drop_targets {port: 12345 queue: 4}
+                 drop_targets {sdk_port: 56789 queue: 1}}
         }
-      }
-      node_id_to_port_shaping_config {
-        key: 7654321
-        value {
-          per_port_shaping_configs {
+        node_id_to_port_shaping_config {
+          key: 7654321
+          value {per_port_shaping_configs {
             key: 12345
-            value {
-              byte_shaping {
-                rate_bps: 10000000000
-                burst_bytes: 16384
-              }
-            }
-          }
-        }
-      }
-    }
+            value {byte_shaping {rate_bps: 10000000000 burst_bytes: 16384}}
+          }}
+        }}
   )pb";
 
   constexpr int kCpuPort = 64;

--- a/stratum/hal/lib/barefoot/bf_pipeline_utils_test.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils_test.cc
@@ -19,25 +19,13 @@ namespace barefoot {
 static constexpr char bf_config_1pipe_str[] = R"pb(
   p4_name: "prog1"
   bfruntime_info: "{json: true}"
-  profiles {
-    profile_name: "pipe1"
-    context: "{json: true}"
-    binary: "<raw bin>"
-  })pb";
+  profiles {profile_name: "pipe1" context: "{json: true}" binary: "<raw bin>"})pb";
 
 static constexpr char bf_config_2pipe_str[] = R"pb(
   p4_name: "prog1"
   bfruntime_info: "{json: true}"
-  profiles {
-    profile_name: "pipe1"
-    context: "{json: true}"
-    binary: "<raw bin>"
-  }
-  profiles {
-    profile_name: "pipe2"
-    context: "{json: true}"
-    binary: "<raw bin>"
-  })pb";
+  profiles {profile_name: "pipe1" context: "{json: true}" binary: "<raw bin>"}
+  profiles {profile_name: "pipe2" context: "{json: true}" binary: "<raw bin>"})pb";
 
 TEST(ExtractBfPipelineTest, ExtractBfPipelineConfigFromProtoSuccess) {
   BfPipelineConfig bf_config;

--- a/stratum/hal/lib/barefoot/bfrt_counter_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_counter_manager_test.cc
@@ -58,13 +58,8 @@ TEST_F(BfrtCounterManagerTest, ModifyIndirectCounterTest) {
 
   const std::string kIndirectCounterEntryText = R"pb(
     counter_id: 55
-    index {
-      index: 100
-    }
-    data {
-      byte_count: 100
-      packet_count: 200
-    }
+    index {index: 100}
+    data {byte_count: 100 packet_count: 200}
   )pb";
   ::p4::v1::CounterEntry entry;
   ASSERT_OK(ParseProtoFromString(kIndirectCounterEntryText, &entry));

--- a/stratum/hal/lib/barefoot/bfrt_node_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node_test.cc
@@ -205,65 +205,25 @@ class BfrtNodeTest : public ::testing::Test {
   static constexpr char kBfConfigPipelineString[] = R"pb(
     p4_name: "prog1"
     bfruntime_info: "{json: true}"
-    profiles {
-      profile_name: "pipe1"
-      context: "{json: true}"
-      binary: "<raw bin>"
-    }
+    profiles {profile_name: "pipe1" context: "{json: true}" binary: "<raw bin>"}
   )pb";
   static constexpr char kValidP4InfoString[] = R"pb(
-    pkg_info {
-      arch: "tna"
-    }
+    pkg_info {arch: "tna"}
     tables {
-      preamble {
-        id: 33583783
-        name: "Ingress.control.table1"
-      }
-      match_fields {
-        id: 1
-        name: "field1"
-        bitwidth: 9
-        match_type: EXACT
-      }
-      match_fields {
-        id: 2
-        name: "field2"
-        bitwidth: 12
-        match_type: TERNARY
-      }
-      match_fields {
-        id: 3
-        name: "field3"
-        bitwidth: 15
-        match_type: RANGE
-      }
-      action_refs {
-        id: 16794911
-      }
+      preamble {id: 33583783 name: "Ingress.control.table1"}
+      match_fields {id: 1 name: "field1" bitwidth: 9 match_type: EXACT}
+      match_fields {id: 2 name: "field2" bitwidth: 12 match_type: TERNARY}
+      match_fields {id: 3 name: "field3" bitwidth: 15 match_type: RANGE}
+      action_refs {id: 16794911}
       const_default_action_id: 16836487
       direct_resource_ids: 318814845
       size: 1024
     }
-    actions {
-      preamble {
-        id: 16794911
-        name: "Ingress.control.action1"
-      }
-      params {
-        id: 1
-        name: "vlan_id"
-        bitwidth: 12
-      }
-    }
+    actions {preamble {id: 16794911 name: "Ingress.control.action1"}
+             params {id: 1 name: "vlan_id" bitwidth: 12}}
     direct_counters {
-      preamble {
-        id: 318814845
-        name: "Ingress.control.counter1"
-      }
-      spec {
-        unit: BOTH
-      }
+      preamble {id: 318814845 name: "Ingress.control.counter1"}
+      spec {unit: BOTH}
       direct_table_id: 33583783
     }
     meters {
@@ -272,9 +232,7 @@ class BfrtNodeTest : public ::testing::Test {
         name: "Ingress.control.meter_bytes"
         alias: "meter_bytes"
       }
-      spec {
-        unit: BYTES
-      }
+      spec {unit: BYTES}
       size: 500
     }
     meters {
@@ -283,9 +241,7 @@ class BfrtNodeTest : public ::testing::Test {
         name: "Ingress.control.meter_packets"
         alias: "meter_packets"
       }
-      spec {
-        unit: PACKETS
-      }
+      spec {unit: PACKETS}
       size: 500
     }
   )pb";

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager_test.cc
@@ -96,52 +96,25 @@ class BfrtPacketioManagerTest : public ::testing::Test {
   static constexpr int kDevice1 = 0;
   static constexpr char kP4Info[] = R"pb(
     controller_packet_metadata {
-      preamble {
-        id: 67146229
-        name: "packet_in"
-        alias: "packet_in"
-        annotations: "@controller_header(\"packet_in\")"
-      }
-      metadata {
-        id: 1
-        name: "ingress_port"
-        bitwidth: 9
-      }
-      metadata {
-        id: 2
-        name: "_pad0"
-        bitwidth: 7
-      }
-    }
+        preamble {
+          id: 67146229
+          name: "packet_in"
+          alias: "packet_in"
+          annotations: "@controller_header(\"packet_in\")"
+        }
+        metadata {id: 1 name: "ingress_port" bitwidth: 9}
+        metadata {id: 2 name: "_pad0" bitwidth: 7}}
     controller_packet_metadata {
-      preamble {
-        id: 67121543
-        name: "packet_out"
-        alias: "packet_out"
-        annotations: "@controller_header(\"packet_out\")"
-      }
-      metadata {
-        id: 1
-        name: "egress_port"
-        bitwidth: 9
-      }
-      metadata {
-        id: 2
-        name: "cpu_loopback_mode"
-        bitwidth: 2
-      }
-      metadata {
-        id: 3
-        name: "pad0"
-        annotations: "@padding"
-        bitwidth: 85
-      }
-      metadata {
-        id: 4
-        name: "ether_type"
-        bitwidth: 16
-      }
-    }
+        preamble {
+          id: 67121543
+          name: "packet_out"
+          alias: "packet_out"
+          annotations: "@controller_header(\"packet_out\")"
+        }
+        metadata {id: 1 name: "egress_port" bitwidth: 9}
+        metadata {id: 2 name: "cpu_loopback_mode" bitwidth: 2}
+        metadata {id: 3 name: "pad0" annotations: "@padding" bitwidth: 85}
+        metadata {id: 4 name: "ether_type" bitwidth: 16}}
   )pb";
 
   std::unique_ptr<BfSdeMock> bf_sde_wrapper_mock_;
@@ -168,18 +141,13 @@ TEST_F(BfrtPacketioManagerTest, PushInvalidPacketInConfigAndShutdown) {
   // The total length of packet-in metadata is not byte aligned
   const char invalid_packet_in[] = R"pb(
     controller_packet_metadata {
-      preamble {
-        id: 67146229
-        name: "packet_in"
-        alias: "packet_in"
-        annotations: "@controller_header(\"packet_in\")"
-      }
-      metadata {
-        id: 1
-        name: "ingress_port"
-        bitwidth: 9
-      }
-    }
+        preamble {
+          id: 67146229
+          name: "packet_in"
+          alias: "packet_in"
+          annotations: "@controller_header(\"packet_in\")"
+        }
+        metadata {id: 1 name: "ingress_port" bitwidth: 9}}
   )pb";
   auto status = PushPipelineConfig(invalid_packet_in, false);
   EXPECT_THAT(
@@ -193,18 +161,13 @@ TEST_F(BfrtPacketioManagerTest, PushInvalidPacketOutConfigAndShutdown) {
   // The total length of packet-out metadata is not byte aligned
   const char invalid_packet_out[] = R"pb(
     controller_packet_metadata {
-      preamble {
-        id: 67121543
-        name: "packet_out"
-        alias: "packet_out"
-        annotations: "@controller_header(\"packet_out\")"
-      }
-      metadata {
-        id: 1
-        name: "egress_port"
-        bitwidth: 9
-      }
-    }
+        preamble {
+          id: 67121543
+          name: "packet_out"
+          alias: "packet_out"
+          annotations: "@controller_header(\"packet_out\")"
+        }
+        metadata {id: 1 name: "egress_port" bitwidth: 9}}
   )pb";
   auto status = PushPipelineConfig(invalid_packet_out, false);
   EXPECT_THAT(
@@ -219,27 +182,20 @@ TEST_F(BfrtPacketioManagerTest,
        PushUnknownControllerPacketMetadataConfigAndShutdown) {
   // The unknown
   const char p4info_with_known[] = R"pb(
+    controller_packet_metadata {preamble {
+      id: 1234567
+      name: "unknown"
+      alias: "unknown"
+      annotations: "@controller_header(\"unknown\")"
+    }}
     controller_packet_metadata {
-      preamble {
-        id: 1234567
-        name: "unknown"
-        alias: "unknown"
-        annotations: "@controller_header(\"unknown\")"
-      }
-    }
-    controller_packet_metadata {
-      preamble {
-        id: 67121543
-        name: "packet_out"
-        alias: "packet_out"
-        annotations: "@controller_header(\"packet_out\")"
-      }
-      metadata {
-        id: 1
-        name: "egress_port"
-        bitwidth: 8
-      }
-    }
+        preamble {
+          id: 67121543
+          name: "packet_out"
+          alias: "packet_out"
+          annotations: "@controller_header(\"packet_out\")"
+        }
+        metadata {id: 1 name: "egress_port" bitwidth: 8}}
   )pb";
   EXPECT_OK(PushPipelineConfig(p4info_with_known));
   EXPECT_OK(Shutdown());
@@ -250,22 +206,10 @@ TEST_F(BfrtPacketioManagerTest, TransmitPacketAfterPipelineConfigPush) {
   p4::v1::PacketOut packet_out;
   const char packet_out_str[] = R"pb(
     payload: "abcde"
-    metadata {
-      metadata_id: 1
-      value: "\x1"
-    }
-    metadata {
-      metadata_id: 2
-      value: "\x0"
-    }
-    metadata {
-      metadata_id: 3
-      value: "\x0"
-    }
-    metadata {
-      metadata_id: 4
-      value: "\xbf\x01"
-    }
+    metadata {metadata_id: 1 value: "\x1"}
+    metadata {metadata_id: 2 value: "\x0"}
+    metadata {metadata_id: 3 value: "\x0"}
+    metadata {metadata_id: 4 value: "\xbf\x01"}
   )pb";
   EXPECT_OK(ParseProtoFromString(packet_out_str, &packet_out));
   const std::string expected_packet(
@@ -287,18 +231,9 @@ TEST_F(BfrtPacketioManagerTest, TransmitInvalidPacketAfterPipelineConfigPush) {
   // Missing the third metadata.
   const char packet_out_str[] = R"pb(
     payload: "abcde"
-    metadata {
-      metadata_id: 1
-      value: "\x1"
-    }
-    metadata {
-      metadata_id: 2
-      value: "\x0"
-    }
-    metadata {
-      metadata_id: 3
-      value: "\x0"
-    }
+    metadata {metadata_id: 1 value: "\x1"}
+    metadata {metadata_id: 2 value: "\x0"}
+    metadata {metadata_id: 3 value: "\x0"}
   )pb";
   EXPECT_OK(ParseProtoFromString(packet_out_str, &packet_out));
   EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
@@ -317,14 +252,8 @@ TEST_F(BfrtPacketioManagerTest, TestPacketIn) {
   EXPECT_OK(bfrt_packetio_manager_->RegisterPacketReceiveWriter(writer));
   const char expected_packet_in_str[] = R"pb(
     payload: "abcde"
-    metadata {
-      metadata_id: 1
-      value: "\001"
-    }
-    metadata {
-      metadata_id: 2
-      value: "\000"
-    }
+    metadata {metadata_id: 1 value: "\001"}
+    metadata {metadata_id: 2 value: "\000"}
   )pb";
   ::p4::v1::PacketIn expected_packet_in;
   EXPECT_OK(ParseProtoFromString(expected_packet_in_str, &expected_packet_in));

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager_test.cc
@@ -61,18 +61,9 @@ TEST_F(BfrtPreManagerTest, InsertMulticastGroupSuccess) {
   const std::string kMulticastGroupEntryText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
-      replicas {
-        egress_port: 1
-        instance: 789
-      }
-      replicas {
-        egress_port: 2
-        instance: 789
-      }
-      replicas {
-        egress_port: 3
-        instance: 654
-      }
+      replicas {egress_port: 1 instance: 789}
+      replicas {egress_port: 2 instance: 789}
+      replicas {egress_port: 3 instance: 654}
     }
   )pb";
   constexpr int kGroupId = 55;
@@ -111,18 +102,9 @@ TEST_F(BfrtPreManagerTest, ModifyMulticastGroupSuccess) {
   const std::string kMulticastGroupEntryText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
-      replicas {
-        egress_port: 5
-        instance: 432
-      }
-      replicas {
-        egress_port: 6
-        instance: 432
-      }
-      replicas {
-        egress_port: 7
-        instance: 987
-      }
+      replicas {egress_port: 5 instance: 432}
+      replicas {egress_port: 6 instance: 432}
+      replicas {egress_port: 7 instance: 987}
     }
   )pb";
   constexpr int kGroupId = 55;
@@ -167,9 +149,7 @@ TEST_F(BfrtPreManagerTest, ModifyMulticastGroupSuccess) {
 
 TEST_F(BfrtPreManagerTest, DeleteMulticastGroupSuccess) {
   const std::string kMulticastGroupEntryText = R"pb(
-    multicast_group_entry {
-      multicast_group_id: 55
-    }
+    multicast_group_entry {multicast_group_id: 55}
   )pb";
   constexpr int kGroupId = 55;
   const std::vector<uint32> nodes = {1, 2, 3};
@@ -200,34 +180,16 @@ TEST_F(BfrtPreManagerTest, ReadMulticastGroupSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
   const std::string kMulticastGroupRequestText = R"pb(
-    multicast_group_entry {
-      multicast_group_id: 55
-    }
+    multicast_group_entry {multicast_group_id: 55}
   )pb";
   const std::string kMulticastGroupResponseText = R"pb(
-    entities {
-      packet_replication_engine_entry {
-        multicast_group_entry {
-          multicast_group_id: 55
-          replicas {
-            instance: 111
-            egress_port: 1
-          }
-          replicas {
-            instance: 111
-            egress_port: 2
-          }
-          replicas {
-            instance: 222
-            egress_port: 3
-          }
-          replicas {
-            instance: 222
-            egress_port: 4
-          }
-        }
-      }
-    }
+    entities {packet_replication_engine_entry {multicast_group_entry {
+                multicast_group_id: 55
+                replicas {instance: 111 egress_port: 1}
+                replicas {instance: 111 egress_port: 2}
+                replicas {instance: 222 egress_port: 3}
+                replicas {instance: 222 egress_port: 4}
+              }}}
   )pb";
   const int kMcNodeId1 = 100;
   const int kReplicationId1 = 111;
@@ -286,41 +248,19 @@ TEST_F(BfrtPreManagerTest, ReadMulticastGroupWildcardSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
   const std::string kMulticastGroupRequestText = R"pb(
-    multicast_group_entry {
-      multicast_group_id: 0
-    }
+    multicast_group_entry {multicast_group_id: 0}
   )pb";
   const std::string kMulticastGroupResponseText = R"pb(
-    entities {
-      packet_replication_engine_entry {
-        multicast_group_entry {
-          multicast_group_id: 55
-          replicas {
-            instance: 111
-            egress_port: 1
-          }
-          replicas {
-            instance: 111
-            egress_port: 2
-          }
-        }
-      }
-    }
-    entities {
-      packet_replication_engine_entry {
-        multicast_group_entry {
-          multicast_group_id: 88
-          replicas {
-            instance: 222
-            egress_port: 3
-          }
-          replicas {
-            instance: 222
-            egress_port: 4
-          }
-        }
-      }
-    }
+    entities {packet_replication_engine_entry {multicast_group_entry {
+                multicast_group_id: 55
+                replicas {instance: 111 egress_port: 1}
+                replicas {instance: 111 egress_port: 2}
+              }}}
+    entities {packet_replication_engine_entry {multicast_group_entry {
+                multicast_group_id: 88
+                replicas {instance: 222 egress_port: 3}
+                replicas {instance: 222 egress_port: 4}
+              }}}
   )pb";
   const int kMcNodeId1 = 100;
   const int kReplicationId1 = 111;
@@ -381,10 +321,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionSuccess) {
   const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
-      replicas {
-        egress_port: 123
-        instance: 0
-      }
+      replicas {egress_port: 123 instance: 0}
       class_of_service: 2
       packet_length_bytes: 1500
     }
@@ -414,12 +351,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionSuccess) {
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidSessionIdFail) {
   const std::string kCloneSessionEntryText = R"pb(
-    clone_session_entry {
-      session_id: 1016
-      replicas {
-        egress_port: 123
-      }
-    }
+    clone_session_entry {session_id: 1016 replicas {egress_port: 123}}
   )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
@@ -442,9 +374,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidPacketLengthFail) {
   const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
-      replicas {
-        egress_port: 123
-      }
+      replicas {egress_port: 123}
       packet_length_bytes: 65536
     }
   )pb";
@@ -470,12 +400,8 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionMultipleReplicasFail) {
   const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
-      replicas {
-        egress_port: 123
-      }
-      replicas {
-        egress_port: 456
-      }
+      replicas {egress_port: 123}
+      replicas {egress_port: 456}
     }
   )pb";
   auto session_mock = std::make_shared<SessionMock>();
@@ -498,13 +424,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionMultipleReplicasFail) {
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInstanceSetFail) {
   const std::string kCloneSessionEntryText = R"pb(
-    clone_session_entry {
-      session_id: 55
-      replicas {
-        egress_port: 123
-        instance: 1
-      }
-    }
+    clone_session_entry {session_id: 55 replicas {egress_port: 123 instance: 1}}
   )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
@@ -526,12 +446,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInstanceSetFail) {
 
 TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidEgressPortFail) {
   const std::string kCloneSessionEntryText = R"pb(
-    clone_session_entry {
-      session_id: 55
-      replicas {
-        egress_port: 0
-      }
-    }
+    clone_session_entry {session_id: 55 replicas {egress_port: 0}}
   )pb";
   auto session_mock = std::make_shared<SessionMock>();
 
@@ -554,9 +469,7 @@ TEST_F(BfrtPreManagerTest, InsertCloneSessionInvalidCosFail) {
   const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
-      replicas {
-        egress_port: 123
-      }
+      replicas {egress_port: 123}
       class_of_service: 9
     }
   )pb";
@@ -582,10 +495,7 @@ TEST_F(BfrtPreManagerTest, ModifyCloneSessionSuccess) {
   const std::string kCloneSessionEntryText = R"pb(
     clone_session_entry {
       session_id: 55
-      replicas {
-        egress_port: 654
-        instance: 0
-      }
+      replicas {egress_port: 654 instance: 0}
       class_of_service: 4
       packet_length_bytes: 510
     }
@@ -615,9 +525,7 @@ TEST_F(BfrtPreManagerTest, ModifyCloneSessionSuccess) {
 
 TEST_F(BfrtPreManagerTest, DeleteCloneSessionSuccess) {
   const std::string kCloneSessionEntryText = R"pb(
-    clone_session_entry {
-      session_id: 55
-    }
+    clone_session_entry {session_id: 55}
   )pb";
   constexpr uint32 kSessionId = 55;
   auto session_mock = std::make_shared<SessionMock>();
@@ -642,24 +550,15 @@ TEST_F(BfrtPreManagerTest, ReadCloneSessionSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
   const std::string kCloneSessionEntryRequestText = R"pb(
-    clone_session_entry {
-      session_id: 55
-    }
+    clone_session_entry {session_id: 55}
   )pb";
   const std::string kCloneSessionEntryResponseText = R"pb(
-    entities {
-      packet_replication_engine_entry {
-        clone_session_entry {
-          session_id: 55
-          replicas {
-            egress_port: 123
-            instance: 0
-          }
-          class_of_service: 2
-          packet_length_bytes: 1500
-        }
-      }
-    }
+    entities {packet_replication_engine_entry {clone_session_entry {
+                session_id: 55
+                replicas {egress_port: 123 instance: 0}
+                class_of_service: 2
+                packet_length_bytes: 1500
+              }}}
   )pb";
   const int kSessionId = 55;
   std::vector<uint32> session_ids = {kSessionId};
@@ -701,37 +600,21 @@ TEST_F(BfrtPreManagerTest, ReadCloneSessionWildcardSuccess) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
   const std::string kCloneSessionEntryRequestText = R"pb(
-    clone_session_entry {
-      session_id: 0
-    }
+    clone_session_entry {session_id: 0}
   )pb";
   const std::string kCloneSessionEntryResponseText = R"pb(
-    entities {
-      packet_replication_engine_entry {
-        clone_session_entry {
-          session_id: 55
-          replicas {
-            egress_port: 123
-            instance: 0
-          }
-          class_of_service: 2
-          packet_length_bytes: 1500
-        }
-      }
-    }
-    entities {
-      packet_replication_engine_entry {
-        clone_session_entry {
-          session_id: 88
-          replicas {
-            egress_port: 456
-            instance: 0
-          }
-          class_of_service: 6
-          packet_length_bytes: 510
-        }
-      }
-    }
+    entities {packet_replication_engine_entry {clone_session_entry {
+                session_id: 55
+                replicas {egress_port: 123 instance: 0}
+                class_of_service: 2
+                packet_length_bytes: 1500
+              }}}
+    entities {packet_replication_engine_entry {clone_session_entry {
+                session_id: 88
+                replicas {egress_port: 456 instance: 0}
+                class_of_service: 6
+                packet_length_bytes: 510
+              }}}
   )pb";
   const int kSessionId1 = 55;
   const int kSessionId2 = 88;

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -51,84 +51,41 @@ class BfrtTableManagerTest : public ::testing::Test {
     const std::string kSamplePipelineText = R"pb(
       programs {
         name: "test pipeline config",
-        p4info {
-          pkg_info {
-            arch: "tna"
-          }
-          tables {
-            preamble {
-              id: 33583783
-              name: "Ingress.control.table1"
-            }
-            match_fields {
-              id: 1
-              name: "field1"
-              bitwidth: 9
-              match_type: EXACT
-            }
-            match_fields {
-              id: 2
-              name: "field2"
-              bitwidth: 12
-              match_type: TERNARY
-            }
-            match_fields {
-              id: 3
-              name: "field3"
-              bitwidth: 15
-              match_type: RANGE
-            }
-            action_refs {
-              id: 16794911
-            }
-            const_default_action_id: 16836487
-            direct_resource_ids: 318814845
-            size: 1024
-          }
-          actions {
-            preamble {
-              id: 16794911
-              name: "Ingress.control.action1"
-            }
-            params {
-              id: 1
-              name: "vlan_id"
-              bitwidth: 12
-            }
-          }
-          direct_counters {
-            preamble {
-              id: 318814845
-              name: "Ingress.control.counter1"
-            }
-            spec {
-              unit: BOTH
-            }
-            direct_table_id: 33583783
-          }
-          meters {
-            preamble {
-              id: 55555
-              name: "Ingress.control.meter_bytes"
-              alias: "meter_bytes"
-            }
-            spec {
-              unit: BYTES
-            }
-            size: 500
-          }
-          meters {
-            preamble {
-              id: 55556
-              name: "Ingress.control.meter_packets"
-              alias: "meter_packets"
-            }
-            spec {
-              unit: PACKETS
-            }
-            size: 500
-          }
+        p4info {pkg_info {arch: "tna"} tables {
+          preamble {id: 33583783 name: "Ingress.control.table1"}
+          match_fields {id: 1 name: "field1" bitwidth: 9 match_type: EXACT}
+          match_fields {id: 2 name: "field2" bitwidth: 12 match_type: TERNARY}
+          match_fields {id: 3 name: "field3" bitwidth: 15 match_type: RANGE}
+          action_refs {id: 16794911}
+          const_default_action_id: 16836487
+          direct_resource_ids: 318814845
+          size: 1024
         }
+                actions {preamble {id: 16794911 name: "Ingress.control.action1"}
+                         params {id: 1 name: "vlan_id" bitwidth: 12}}
+                direct_counters {
+                  preamble {id: 318814845 name: "Ingress.control.counter1"}
+                  spec {unit: BOTH}
+                  direct_table_id: 33583783
+                }
+                meters {
+                  preamble {
+                    id: 55555
+                    name: "Ingress.control.meter_bytes"
+                    alias: "meter_bytes"
+                  }
+                  spec {unit: BYTES}
+                  size: 500
+                }
+                meters {
+                  preamble {
+                    id: 55556
+                    name: "Ingress.control.meter_packets"
+                    alias: "meter_packets"
+                  }
+                  spec {unit: PACKETS}
+                  size: 500
+                }}
       }
     )pb";
     BfrtDeviceConfig config;
@@ -177,21 +134,11 @@ TEST_F(BfrtTableManagerTest, WriteDirectCounterEntryTest) {
   const std::string kDirectCounterEntryText = R"pb(
     table_entry {
       table_id: 33583783
-      match {
-        field_id: 1
-        exact { value: "\001" }
-      }
-      match {
-        field_id: 2
-        ternary { value: "\x00" mask: "\x0f\xff" }
-      }
-      action { action { action_id: 1 } }
-      priority: 10
+      match {field_id: 1 exact {value: "\001"}}
+      match {field_id: 2 ternary {value: "\x00" mask: "\x0f\xff"}}
+      action {action {action_id: 1}} priority: 10
     }
-    data {
-      byte_count: 200
-      packet_count: 100
-    }
+    data {byte_count: 200 packet_count: 100}
   )pb";
 
   ::p4::v1::DirectCounterEntry entry;
@@ -221,15 +168,8 @@ TEST_F(BfrtTableManagerTest, WriteIndirectMeterEntryTest) {
 
   const std::string kMeterEntryText = R"pb(
     meter_id: 55555
-    index {
-      index: 12345
-    }
-    config {
-      cir: 1
-      cburst: 100
-      pir: 2
-      pburst: 200
-    }
+    index {index: 12345}
+    config {cir: 1 cburst: 100 pir: 2 pburst: 200}
   )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
@@ -259,10 +199,7 @@ TEST_F(BfrtTableManagerTest, ResetIndirectMeterEntryTest) {
       .WillOnce(Return(::util::OkStatus()));
 
   const std::string kMeterEntryText = R"pb(
-    meter_id: 55555
-    index {
-      index: 12345
-    }
+    meter_id: 55555 index {index: 12345}
   )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
@@ -280,15 +217,8 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
 
   const std::string kMeterEntryText = R"pb(
     meter_id: 0
-    index {
-      index: 12345
-    }
-    config {
-      cir: 1
-      cburst: 100
-      pir: 2
-      pburst: 200
-    }
+    index {index: 12345}
+    config {cir: 1 cburst: 100 pir: 2 pburst: 200}
   )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
@@ -309,15 +239,8 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryInsertDelete) {
 
   const std::string kMeterEntryText = R"pb(
     meter_id: 55555
-    index {
-      index: 12345
-    }
-    config {
-      cir: 1
-      cburst: 100
-      pir: 2
-      pburst: 200
-    }
+    index {index: 12345}
+    config {cir: 1 cburst: 100 pir: 2 pburst: 200}
   )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
@@ -362,20 +285,11 @@ TEST_F(BfrtTableManagerTest, ReadSingleIndirectMeterEntryTest) {
                         Return(::util::OkStatus())));
 
     const std::string kMeterResponseText = R"pb(
-      entities {
-        meter_entry {
-          meter_id: 55555
-          index {
-            index: 12345
-          }
-          config {
-            cir: 1
-            cburst: 100
-            pir: 2
-            pburst: 200
-          }
-        }
-      }
+      entities {meter_entry {
+        meter_id: 55555
+        index {index: 12345}
+        config {cir: 1 cburst: 100 pir: 2 pburst: 200}
+      }}
     )pb";
     ::p4::v1::ReadResponse resp;
     ASSERT_OK(ParseProtoFromString(kMeterResponseText, &resp));
@@ -387,10 +301,7 @@ TEST_F(BfrtTableManagerTest, ReadSingleIndirectMeterEntryTest) {
   }
 
   const std::string kMeterEntryText = R"pb(
-    meter_id: 55555
-    index {
-      index: 12345
-    }
+    meter_id: 55555 index {index: 12345}
   )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
@@ -409,15 +320,8 @@ TEST_F(BfrtTableManagerTest, RejectMeterEntryReadWithoutId) {
 
   const std::string kMeterEntryText = R"pb(
     meter_id: 0
-    index {
-      index: 12345
-    }
-    config {
-      cir: 1
-      cburst: 100
-      pir: 2
-      pburst: 200
-    }
+    index {index: 12345}
+    config {cir: 1 cburst: 100 pir: 2 pburst: 200}
   )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
@@ -453,10 +357,7 @@ TEST_F(BfrtTableManagerTest, RejectTableEntryWithDontCareRangeMatch) {
 
   const std::string kTableEntryText = R"pb(
     table_id: 33583783
-    match {
-      field_id: 3
-      range { low: "\000\000" high: "\x7f\xff" }
-    }
+    match {field_id: 3 range {low: "\000\000" high: "\x7f\xff"}}
     priority: 10
   )pb";
   ::p4::v1::TableEntry entry;
@@ -472,48 +373,38 @@ TEST_F(BfrtTableManagerTest, RejectTableEntryWithDontCareRangeMatch) {
 }
 
 TEST_F(BfrtTableManagerTest, WriteTableEntryTest) {
-    ASSERT_OK(PushTestConfig());
-    constexpr int kP4TableId = 33583783;
-    constexpr int kBfRtTableId = 20;
-    auto table_key_mock = absl::make_unique<TableKeyMock>();
-    auto table_data_mock = absl::make_unique<TableDataMock>();
-    auto session_mock = std::make_shared<SessionMock>();
-    WriterMock<::p4::v1::ReadResponse> writer_mock;
+  ASSERT_OK(PushTestConfig());
+  constexpr int kP4TableId = 33583783;
+  constexpr int kBfRtTableId = 20;
+  auto table_key_mock = absl::make_unique<TableKeyMock>();
+  auto table_data_mock = absl::make_unique<TableDataMock>();
+  auto session_mock = std::make_shared<SessionMock>();
+  WriterMock<::p4::v1::ReadResponse> writer_mock;
 
-    EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4TableId))
-                .WillOnce(Return(kBfRtTableId));
-    EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableKey(kBfRtTableId))
-                .WillOnce(Return(ByMove(
-                        ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableKeyInterface>>(
-                                std::move(table_key_mock)))));
-    EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableData(kBfRtTableId, _))
-                .WillOnce(Return(ByMove(
-                        ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableDataInterface>>(
-                                std::move(table_data_mock)))));
-    
-    const std::string kTableEntryText = R"pb(
+  EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4TableId))
+      .WillOnce(Return(kBfRtTableId));
+  EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableKey(kBfRtTableId))
+      .WillOnce(Return(ByMove(
+          ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableKeyInterface>>(
+              std::move(table_key_mock)))));
+  EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableData(kBfRtTableId, _))
+      .WillOnce(Return(ByMove(
+          ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableDataInterface>>(
+              std::move(table_data_mock)))));
+
+  const std::string kTableEntryText = R"pb(
     table_id: 33583783
-      match {
-        field_id: 2
-        ternary {
-          value: "\211B"
-          mask: "\377\377"
-        }
-      }
-      action {
-        action {
-          action_id: 16794911
-        }
-      }
-      priority: 10
-    )pb";
-    ::p4::v1::TableEntry entry;
-    ASSERT_OK(ParseProtoFromString(kTableEntryText, &entry));
-    EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
-                TranslateTableEntry(EqualsProto(entry), true))
-            .WillOnce(Return(::util::StatusOr<::p4::v1::TableEntry>(entry)));
-    EXPECT_OK(bfrt_table_manager_->WriteTableEntry(
-                session_mock, ::p4::v1::Update::INSERT, entry));
+    match {field_id: 2 ternary {value: "\211B" mask: "\377\377"}}
+    action {action {action_id: 16794911}}
+    priority: 10
+  )pb";
+  ::p4::v1::TableEntry entry;
+  ASSERT_OK(ParseProtoFromString(kTableEntryText, &entry));
+  EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
+              TranslateTableEntry(EqualsProto(entry), true))
+      .WillOnce(Return(::util::StatusOr<::p4::v1::TableEntry>(entry)));
+  EXPECT_OK(bfrt_table_manager_->WriteTableEntry(
+      session_mock, ::p4::v1::Update::INSERT, entry));
 }
 
 }  // namespace barefoot

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -494,7 +494,7 @@ TEST_F(BfrtTableManagerTest, WriteTableEntryTest) {
     const std::string kTableEntryText = R"pb(
     table_id: 33583783
       match {
-        field_id: 4
+        field_id: 2
         ternary {
           value: "\211B"
           mask: "\377\377"
@@ -502,7 +502,7 @@ TEST_F(BfrtTableManagerTest, WriteTableEntryTest) {
       }
       action {
         action {
-          action_id: 16783057
+          action_id: 16794911
         }
       }
       priority: 10

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -471,6 +471,51 @@ TEST_F(BfrtTableManagerTest, RejectTableEntryWithDontCareRangeMatch) {
   EXPECT_EQ(ERR_INVALID_PARAM, ret.error_code());
 }
 
+TEST_F(BfrtTableManagerTest, WriteTableEntryTest) {
+    ASSERT_OK(PushTestConfig());
+    constexpr int kP4TableId = 33583783;
+    constexpr int kBfRtTableId = 20;
+    auto table_key_mock = absl::make_unique<TableKeyMock>();
+    auto table_data_mock = absl::make_unique<TableDataMock>();
+    auto session_mock = std::make_shared<SessionMock>();
+    WriterMock<::p4::v1::ReadResponse> writer_mock;
+
+    EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4TableId))
+                .WillOnce(Return(kBfRtTableId));
+    EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableKey(kBfRtTableId))
+                .WillOnce(Return(ByMove(
+                        ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableKeyInterface>>(
+                                std::move(table_key_mock)))));
+    EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableData(kBfRtTableId, _))
+                .WillOnce(Return(ByMove(
+                        ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableDataInterface>>(
+                                std::move(table_data_mock)))));
+    
+    const std::string kTableEntryText = R"pb(
+    table_id: 33583783
+      match {
+        field_id: 4
+        ternary {
+          value: "\211B"
+          mask: "\377\377"
+        }
+      }
+      action {
+        action {
+          action_id: 16783057
+        }
+      }
+      priority: 10
+    )pb";
+    ::p4::v1::TableEntry entry;
+    ASSERT_OK(ParseProtoFromString(kTableEntryText, &entry));
+    EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
+                TranslateTableEntry(EqualsProto(entry), true))
+            .WillOnce(Return(::util::StatusOr<::p4::v1::TableEntry>(entry)));
+    EXPECT_OK(bfrt_table_manager_->WriteTableEntry(
+                session_mock, ::p4::v1::Update::INSERT, entry));
+}
+
 }  // namespace barefoot
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -373,7 +373,6 @@ TEST_F(BfrtTableManagerTest, RejectTableEntryWithDontCareRangeMatch) {
 }
 
 TEST_F(BfrtTableManagerTest, WriteTableEntryTest) {
-<<<<<<< HEAD
   ASSERT_OK(PushTestConfig());
   constexpr int kP4TableId = 33583783;
   constexpr int kBfRtTableId = 20;
@@ -406,50 +405,6 @@ TEST_F(BfrtTableManagerTest, WriteTableEntryTest) {
       .WillOnce(Return(::util::StatusOr<::p4::v1::TableEntry>(entry)));
   EXPECT_OK(bfrt_table_manager_->WriteTableEntry(
       session_mock, ::p4::v1::Update::INSERT, entry));
-=======
-    ASSERT_OK(PushTestConfig());
-    constexpr int kP4TableId = 33583783;
-    constexpr int kBfRtTableId = 20;
-    auto table_key_mock = absl::make_unique<TableKeyMock>();
-    auto table_data_mock = absl::make_unique<TableDataMock>();
-    auto session_mock = std::make_shared<SessionMock>();
-    WriterMock<::p4::v1::ReadResponse> writer_mock;
-
-    EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4TableId))
-                .WillOnce(Return(kBfRtTableId));
-    EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableKey(kBfRtTableId))
-                .WillOnce(Return(ByMove(
-                        ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableKeyInterface>>(
-                                std::move(table_key_mock)))));
-    EXPECT_CALL(*bf_sde_wrapper_mock_, CreateTableData(kBfRtTableId, _))
-                .WillOnce(Return(ByMove(
-                        ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableDataInterface>>(
-                                std::move(table_data_mock)))));
-    
-    const std::string kTableEntryText = R"pb(
-    table_id: 33583783
-      match {
-        field_id: 2
-        ternary {
-          value: "\211B"
-          mask: "\377\377"
-        }
-      }
-      action {
-        action {
-          action_id: 16794911
-        }
-      }
-      priority: 10
-    )pb";
-    ::p4::v1::TableEntry entry;
-    ASSERT_OK(ParseProtoFromString(kTableEntryText, &entry));
-    EXPECT_CALL(*bfrt_p4runtime_translator_mock_,
-                TranslateTableEntry(EqualsProto(entry), true))
-            .WillOnce(Return(::util::StatusOr<::p4::v1::TableEntry>(entry)));
-    EXPECT_OK(bfrt_table_manager_->WriteTableEntry(
-                session_mock, ::p4::v1::Update::INSERT, entry));
->>>>>>> 0b3511b9f355979ff857fd96aead490689581a69
 }
 
 }  // namespace barefoot

--- a/stratum/hal/lib/bcm/acl_table_test.cc
+++ b/stratum/hal/lib/bcm/acl_table_test.cc
@@ -29,10 +29,10 @@ using testing::UnorderedElementsAre;
 using testing::UnorderedElementsAreArray;
 
 constexpr char kDefaultP4Table[] = R"pb(
-  preamble { id: 1 name: "table_1" }
-  match_fields { id: 100 }
-  match_fields { id: 200 }
-  match_fields { id: 300 }
+  preamble {id: 1 name: "table_1"}
+  match_fields {id: 100}
+  match_fields {id: 200}
+  match_fields {id: 300}
   size: 10
 )pb";
 

--- a/stratum/hal/lib/bcm/bcm_flow_table_test.cc
+++ b/stratum/hal/lib/bcm/bcm_flow_table_test.cc
@@ -21,29 +21,12 @@ using test_utils::EqualsProto;
 using test_utils::IsOkAndHolds;
 
 constexpr char kMockTableEntry[] = R"pb(
-    table_id: 1
-    match {
-      field_id: 1
-      exact { value: "2" }
-    }
-    match {
-      field_id: 2
-      ternary {
-        value: "3"
-        mask: "4"
-      }
-    }
-    match {
-      field_id: 3
-      lpm {
-        value: "5"
-        prefix_len: 6
-      }
-    }
-    priority: 10
-    action {
-      action_profile_member_id: 11
-    })pb";
+  table_id: 1
+  match {field_id: 1 exact {value: "2"}}
+  match {field_id: 2 ternary {value: "3" mask: "4"}}
+  match {field_id: 3 lpm {value: "5" prefix_len: 6}}
+  priority: 10
+  action {action_profile_member_id: 11})pb";
 
 const ::p4::v1::TableEntry& MockTableEntry() {
   static const ::p4::v1::TableEntry* entry = []() {

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
@@ -3990,10 +3990,9 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   auto _ = absl::MakeCleanup([entry_hdl]() { bcmlt_entry_free(entry_hdl); });
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, VLAN_IDs, vlan));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MAC_ADDRs, dst_mac));
-  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(entry_hdl, DEST_TYPEs,
-                                                   logical_port ? PORTs
-                                                   : trunk_port ? TRUNKs
-                                                                : L2_MC_GRPs));
+  RETURN_IF_BCM_ERROR(bcmlt_entry_field_symbol_add(
+      entry_hdl, DEST_TYPEs,
+      logical_port ? PORTs : trunk_port ? TRUNKs : L2_MC_GRPs));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, TRUNK_IDs, trunk_port));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODIDs, 0));
   RETURN_IF_BCM_ERROR(bcmlt_entry_field_add(entry_hdl, MODPORTs, logical_port));

--- a/stratum/hal/lib/common/admin_service.cc
+++ b/stratum/hal/lib/common/admin_service.cc
@@ -85,13 +85,12 @@ AdminService::AdminService(OperationMode mode,
   switch (req->method()) {
     case gnoi::system::RebootMethod::COLD: {
       ++reboot_count_;
-      TimerDaemon::RequestOneShotTimer(
-          delay,
-          [this]() {
-            hal_signal_handle_(SIGINT);
-            return ::util::OkStatus();
-          },
-          &reboot_timer_);
+      TimerDaemon::RequestOneShotTimer(delay,
+                                       [this]() {
+                                         hal_signal_handle_(SIGINT);
+                                         return ::util::OkStatus();
+                                       },
+                                       &reboot_timer_);
       LOG(INFO) << "Rebooting in " << delay << " ms.";
       break;
     }

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -505,7 +505,8 @@ message GoogleConfig {
     map<int32, BcmDmaChannelConfig> dma_channel_configs = 8;
   }
 
-  message BcmTxConfig {}
+  message BcmTxConfig {
+  }
 
   // BcmRateLimitConfig specifies rate limit settings for a unit. This is just
   // a proto wrapper around BcmSdkInterface::RateLimitConfig;
@@ -1341,7 +1342,8 @@ message DataRequest {
       uint64 node_id = 1;
     }
     // Defined the data required to get a data for a chassis.
-    message Chassis {}
+    message Chassis {
+    }
     // Defined the data required to get a data for a queue of a port.
     message PortQueue {
       uint64 node_id = 1;

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -117,31 +117,23 @@ class ConfigMonitoringServiceTest
   }
 
   static constexpr char kChassisConfigTemplate[] = R"pb(
-      description: "Sample test config."
-      nodes {
-        id:  $0
-        slot: 1
-        index: $1
-      }
-      nodes {
-        id:  $2
-        slot: 1
-        index: $3
-      }
-      singleton_ports {
-        id: 1
-        name: "device1.domain.net.com:ce-1/1"
-        slot: 1
-        port: 1
-        speed_bps: 100000000000
-      }
-      singleton_ports {
-        id: 2
-        name: "device1.domain.net.com:ce-1/2"
-        slot: 1
-        port: 2
-        speed_bps: 100000000000
-      }
+    description: "Sample test config."
+    nodes {id: $0 slot: 1 index: $1}
+    nodes {id: $2 slot: 1 index: $3}
+    singleton_ports {
+      id: 1
+      name: "device1.domain.net.com:ce-1/1"
+      slot: 1
+      port: 1
+      speed_bps: 100000000000
+    }
+    singleton_ports {
+      id: 2
+      name: "device1.domain.net.com:ce-1/2"
+      slot: 1
+      port: 2
+      speed_bps: 100000000000
+    }
   )pb";
   static constexpr char kErrorMsg[] = "Some error";
   static constexpr uint64 kNodeId1 = 123123123;
@@ -347,17 +339,15 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathSuccess) {
   // Build a stream subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+    subscribe {
+      mode: STREAM
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: SAMPLE
+        sample_interval: 1
       }
-      mode: SAMPLE
-      sample_interval: 1
     }
-  }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -384,16 +374,10 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathFail) {
   // Build a stream subscription request for subtree that is not supported.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "blah" }
-      }
-      mode: SAMPLE
-      sample_interval: 1
+    subscribe {
+      mode: STREAM
+      subscription {path {elem {name: "blah"}} mode: SAMPLE sample_interval: 1}
     }
-  }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -431,24 +415,16 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathPassFail) {
   // Build a stream subscription request for subtree that is not supported.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+    subscribe {
+      mode: STREAM
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: SAMPLE
+        sample_interval: 1
       }
-      mode: SAMPLE
-      sample_interval: 1
+      subscription {path {elem {name: "blah"}} mode: SAMPLE sample_interval: 1}
     }
-    subscription {
-      path {
-        elem { name: "blah" }
-      }
-      mode: SAMPLE
-      sample_interval: 1
-    }
-  }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -487,15 +463,12 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeAndPollSuccess) {
   // Build a poll subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req1;
   constexpr char kReq1[] = R"pb(
-  subscribe {
-    mode: POLL
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
-      }
+    subscribe {
+      mode: POLL
+      subscription {
+          path {elem {name: "interfaces"}
+                elem {name: "interface" key {key: "name" value: "*"}}}}
     }
-  }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq1, &req1))
       << "Failed to parse proto from the following string: " << kReq1;
@@ -503,8 +476,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeAndPollSuccess) {
   // Build actual poll request.
   ::gnmi::SubscribeRequest req2;
   constexpr char kReq2[] = R"pb(
-  poll {
-  }
+    poll {}
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq2, &req2))
       << "Failed to parse proto from the following string: " << kReq2;
@@ -537,17 +509,15 @@ TEST_P(ConfigMonitoringServiceTest, DoubleSubscribeFail) {
   // Build a stream subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+    subscribe {
+      mode: STREAM
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: SAMPLE
+        sample_interval: 1
       }
-      mode: SAMPLE
-      sample_interval: 1
     }
-  }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -587,25 +557,21 @@ TEST_P(ConfigMonitoringServiceTest, DuplicateSubscribeFail) {
   // Add another request for the same path. This is illeagal combination.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+    subscribe {
+      mode: STREAM
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: SAMPLE
+        sample_interval: 1
       }
-      mode: SAMPLE
-      sample_interval: 1
-    }
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: SAMPLE
+        sample_interval: 1
       }
-      mode: SAMPLE
-      sample_interval: 1
     }
-  }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -649,16 +615,14 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeOnChangeWithInitialValueSuccess) {
   // Build a on_change subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+    subscribe {
+      mode: STREAM
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: ON_CHANGE
       }
-      mode: ON_CHANGE
-   }
-  }
+    }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -708,16 +672,14 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
   // request.
   ::gnmi::SubscribeRequest req;
   constexpr char kReq[] = R"pb(
-  subscribe {
-    mode: STREAM
-    subscription {
-      path {
-        elem { name: "interfaces" }
-        elem { name: "interface" key { key: "name" value: "*" } }
+    subscribe {
+      mode: STREAM
+      subscription {
+        path {elem {name: "interfaces"}
+              elem {name: "interface" key {key: "name" value: "*"}}}
+        mode: TARGET_DEFINED
       }
-      mode: TARGET_DEFINED
-   }
-  }
+    }
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -772,10 +734,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootConfigBeforePush) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
   constexpr char kReq[] = R"pb(
-  path {
-  }
-  type: CONFIG
-  encoding: PROTO
+    path {} type: CONFIG encoding: PROTO
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -799,10 +758,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootNonConfig) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
   constexpr char kReq[] = R"pb(
-  path {
-  }
-  type: STATE
-  encoding: PROTO
+    path {} type: STATE encoding: PROTO
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -826,10 +782,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootNonProto) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
   constexpr char kReq[] = R"pb(
-  path {
-  }
-  type: CONFIG
-  encoding: JSON
+    path {} type: CONFIG encoding: JSON
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -853,10 +806,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootConfig) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
   constexpr char kReq[] = R"pb(
-  path {
-  }
-  type: CONFIG
-  encoding: PROTO
+    path {} type: CONFIG encoding: PROTO
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -883,16 +833,14 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetBlah) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
   constexpr char kReq[] = R"pb(
-  path {
-    elem { name: "interfaces" }
-    elem { name: "interface"
-           key { key: "name" value: "device1.domain.net.com:ce-1/2" }
-         }
-    elem { name: "state" }
-    elem { name: "blah" }
-  }
-  type: CONFIG
-  encoding: PROTO
+    path {elem {name: "interfaces"} elem {
+      name: "interface"
+      key {key: "name" value: "device1.domain.net.com:ce-1/2"}
+    }
+          elem {name: "state"}
+          elem {name: "blah"}}
+    type: CONFIG
+    encoding: PROTO
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -917,16 +865,14 @@ TEST_P(ConfigMonitoringServiceTest,
   // Prepare a GET request.
   ::gnmi::GetRequest req;
   constexpr char kReq[] = R"pb(
-  path {
-    elem { name: "interfaces" }
-    elem { name: "interface"
-           key { key: "name" value: "device1.domain.net.com:ce-1/2" }
-         }
-    elem { name: "state" }
-    elem { name: "admin-status" }
-  }
-  type: CONFIG
-  encoding: PROTO
+    path {elem {name: "interfaces"} elem {
+      name: "interface"
+      key {key: "name" value: "device1.domain.net.com:ce-1/2"}
+    }
+          elem {name: "state"}
+          elem {name: "admin-status"}}
+    type: CONFIG
+    encoding: PROTO
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -1092,18 +1038,13 @@ TEST_P(ConfigMonitoringServiceTest,
   // Prepare a GET request.
   ::gnmi::SetRequest req;
   constexpr char kReq[] = R"pb(
-    replace {
-      path {
-        elem { name: "interfaces" }
-        elem {
-          name: "interface"
-          key { key: "name" value: "ju1u1t1.xyz99.net.google.com:ce-1/2" }
-        }
-        elem { name: "state" }
-        elem { name: "health-indicator" }
-      }
-      val { string_val: "BAD" }
-    }
+    replace {path {elem {name: "interfaces"} elem {
+               name: "interface"
+               key {key: "name" value: "ju1u1t1.xyz99.net.google.com:ce-1/2"}
+             }
+                   elem {name: "state"}
+                   elem {name: "health-indicator"}}
+             val {string_val: "BAD"}}
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
@@ -1143,15 +1084,12 @@ TEST_P(ConfigMonitoringServiceTest,
   // Prepare a GET request.
   ::gnmi::SetRequest req;
   constexpr char kReq[] = R"pb(
-    delete {
-      elem { name: "interfaces" }
-      elem {
-        name: "interface"
-        key { key: "name" value: "ju1u1t1.xyz99.net.google.com:ce-1/2" }
-      }
-      elem { name: "state" }
-      elem { name: "health-indicator" }
+    delete {elem {name: "interfaces"} elem {
+      name: "interface"
+      key {key: "name" value: "ju1u1t1.xyz99.net.google.com:ce-1/2"}
     }
+            elem {name: "state"}
+            elem {name: "health-indicator"}}
   )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;

--- a/stratum/hal/lib/common/gnmi_publisher_test.cc
+++ b/stratum/hal/lib/common/gnmi_publisher_test.cc
@@ -51,22 +51,19 @@ class SubscriptionTestBase {
   void GetSampleHalConfig() {
     constexpr char kHalConfig[] = R"pb(
       description: "Sample Generic Tomahawk config with 2x100G ports."
-      chassis { platform: PLT_GENERIC_TOMAHAWK name: "device1.domain.net.com" }
+      chassis {platform: PLT_GENERIC_TOMAHAWK name: "device1.domain.net.com"}
       nodes {
         id: 1
         name: "xy1switch.domain.net.com"
         slot: 1
         index: 1
-        config_params {
-          qos_config {
-            traffic_class_mapping { internal_priority: 0 traffic_class: BE1 }
-            traffic_class_mapping { internal_priority: 1 traffic_class: AF1 }
-            traffic_class_mapping { internal_priority: 2 traffic_class: AF2 }
-            cosq_mapping { internal_priority: 2 q_num: 0 }
-            cosq_mapping { internal_priority: 1 q_num: 1 }
-            cosq_mapping { internal_priority: 0 q_num: 2 }
-          }
-        }
+        config_params {qos_config {
+            traffic_class_mapping {internal_priority: 0 traffic_class: BE1}
+            traffic_class_mapping {internal_priority: 1 traffic_class: AF1}
+            traffic_class_mapping {internal_priority: 2 traffic_class: AF2}
+            cosq_mapping {internal_priority: 2 q_num: 0}
+            cosq_mapping {internal_priority: 1 q_num: 1}
+            cosq_mapping {internal_priority: 0 q_num: 2}}}
       }
       singleton_ports {
         id: 1

--- a/stratum/hal/lib/dummy/dummy_test.proto
+++ b/stratum/hal/lib/dummy/dummy_test.proto
@@ -28,11 +28,13 @@ service Test {
   // Updates device state such as port operation state, port counters, and so
   // on.
   rpc DeviceStatusUpdate(DeviceStatusUpdateRequest)
-      returns (DeviceStatusUpdateResponse) {}
+      returns (DeviceStatusUpdateResponse) {
+  }
 
   // Sends transceiver event to dummy switch.
   rpc TransceiverEventUpdate(TransceiverEventRequest)
-      returns (TransceiverEventResponse) {}
+      returns (TransceiverEventResponse) {
+  }
 }
 
 message DeviceStatusUpdateRequest {
@@ -44,7 +46,8 @@ message DeviceStatusUpdateRequest {
     message Node {
       uint64 node_id = 1;
     }
-    message Chassis {}
+    message Chassis {
+    }
     message PortQueue {
       uint64 node_id = 1;
       uint32 port_id = 2;
@@ -61,7 +64,8 @@ message DeviceStatusUpdateRequest {
   DataResponse state_update = 2;
 }
 
-message DeviceStatusUpdateResponse {}
+message DeviceStatusUpdateResponse {
+}
 
 message TransceiverEventRequest {
   uint32 slot = 1;
@@ -69,4 +73,5 @@ message TransceiverEventRequest {
   HwState state = 3;
 }
 
-message TransceiverEventResponse {}
+message TransceiverEventResponse {
+}

--- a/stratum/hal/lib/p4/utils_test.cc
+++ b/stratum/hal/lib/p4/utils_test.cc
@@ -102,10 +102,7 @@ TEST(ValidMeterConfigTest, IsValidMeterConfigEmptyValid) {
 TEST(ValidMeterConfigTest, IsValidMeterConfigZeroBurstInvalid) {
   constexpr char kInvalidMeterConfigText[] = R"pb(
     # Zero burst sizes.
-    cir: 100
-    pir: 200
-    cburst: 0
-    pburst: 0
+    cir: 100 pir: 200 cburst: 0 pburst: 0
   )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
@@ -115,10 +112,7 @@ TEST(ValidMeterConfigTest, IsValidMeterConfigZeroBurstInvalid) {
 TEST(ValidMeterConfigTest, IsValidMeterConfigRatesInvalid) {
   constexpr char kInvalidMeterConfigText[] = R"pb(
     # Commited rate greater peak rate.
-    cir: 500
-    pir: 400
-    cburst: 100
-    pburst: 100
+    cir: 500 pir: 400 cburst: 100 pburst: 100
   )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kInvalidMeterConfigText, &config));
@@ -126,11 +120,9 @@ TEST(ValidMeterConfigTest, IsValidMeterConfigRatesInvalid) {
 }
 
 TEST(ValidMeterConfigTest, IsValidMeterConfigValid) {
-  constexpr char kValidMeterConfigText[] = R"pb(
-    cir: 50
-    pir: 100
-    cburst: 400
-    pburst: 800
+  constexpr char kValidMeterConfigText[] =
+      R"pb(
+    cir: 50 pir: 100 cburst: 400 pburst: 800
   )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kValidMeterConfigText, &config));
@@ -140,10 +132,7 @@ TEST(ValidMeterConfigTest, IsValidMeterConfigValid) {
 TEST(ValidMeterConfigTest, IsValidMeterConfigBurstsValid) {
   constexpr char kValidMeterConfigText[] = R"pb(
     # Commited burst size is allowed to be greater than peak burst size.
-    cir: 1000
-    pir: 2000
-    cburst: 800
-    pburst: 400
+    cir: 1000 pir: 2000 cburst: 800 pburst: 400
   )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kValidMeterConfigText, &config));
@@ -153,10 +142,7 @@ TEST(ValidMeterConfigTest, IsValidMeterConfigBurstsValid) {
 TEST(ValidMeterConfigTest, IsValidMeterConfigZeroRateValid) {
   constexpr char kValidMeterConfigText[] = R"pb(
     # Zero rates are allowed.
-    cir: 0
-    pir: 0
-    cburst: 400
-    pburst: 800
+    cir: 0 pir: 0 cburst: 400 pburst: 800
   )pb";
   ::p4::v1::MeterConfig config;
   CHECK_OK(ParseProtoFromString(kValidMeterConfigText, &config));

--- a/stratum/hal/lib/phal/db.proto
+++ b/stratum/hal/lib/phal/db.proto
@@ -197,13 +197,16 @@ message TemperatureData {
 // Attribute DB (i.e. Phal DB) services
 service PhalDb {
   // Get one or more attributes
-  rpc Get(GetRequest) returns (GetResponse) {}
+  rpc Get(GetRequest) returns (GetResponse) {
+  }
 
   // Set one or more attributes
-  rpc Set(SetRequest) returns (SetResponse) {}
+  rpc Set(SetRequest) returns (SetResponse) {
+  }
 
   // Subscribe to one or more attributes
-  rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse) {}
+  rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse) {
+  }
 }
 
 message PathQuery {
@@ -270,7 +273,8 @@ message SetRequest {
   repeated Update updates = 1;
 }
 
-message SetResponse {}
+message SetResponse {
+}
 
 // Error message used to report a single update error for a Set RPC.
 message Error {

--- a/stratum/hal/lib/phal/onlp/onlp_switch_configurator_test.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_switch_configurator_test.cc
@@ -57,33 +57,15 @@ class OnlpSwitchConfiguratorTest : public ::testing::Test {
   static constexpr char kPhalInitConfig[] = R"pb(
     cards {
       slot: 1
-      ports { port: 1 physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE }
+      ports {port: 1 physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE}
     }
-    fan_trays {
-      slot: 1
-      fans {
-        slot: 1
-        cache_policy { type: FETCH_ONCE }
-      }
-    }
-    psu_trays {
-      psus {
-        slot: 1
-        cache_policy { type: NO_CACHE }
-      }
-    }
-    led_groups {
-      leds {
-        led_index: 1
-        cache_policy { type: NO_CACHE }
-      }
-    }
-    thermal_groups {
-      thermals {
-        thermal_index: 1
-        cache_policy { type: TIMED_CACHE timed_value: 2 }
-      }
-    }
+    fan_trays {slot: 1 fans {slot: 1 cache_policy {type: FETCH_ONCE}}}
+    psu_trays {psus {slot: 1 cache_policy {type: NO_CACHE}}}
+    led_groups {leds {led_index: 1 cache_policy {type: NO_CACHE}}}
+    thermal_groups {thermals {
+      thermal_index: 1
+      cache_policy {type: TIMED_CACHE timed_value: 2}
+    }}
   )pb";
 };
 

--- a/stratum/hal/lib/phal/phaldb_service.cc
+++ b/stratum/hal/lib/phal/phaldb_service.cc
@@ -177,9 +177,7 @@ namespace {
         attribute_map[path] = update.value().bytes_val();
         break;
       }
-      default: {
-        return MAKE_ERROR(ERR_INVALID_PARAM) << "Unknown value type";
-      }
+      default: { return MAKE_ERROR(ERR_INVALID_PARAM) << "Unknown value type"; }
     }
   }
   auto adapter = absl::make_unique<Adapter>(attribute_db_interface_);

--- a/stratum/hal/lib/phal/phaldb_service_test.cc
+++ b/stratum/hal/lib/phal/phaldb_service_test.cc
@@ -78,49 +78,32 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
   std::unique_ptr<AttributeDatabaseMock> database_mock_;
 
   const std::string valid_request_path_proto = R"pb(
-    entries {
-      name: "cards"
-      index: 0
-      indexed: true
-    }
-    entries {
-      name: "ports"
-      index: 0
-      indexed: true
-    }
-    entries {
-      name: "transceiver"
-      terminal_group: true
-    }
+    entries {name: "cards" index: 0 indexed: true}
+    entries {name: "ports" index: 0 indexed: true}
+    entries {name: "transceiver" terminal_group: true}
   )pb";
 
   const std::string invalid_request_path_proto = R"pb(
-    entries {
-      name: "does_not_exists"
-      index: 0
-      indexed: true
-    }
+    entries {name: "does_not_exists" index: 0 indexed: true}
   )pb";
 
   const std::string phaldb_get_response_proto = R"pb(
-    cards {
-      ports {
-        physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
-        transceiver {
-          id: 0
-          description: "port-0"
-          hardware_state: HW_STATE_PRESENT
-          media_type: MEDIA_TYPE_SFP
-          connector_type: SFP_TYPE_SFP
-          module_type: SFP_MODULE_TYPE_10G_BASE_CR
-          info {
-            mfg_name: "test_vendor"
-            part_no: "test part #"
-            serial_no: "test1234"
-          }
+    cards {ports {
+      physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
+      transceiver {
+        id: 0
+        description: "port-0"
+        hardware_state: HW_STATE_PRESENT
+        media_type: MEDIA_TYPE_SFP
+        connector_type: SFP_TYPE_SFP
+        module_type: SFP_MODULE_TYPE_10G_BASE_CR
+        info {
+          mfg_name: "test_vendor"
+          part_no: "test part #"
+          serial_no: "test1234"
         }
       }
-    }
+    }}
   )pb";
 };
 

--- a/stratum/hal/lib/phal/sfp_adapter_test.cc
+++ b/stratum/hal/lib/phal/sfp_adapter_test.cc
@@ -48,24 +48,22 @@ class SfpAdapterTest : public ::testing::Test {
   std::unique_ptr<SfpAdapter> sfp_adapter_;
 
   const std::string phaldb_get_response_proto = R"pb(
-    cards {
-      ports {
-        physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
-        transceiver {
-          id: 0
-          description: "port-0"
-          hardware_state: HW_STATE_PRESENT
-          media_type: MEDIA_TYPE_SFP
-          connector_type: SFP_TYPE_SFP
-          module_type: SFP_MODULE_TYPE_10G_BASE_CR
-          info {
-            mfg_name: "test_vendor"
-            part_no: "test part #"
-            serial_no: "test1234"
-          }
+    cards {ports {
+      physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
+      transceiver {
+        id: 0
+        description: "port-0"
+        hardware_state: HW_STATE_PRESENT
+        media_type: MEDIA_TYPE_SFP
+        connector_type: SFP_TYPE_SFP
+        module_type: SFP_MODULE_TYPE_10G_BASE_CR
+        info {
+          mfg_name: "test_vendor"
+          part_no: "test part #"
+          serial_no: "test1234"
         }
       }
-    }
+    }}
   )pb";
 };
 

--- a/stratum/hal/lib/phal/udev_event_handler_test.cc
+++ b/stratum/hal/lib/phal/udev_event_handler_test.cc
@@ -326,16 +326,16 @@ TEST_F(ConcurrentUdevEventHandlerTest, ManyConcurrentCallbacksExecute) {
   std::vector<pthread_t> test_threads;
   for (int i = 0; i < kNumTestThreads; i++) {
     pthread_t test_thread;
-    ASSERT_EQ(0, pthread_create(
-                     &test_thread, nullptr,
-                     +[](void* t) -> void* {
-                       if (!static_cast<ConcurrentUdevEventHandlerTest*>(t)
-                                ->TriggerSomeCallbacks()
-                                .ok())
-                         return t;  // Error, non-zero return.
-                       return nullptr;
-                     },
-                     this));
+    ASSERT_EQ(
+        0, pthread_create(&test_thread, nullptr,
+                          +[](void* t) -> void* {
+                            if (!static_cast<ConcurrentUdevEventHandlerTest*>(t)
+                                     ->TriggerSomeCallbacks()
+                                     .ok())
+                              return t;  // Error, non-zero return.
+                            return nullptr;
+                          },
+                          this));
     test_threads.push_back(test_thread);
   }
   {

--- a/stratum/lib/security/test.proto
+++ b/stratum/lib/security/test.proto
@@ -6,7 +6,9 @@ syntax = "proto3";
 package testing;
 
 service TestService {
-  rpc Test(Empty) returns (Empty) {}
+  rpc Test(Empty) returns (Empty) {
+  }
 }
 
-message Empty {}
+message Empty {
+}

--- a/stratum/lib/timer_daemon_test.cc
+++ b/stratum/lib/timer_daemon_test.cc
@@ -117,36 +117,36 @@ TEST_F(TimerDaemonTest, CompareBiggerSmaller) {
 TEST_F(TimerDaemonTest, CreateOneShot) {
   // This test verifies that TimerDaemon does create one-shot timer.
   TimerDaemon::DescriptorPtr desc;
-  ASSERT_OK(TimerDaemon::RequestOneShotTimer(
-      1000,
-      [&]() {
-        absl::WriterMutexLock l(&access_lock_);
-        EXPECT_EQ(count_++, 0);
-        return ::util::OkStatus();
-      },
-      &desc));
+  ASSERT_OK(TimerDaemon::RequestOneShotTimer(1000,
+                                             [&]() {
+                                               absl::WriterMutexLock l(
+                                                   &access_lock_);
+                                               EXPECT_EQ(count_++, 0);
+                                               return ::util::OkStatus();
+                                             },
+                                             &desc));
   usleep(1100000);
 }
 
 TEST_F(TimerDaemonTest, CreateTwoOneShots) {
   // This test verifies that TimerDaemon does create two one-shot timers.
   TimerDaemon::DescriptorPtr desc1, desc2;
-  ASSERT_OK(TimerDaemon::RequestOneShotTimer(
-      1000,
-      [&]() {
-        absl::WriterMutexLock l(&access_lock_);
-        EXPECT_EQ(count_++, 1);
-        return ::util::OkStatus();
-      },
-      &desc1));
-  ASSERT_OK(TimerDaemon::RequestOneShotTimer(
-      100,
-      [&]() {
-        absl::WriterMutexLock l(&access_lock_);
-        EXPECT_EQ(count_++, 0);
-        return ::util::OkStatus();
-      },
-      &desc2));
+  ASSERT_OK(TimerDaemon::RequestOneShotTimer(1000,
+                                             [&]() {
+                                               absl::WriterMutexLock l(
+                                                   &access_lock_);
+                                               EXPECT_EQ(count_++, 1);
+                                               return ::util::OkStatus();
+                                             },
+                                             &desc1));
+  ASSERT_OK(TimerDaemon::RequestOneShotTimer(100,
+                                             [&]() {
+                                               absl::WriterMutexLock l(
+                                                   &access_lock_);
+                                               EXPECT_EQ(count_++, 0);
+                                               return ::util::OkStatus();
+                                             },
+                                             &desc2));
   usleep(1500000);
 }
 

--- a/stratum/p4c_backends/common/build_defs.bzl
+++ b/stratum/p4c_backends/common/build_defs.bzl
@@ -128,7 +128,7 @@ p4_fpm_compile = rule(
             default = Label("@com_github_p4lang_p4c//:p4include/core.p4"),
         ),
         "_p4c_stratum_fpm_binary": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("//stratum/p4c_backends/fpm:p4c-fpm"),
         ),

--- a/stratum/p4c_backends/test/build_defs.bzl
+++ b/stratum/p4c_backends/test/build_defs.bzl
@@ -86,7 +86,7 @@ p4c_save_ir = rule(
             default = Label("@com_github_p4lang_p4c//:p4include/core.p4"),  # FIXME
         ),
         "_p4c_ir_json_saver": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("//stratum/p4c_backends/test:p4c_ir_json_saver"),
         ),

--- a/stratum/procmon/procmon.proto
+++ b/stratum/procmon/procmon.proto
@@ -49,7 +49,8 @@ message CheckinRequest {
   int32 checkin_key = 1;
 }
 
-message CheckinResponse {}
+message CheckinResponse {
+}
 
 // This service is in charge of handling Checkin, etc requests from all the
 // processes managed by procmon.

--- a/stratum/procmon/procmon_test.cc
+++ b/stratum/procmon/procmon_test.cc
@@ -116,7 +116,7 @@ class FakeProcessHandler : public ProcessHandler {
     if (found == procs_running_.end()) return -1;
     bool running = found->second;
     // We should never see a blocking waitpid on a live process.
-    if (!(options & WNOHANG)) EXPECT_FALSE(running);
+    if (!(options & WNOHANG)) {EXPECT_FALSE(running);}
     if (running) {
       return 0;
     } else {

--- a/stratum/procmon/procmon_test.cc
+++ b/stratum/procmon/procmon_test.cc
@@ -116,7 +116,9 @@ class FakeProcessHandler : public ProcessHandler {
     if (found == procs_running_.end()) return -1;
     bool running = found->second;
     // We should never see a blocking waitpid on a live process.
-    if (!(options & WNOHANG)) {EXPECT_FALSE(running);}
+    if (!(options & WNOHANG)) {
+      EXPECT_FALSE(running);
+    }
     if (running) {
       return 0;
     } else {

--- a/stratum/public/proto/openconfig-goog-bcm.proto
+++ b/stratum/public/proto/openconfig-goog-bcm.proto
@@ -35,7 +35,8 @@ message Chassis {
     // Components.Component.Chassis.Conf.ConfigParams represents the
     // /openconfig-platform/components/component/chassis/conf/config-params
     // YANG schema element.
-    message ConfigParams {}
+    message ConfigParams {
+    }
 
     // Components.Component.Chassis.Conf.NodeIdToRateLimitConfig represents
     // the
@@ -147,7 +148,8 @@ message Chassis {
     // Components.Component.Chassis.State.ConfigParams represents the
     // /openconfig-platform/components/component/chassis/state/config-params
     // YANG schema element.
-    message ConfigParams {}
+    message ConfigParams {
+    }
 
     // Components.Component.Chassis.State.NodeIdToKnetConfig represents the
     // /openconfig-platform/components/component/chassis/state/node_id_to_knet_config


### PR DESCRIPTION
New test is added to bfrt_table_manage_test, this test insert an entry in a flow table.

In order to test via `xargs -a .circleci/test-targets.txt bazel test` I have to modify a line in  procmon_test.cc in order to start the test. Maybe out o scope for this pull req