### PR TITLE
Add support for SDE 9.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ workflows:
             - publish-docker-build
           matrix:
             parameters:
-              sde_version: ["9.5.0", "9.5.2", "9.7.0", "9.7.1", "9.8.0"]
+              sde_version: ["9.5.0", "9.5.2", "9.7.0", "9.7.1", "9.7.2", "9.8.0"]
       - publish-docker-stratum-tools:
           requires:
             - publish-docker-build

--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -140,6 +140,13 @@ config_setting(
 )
 
 config_setting(
+    name = "sde_version_9.7.2",
+    flag_values = {
+        ":sde_version_setting": "9.7.2",
+    },
+)
+
+config_setting(
     name = "sde_version_9.8.0",
     flag_values = {
         ":sde_version_setting": "9.8.0",

--- a/stratum/hal/bin/barefoot/README.build.md
+++ b/stratum/hal/bin/barefoot/README.build.md
@@ -24,6 +24,7 @@ access P4 Studio SDE. Contact Intel for more details.*
  - ~~9.6.0~~ (skipped)
  - 9.7.0 (experimental; stratum_bfrt only)
  - 9.7.1 (experimental; stratum_bfrt only)
+ - 9.7.2 (experimental; stratum_bfrt only)
  - 9.8.0 (experimental; stratum_bfrt only)
 
 The rest of this guide depends on the BF SDE tarball, so you can export an

--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -27,6 +27,7 @@ SDE_DEFINES = select(
         "@local_barefoot_bin//:sde_version_9.5.2": ["SDE_9_5_2"],
         "@local_barefoot_bin//:sde_version_9.7.0": ["SDE_9_7_0"],
         "@local_barefoot_bin//:sde_version_9.7.1": ["SDE_9_7_1"],
+        "@local_barefoot_bin//:sde_version_9.7.2": ["SDE_9_7_2"],
         "@local_barefoot_bin//:sde_version_9.8.0": ["SDE_9_8_0"],
     },
     no_match_error = "Unsupported SDE version",

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -490,7 +490,8 @@ template <typename T>
       table_type == bfrt::BfRtTable::TableType::COUNTER) {
     size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2) || \
+    defined(SDE_9_8_0)
     RETURN_IF_BFRT_ERROR(
         table->tableSizeGet(*bfrt_session, bf_dev_target, &table_size));
 #else
@@ -1666,6 +1667,8 @@ std::string BfSdeWrapper::GetSdeVersion() const {
   return "9.7.0";
 #elif defined(SDE_9_7_1)
   return "9.7.1";
+#elif defined(SDE_9_7_2)
+  return "9.7.2";
 #elif defined(SDE_9_8_0)
   return "9.8.0";
 #else
@@ -2108,7 +2111,7 @@ namespace {
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromNameGet(kPreNodeTable, &table));
   size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2)|| defined(SDE_9_8_0)
   RETURN_IF_BFRT_ERROR(table->tableSizeGet(*real_session->bfrt_session_,
                                            bf_dev_tgt, &table_size));
 #else
@@ -2772,7 +2775,7 @@ namespace {
     // Wildcard write to all indices.
     size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2)|| defined(SDE_9_8_0)
     RETURN_IF_BFRT_ERROR(table->tableSizeGet(*real_session->bfrt_session_,
                                              bf_dev_tgt, &table_size));
 #else
@@ -2910,7 +2913,7 @@ namespace {
     // Wildcard write to all indices.
     size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2)|| defined(SDE_9_8_0)
     RETURN_IF_BFRT_ERROR(table->tableSizeGet(*real_session->bfrt_session_,
                                              bf_dev_tgt, &table_size));
 #else

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -2111,7 +2111,8 @@ namespace {
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromNameGet(kPreNodeTable, &table));
   size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2)|| defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2) || \
+    defined(SDE_9_8_0)
   RETURN_IF_BFRT_ERROR(table->tableSizeGet(*real_session->bfrt_session_,
                                            bf_dev_tgt, &table_size));
 #else
@@ -2775,7 +2776,8 @@ namespace {
     // Wildcard write to all indices.
     size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2)|| defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2) || \
+    defined(SDE_9_8_0)
     RETURN_IF_BFRT_ERROR(table->tableSizeGet(*real_session->bfrt_session_,
                                              bf_dev_tgt, &table_size));
 #else
@@ -2913,7 +2915,8 @@ namespace {
     // Wildcard write to all indices.
     size_t table_size;
 #if defined(SDE_9_4_0) || defined(SDE_9_5_0) || defined(SDE_9_5_2) || \
-    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2)|| defined(SDE_9_8_0)
+    defined(SDE_9_7_0) || defined(SDE_9_7_1) || defined(SDE_9_7_2) || \
+    defined(SDE_9_8_0)
     RETURN_IF_BFRT_ERROR(table->tableSizeGet(*real_session->bfrt_session_,
                                              bf_dev_tgt, &table_size));
 #else

--- a/tools/release-stratum.sh
+++ b/tools/release-stratum.sh
@@ -27,7 +27,7 @@ VERSION_LONG=${VERSION_LONG:-$(date +%Y-%m-%d)}  # 2021-03-31
 STRATUM_DIR=${STRATUM_DIR:-$HOME/stratum-$(date +%Y-%m-%d-%H-%M-%SZ)}
 BCM_TARGETS=(stratum_bcm_opennsa stratum_bcm_sdklt)
 BF_TARGETS=(stratum_bf stratum_bfrt)
-BF_SDE_VERSIONS=(9.5.0 9.5.2 9.7.0 9.7.1 9.8.0)
+BF_SDE_VERSIONS=(9.5.0 9.5.2 9.7.0 9.7.1 9.7.2 9.8.0)
 
 # ---------- Build Variables -------------
 JOBS=30


### PR DESCRIPTION
This PR adds experimental support for BF SDE 9.7.2.

Starts successfully on a Tofino switch:

```
I20220623 21:41:54.872570  6825 bf_sde_wrapper.cc:1767] switchd started successfully
I20220623 21:41:54.872656  6825 main_bfrt.cc:50] Detected is_sw_model: 0
I20220623 21:41:54.872676  6825 main_bfrt.cc:51] SDE version: 9.7.2
I20220623 21:41:54.872686  6825 main_bfrt.cc:52] Switch SKU: TOFINO_32D, revision B0, chip_id 0x83058b061255c85
```

- [x] SDE install tar uploaded to AWS