### PR TITLE
Update p4c dependency to most recent compatible version

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -48,9 +48,9 @@ def stratum_deps():
         remote_workspace(
             name = "com_github_p4lang_p4c",
             remote = "https://github.com/p4lang/p4c",
-            commit = "43568b75796d68a6424ad22eebeee62f46ccd3fe",
+            commit = "e41634cd7ae1214fca589eaa92a3f2b37eeea79e",
             build_file = "@//bazel:external/p4c.BUILD",
-            sha256 = "6f0c38ccc82a3876403843c67d2994bd66115c569d1ef11cbf8e23a0281266da",
+            sha256 = "6102fa2392772b9e81092abe8f06236214febfd545b092644f1597eed2ecee97",
         )
 
     if "judy" not in native.existing_rules():

--- a/stratum/p4c_backends/fpm/parser_decoder.cc
+++ b/stratum/p4c_backends/fpm/parser_decoder.cc
@@ -235,8 +235,8 @@ bool ParserDecoder::DecodePathExpression(const IR::PathExpression& expression,
 // in the decoded_case output.
 void ParserDecoder::DecodeSimpleSelectKeySet(
     const IR::Expression& key_set, ParserSelectCase* decoded_case) {
-  mpz_class value;
-  mpz_class mask;
+  boost::multiprecision::mpz_int value;
+  boost::multiprecision::mpz_int mask;
   if (key_set.is<IR::Mask>()) {
     auto mk = key_set.to<IR::Mask>();
     if (!mk->left->is<IR::Constant>()) {
@@ -265,8 +265,8 @@ void ParserDecoder::DecodeSimpleSelectKeySet(
   }
 
   ParserKeySetValue* case_value = decoded_case->add_keyset_values();
-  case_value->mutable_constant()->set_value(value.get_ui());
-  case_value->mutable_constant()->set_mask(mask.get_ui());
+  case_value->mutable_constant()->set_value(static_cast<int64>(value));
+  case_value->mutable_constant()->set_mask(static_cast<int64>(mask));
 }
 
 // A ListExpression means the select key uses a combination of multiple

--- a/stratum/p4c_backends/fpm/parser_decoder.cc
+++ b/stratum/p4c_backends/fpm/parser_decoder.cc
@@ -3,20 +3,17 @@
 
 #include "stratum/p4c_backends/fpm/parser_decoder.h"
 
-#include "stratum/glue/logging.h"
-#include "stratum/p4c_backends/fpm/field_name_inspector.h"
-#include "stratum/p4c_backends/fpm/utils.h"
 #include "absl/debugging/leak_check.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/coreLibrary.h"
 #include "external/com_github_p4lang_p4c/frontends/p4/methodInstance.h"
+#include "stratum/glue/logging.h"
+#include "stratum/p4c_backends/fpm/field_name_inspector.h"
+#include "stratum/p4c_backends/fpm/utils.h"
 
 namespace stratum {
 namespace p4c_backends {
 
-ParserDecoder::ParserDecoder()
-    : ref_map_(nullptr),
-      type_map_(nullptr) {
-}
+ParserDecoder::ParserDecoder() : ref_map_(nullptr), type_map_(nullptr) {}
 
 // TODO(unknown): The Stratum p4c backend needs a consistent approach for
 // handling errors.  Errors can occur in several ways:
@@ -54,7 +51,7 @@ bool ParserDecoder::DecodeParser(const IR::P4Parser& p4_parser,
   for (const auto ir_parser_state : p4_parser.states) {
     // We can't use externalName() here. See pull request #182
     const std::string state_name =
-                            std::string(ir_parser_state->getName().toString());
+        std::string(ir_parser_state->getName().toString());
     VLOG(2) << "ParserState: " << state_name;
     ParserState* decoded_state =
         &(*parser_states_.mutable_parser_states())[state_name];
@@ -137,8 +134,8 @@ bool ParserDecoder::DecodeStatements(
               path_inspector.field_name());
         } else {
           for (const auto& stacked : path_inspector.stacked_header_names()) {
-            decoded_state->mutable_extracted_header()->
-                add_header_paths(stacked);
+            decoded_state->mutable_extracted_header()->add_header_paths(
+                stacked);
           }
         }
       } else {
@@ -233,8 +230,8 @@ bool ParserDecoder::DecodePathExpression(const IR::PathExpression& expression,
 // This code is adapted from p4c's bmv2 backend JsonConverter::convertSimpleKey.
 // It figures out the value and mask for the input key_set and stores them
 // in the decoded_case output.
-void ParserDecoder::DecodeSimpleSelectKeySet(
-    const IR::Expression& key_set, ParserSelectCase* decoded_case) {
+void ParserDecoder::DecodeSimpleSelectKeySet(const IR::Expression& key_set,
+                                             ParserSelectCase* decoded_case) {
   boost::multiprecision::mpz_int value;
   boost::multiprecision::mpz_int mask;
   if (key_set.is<IR::Mask>()) {
@@ -273,9 +270,9 @@ void ParserDecoder::DecodeSimpleSelectKeySet(
 // fields, and the expression lists the key values for each field.  The
 // size of the key_set list must match the number of fields in the
 // select component list.
-void ParserDecoder::DecodeComplexSelectKeySet(
-    const IR::ListExpression& key_set, const IR::ListExpression& select,
-    ParserSelectCase* decoded_case) {
+void ParserDecoder::DecodeComplexSelectKeySet(const IR::ListExpression& key_set,
+                                              const IR::ListExpression& select,
+                                              ParserSelectCase* decoded_case) {
   if (key_set.components.size() != select.components.size()) {
     // TODO(unknown): Should the compiler catch this?
     LOG(ERROR) << "Number of values in select case key set does not match "
@@ -288,8 +285,8 @@ void ParserDecoder::DecodeComplexSelectKeySet(
   }
 }
 
-bool ParserDecoder::DecodeValueSetSelectKeySet(
-    const IR::Expression& key_set, ParserSelectCase* decoded_case) {
+bool ParserDecoder::DecodeValueSetSelectKeySet(const IR::Expression& key_set,
+                                               ParserSelectCase* decoded_case) {
   if (!key_set.is<IR::PathExpression>()) return false;
   if (!key_set.type->is<IR::Type_Set>()) return false;
   auto path_expression = key_set.to<IR::PathExpression>();
@@ -352,8 +349,7 @@ void ParserDecoder::DecodeConcatOperator(
   decoded_select->add_selector_fields(left->member.name);
   decoded_select->add_selector_fields(right->member.name);
   for (auto& decoded_case : *decoded_select->mutable_cases()) {
-    if (decoded_case.is_default())
-      continue;
+    if (decoded_case.is_default()) continue;
     if (decoded_case.keyset_values_size() != 1) {
       LOG(ERROR) << "Compiler bug: expected keyset values of size 1 in select "
                  << "expression with concat operator, found keyset size "
@@ -400,8 +396,8 @@ std::string ParserDecoder::ExtractHeaderType(
           LOG(ERROR) << "extract expects arg type to be Type_Header";
           return header_type_name;
         }
-        header_type_name = std::string(
-            arg_type->to<IR::Type_Header>()->name.toString());
+        header_type_name =
+            std::string(arg_type->to<IR::Type_Header>()->name.toString());
       } else {
         LOG(WARNING) << "Unexpected argument count "
                      << method_call->arguments->size() << " in extract";


### PR DESCRIPTION
This PR updates the `p4c` dependency to the most recent still compatible version. Any later version include breaking changes to the optimizations performed on the P4 code in the frontend, which are not understood by our fpm backend.