### PR TITLE
Fix the `sig_t` handler typedef on MacOS

### DIFF
--- a/stratum/glue/platform.h
+++ b/stratum/glue/platform.h
@@ -141,7 +141,7 @@
 #define s6_addr32 __u6_addr.__u6_addr32
 
 // Typedef for compatability with Linux's sighandler_t.
-typedef void (*sig_t)(int);
+typedef sig_t sighandler_t;
 
 #endif  // __APPLE__
 


### PR DESCRIPTION
We were re-defining `sig_t`, which already exists on MacOS, instead of typedef'ing `sighandler_t` to it.