### PR TITLE
Include platform glue header in `Hal`

### DIFF
--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -501,6 +501,7 @@ stratum_cc_library(
         ":p4_service",
         ":switch_interface",
         "//stratum/glue:logging",
+        "//stratum/glue:platform",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",

--- a/stratum/hal/lib/common/hal.h
+++ b/stratum/hal/lib/common/hal.h
@@ -18,6 +18,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 #include "grpcpp/grpcpp.h"
+#include "stratum/glue/platform.h"
 #include "stratum/hal/lib/common/admin_service.h"
 #include "stratum/hal/lib/common/certificate_management_service.h"
 #include "stratum/hal/lib/common/common.pb.h"


### PR DESCRIPTION
`Hal` uses platform specific types. This change enhances its portability by including out platform glue header.