### PR TITLE
Update Abseil to June 2022 LTS release

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -172,9 +172,9 @@ def stratum_deps():
     if "com_google_absl" not in native.existing_rules():
         http_archive(
             name = "com_google_absl",
-            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
-            strip_prefix = "abseil-cpp-20211102.0",
-            sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
+            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
+            strip_prefix = "abseil-cpp-20220623.0",
+            sha256 = "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602",
         )
 
     if "com_github_google_glog" not in native.existing_rules():


### PR DESCRIPTION
Release notes: https://github.com/abseil/abseil-cpp/releases/tag/20220623.0

> - This will be the last release to support C++11. Future releases will require at least C++14.