### PR TITLE
Add `libexpat` dependency to Stratum-bfrt Debian package

### DIFF
--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -232,6 +232,7 @@ pkg_deb(
     depends = [
         "kmod",
         "libedit2",
+        "libexpat1",
         "libssl1.1",
         "systemd",
         "telnet",


### PR DESCRIPTION
`libexpat` is needed for SDE 9.9.0 and above.

Follow up to PR #980 