### PR TITLE
Remove instructions to unpack BSP tar

### DIFF
--- a/stratum/hal/bin/barefoot/README.build.md
+++ b/stratum/hal/bin/barefoot/README.build.md
@@ -291,31 +291,15 @@ variable before running the
 [`build-stratum-bf-container.sh`](#method-1-build-with-docker-in-one-shot) script:
 
 ```bash
-tar -xzvf bf-reference-bsp-<SDE_VERSION>.tgz
-export BSP=`pwd`/bf-reference-bsp-<SDE_VERSION>
-stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh ...
-```
-
-Or pass the BSP sources to the p4studio_build script with the `--bsp-path` flag.
-
-```bash
-tar -xzvf bf-reference-bsp-<SDE_VERSION>.tgz
-export BSP_PATH=`pwd`/bf-reference-bsp-<SDE_VERSION>
-./p4studio_build.py -up profiles/stratum_profile.yaml --bsp-path $BSP_PATH [-kdir <path/to/linux/sources>]
-```
-
-Starting with SDE 9.7.0 the BSP does not have to be extracted anymore:
-
-```bash
 export BSP=`pwd`/bf-reference-bsp-<SDE_VERSION>.tgz
 stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh ...
 ```
 
-Or directly with `p4studio`:
+Or pass the BSP sources to the `p4studio` script with the `--bsp-path` flag.
 
 ```bash
 export BSP_PATH=`pwd`/bf-reference-bsp-<SDE_VERSION>.tgz
-./p4studio configure ... --bsp-path $BSP_PATH
+./p4studio configure ... --bsp-path $BSP_PATH [-kdir <path/to/linux/sources>]
 ```
 
 [onl-linux-headers]: https://github.com/opennetworkinglab/OpenNetworkLinux/releases/tag/onlpv2-dev-1.0.1

--- a/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
+++ b/stratum/hal/bin/barefoot/docker/build-stratum-bf-container.sh
@@ -60,12 +60,8 @@ if [ -n "$1" ]; then
       CMD_OPTS+="-k /kernel-tar$i/$KERNEL_HEADERS_TAR_NAME "
       ((i+=1))
   done
-  # Mount BSP folder and pass it to the build script, if requested, for SDE 9.6.0 and before.
-  # Pass in the BSP tarball directly, starting with SDE 9.7.0.
-  if [[ -n "$BSP" && -d "$BSP" ]]; then
-    DOCKER_OPTS+="-v $BSP:/bsp-directory "
-    CMD_OPTS+="--bsp-path /bsp-directory "
-  elif [[ -n "$BSP" && -f "$BSP" && $BSP =~ ^.*.tgz$ ]]; then
+  # Pass in the BSP tarball directly.
+  if [[ -n "$BSP" && -f "$BSP" && $BSP =~ ^.*.tgz$ ]]; then
     DOCKER_OPTS+="-v $BSP:/bsp.tgz "
     CMD_OPTS+="--bsp-path /bsp.tgz "
   fi


### PR DESCRIPTION
Not required anymore since 9.7.0, which is the minimum version we support.