### PR TITLE
Add `GetTableId` to `BfSdeInterface::TableKeyInterface`

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -90,6 +90,9 @@ class BfSdeInterface {
 
     // Gets the priority of this table key. 0 is the highest priority.
     virtual ::util::Status GetPriority(uint32* priority) const = 0;
+
+    // Gets the BfRt (not P4) table ID associated with this table key.
+    virtual ::util::Status GetTableId(uint32* table_id) const = 0;
   };
 
   // TableKeyInterface is a proxy class for BfRt table data.

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -44,6 +44,7 @@ class TableKeyMock : public BfSdeInterface::TableKeyInterface {
                                               std::string* high));
   MOCK_METHOD1(SetPriority, ::util::Status(uint32 priority));
   MOCK_CONST_METHOD1(GetPriority, ::util::Status(uint32* priority));
+  MOCK_CONST_METHOD1(GetTableId, ::util::Status(uint32* table_id));
 };
 
 class TableDataMock : public BfSdeInterface::TableDataInterface {

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -725,6 +725,14 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   return key;
 }
 
+::util::Status TableKey::GetTableId(uint32* table_id) const {
+  const bfrt::BfRtTable* table;
+  RETURN_IF_BFRT_ERROR(table_key_->tableGet(&table));
+  RETURN_IF_BFRT_ERROR(table->tableIdGet(table_id));
+
+  return ::util::OkStatus();
+}
+
 ::util::Status TableData::SetParam(int id, const std::string& value) {
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(table_data_->getParent(&table));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -55,6 +55,7 @@ class TableKey : public BfSdeInterface::TableKeyInterface {
                           std::string* high) const override;
   ::util::Status SetPriority(uint32 priority) override;
   ::util::Status GetPriority(uint32* priority) const override;
+  ::util::Status GetTableId(uint32* table_id) const override;
 
   // Allocates a new table key object.
   static ::util::StatusOr<std::unique_ptr<BfSdeInterface::TableKeyInterface>>


### PR DESCRIPTION
This PR add a `GetTableId` function to get the BfRt id of the table a key belong too. This is useful in cases where we did not create the key ourselves, hence might not have the original table id, but need it for further actions.