### PR TITLE
Fix GNU symbols and AIM compilation error on newer Ubuntu OS

### DIFF
--- a/stratum/hal/lib/phal/onlp/onlp_wrapper.h
+++ b/stratum/hal/lib/phal/onlp/onlp_wrapper.h
@@ -6,6 +6,9 @@
 #define STRATUM_HAL_LIB_PHAL_ONLP_ONLP_WRAPPER_H_
 
 extern "C" {
+// Unless we set this define, AIM will undef _GNU_SOURCE and cause compilation
+// errors with GNU-only symbols later.
+#define AIM_CONFIG_INCLUDE_GNU_SOURCE 1
 #include <onlp/fan.h>
 #include <onlp/led.h>
 #include <onlp/oids.h>


### PR DESCRIPTION
AIM, used by ONLP, would undefine `_GNU_SOURCE` unless `AIM_CONFIG_INCLUDE_GNU_SOURCE` is set. This causes missing symbol errors later when GNU-only symbols are used in other code.