### PR TITLE
Skip building the builder image if it is a fork PR

### DIFF
--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -66,7 +66,10 @@ set_bazelrc: &set_bazelrc
 docker_login: &docker_login
   run:
     name: Docker login
-    command: echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
+    command: |
+      if [[ -n $DOCKER_LOGIN ]]; then
+        echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
+      fi
 
 harbor_login: &harbor_login
   run:
@@ -77,6 +80,9 @@ docker_build: &docker_build
   run:
     name: Build Docker image
     command: |
+      if [[ -z $DOCKER_LOGIN ]]; then
+        exit 0
+      fi
       docker pull $DOCKER_IMG || true
       cd $DOCKER_SCOPE
       docker build -f $DOCKER_FILE -t $DOCKER_IMG \
@@ -96,7 +102,10 @@ harbor_tag: &harbor_tag
 docker_push: &docker_push
   run:
     name: Push Docker image
-    command: docker push $DOCKER_IMG
+    command: |
+      if [[ -n $DOCKER_LOGIN ]]; then
+        docker push $DOCKER_IMG
+      fi
 
 harbor_push: &harbor_push
   run:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -185,9 +185,9 @@ jobs:
       - DOCKER_IMG: STRATUM_BUILDER_IMAGE
     steps:
       - run: |
-        if [[ -z $DOCKER_LOGIN ]]; then
-          circleci-agent step halt
-        fi
+          if [[ -z $DOCKER_LOGIN ]]; then
+            circleci-agent step halt
+          fi
       - checkout
       - *docker_login
       - *docker_build

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -66,10 +66,7 @@ set_bazelrc: &set_bazelrc
 docker_login: &docker_login
   run:
     name: Docker login
-    command: |
-      if [[ -n $DOCKER_LOGIN ]]; then
-        echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
-      fi
+    command: echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
 
 harbor_login: &harbor_login
   run:
@@ -80,9 +77,6 @@ docker_build: &docker_build
   run:
     name: Build Docker image
     command: |
-      if [[ -z $DOCKER_LOGIN ]]; then
-        exit 0
-      fi
       docker pull $DOCKER_IMG || true
       cd $DOCKER_SCOPE
       docker build -f $DOCKER_FILE -t $DOCKER_IMG \
@@ -102,10 +96,7 @@ harbor_tag: &harbor_tag
 docker_push: &docker_push
   run:
     name: Push Docker image
-    command: |
-      if [[ -n $DOCKER_LOGIN ]]; then
-        docker push $DOCKER_IMG
-      fi
+    command: docker push $DOCKER_IMG
 
 harbor_push: &harbor_push
   run:
@@ -193,6 +184,10 @@ jobs:
       - DOCKER_FILE: Dockerfile.build
       - DOCKER_IMG: STRATUM_BUILDER_IMAGE
     steps:
+      - run: |
+        if [[ -z $DOCKER_LOGIN ]]; then
+          circleci-agent step halt
+        fi
       - checkout
       - *docker_login
       - *docker_build

--- a/.circleci/generate-config.sh
+++ b/.circleci/generate-config.sh
@@ -5,7 +5,7 @@
 STRATUM_ROOT=$(cd $(dirname ${BASH_SOURCE[0]})/..; pwd)
 STRATUM_BUILDER_IMAGE="stratumproject/build:build"
 
-if [[ "$CIRCLE_BRANCH" != "main" ]]; then
+if [[ "$CIRCLE_BRANCH" != "main" and "$CIRCLE_PR_USERNAME" == "stratum" ]]; then
     DOCKERFILE_SHA=$(sha256sum "$STRATUM_ROOT/Dockerfile.build" | awk '{print $1}')
     STRATUM_BUILDER_IMAGE="stratumproject/build-ci:$DOCKERFILE_SHA"
 fi

--- a/.circleci/generate-config.sh
+++ b/.circleci/generate-config.sh
@@ -5,7 +5,7 @@
 STRATUM_ROOT=$(cd $(dirname ${BASH_SOURCE[0]})/..; pwd)
 STRATUM_BUILDER_IMAGE="stratumproject/build:build"
 
-if [[ "$CIRCLE_BRANCH" != "main" ]] && [[ "$CIRCLE_PR_USERNAME" == "stratum" ]]; then
+if [[ "$CIRCLE_BRANCH" != "main" ]] && [[ -n $DOCKER_LOGIN ]]; then
     DOCKERFILE_SHA=$(sha256sum "$STRATUM_ROOT/Dockerfile.build" | awk '{print $1}')
     STRATUM_BUILDER_IMAGE="stratumproject/build-ci:$DOCKERFILE_SHA"
 fi

--- a/.circleci/generate-config.sh
+++ b/.circleci/generate-config.sh
@@ -5,7 +5,7 @@
 STRATUM_ROOT=$(cd $(dirname ${BASH_SOURCE[0]})/..; pwd)
 STRATUM_BUILDER_IMAGE="stratumproject/build:build"
 
-if [[ "$CIRCLE_BRANCH" != "main" and "$CIRCLE_PR_USERNAME" == "stratum" ]]; then
+if [[ "$CIRCLE_BRANCH" != "main" ]] && [[ "$CIRCLE_PR_USERNAME" == "stratum" ]]; then
     DOCKERFILE_SHA=$(sha256sum "$STRATUM_ROOT/Dockerfile.build" | awk '{print $1}')
     STRATUM_BUILDER_IMAGE="stratumproject/build-ci:$DOCKERFILE_SHA"
 fi


### PR DESCRIPTION
CircleCI won't provide sensitive environment variables for fork PR. Which means we cannot build the builder image and push it.
The current solution is to skip the container build and push if it is an forked PR 