### PR TITLE
Remove unnecessary `reboot()` header includes from `AdminUtils`

### DIFF
--- a/stratum/hal/lib/common/admin_utils.cc
+++ b/stratum/hal/lib/common/admin_utils.cc
@@ -2,11 +2,9 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-#include <linux/reboot.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 #include <sys/reboot.h>
-#include <sys/sysinfo.h>
 #include <sys/wait.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This change removes the extraneous include of Linux-specific header files for the `reboot` syscall. We were using the common BSD variant of it anyway, which is more portable and requires just ` <unistd.h>` and  `<sys/reboot.h>`.
As a side effect, this class now builds on MacOS as well.

Closes #846 #843 