### PR TITLE
Make Stratum-bcm independent from ONLP

### DIFF
--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -1136,7 +1136,10 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
     if (bcm_port.internal()) {
       xcvr_port_key_to_xcvr_state_[port_group_key] = HW_STATE_PRESENT;
     } else {
-      xcvr_port_key_to_xcvr_state_[port_group_key] = HW_STATE_UNKNOWN;
+      // TODO(max): With the transition away from ONL we lost the transceiver
+      // events and have to assume all transceivers are present instead of
+      // unknown. Find an alternative way to fix this.
+      xcvr_port_key_to_xcvr_state_[port_group_key] = HW_STATE_PRESENT;
     }
   }
 

--- a/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
@@ -723,7 +723,7 @@ TEST_P(BcmChassisManagerTest,
   EXPECT_CALL(*bcm_sdk_mock_, StartDiagShellServer())
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, SetPortOptions(0, 34, _))
-      .Times(4)
+      .Times(2)
       .WillRepeatedly(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               RegisterLinkscanEventWriter(
@@ -1479,7 +1479,7 @@ TEST_P(BcmChassisManagerTest,
   EXPECT_CALL(*bcm_sdk_mock_, StartDiagShellServer())
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, SetPortOptions(0, 1, _))
-      .Times(4)
+      .Times(2)
       .WillRepeatedly(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               RegisterLinkscanEventWriter(
@@ -2316,8 +2316,7 @@ TEST_P(BcmChassisManagerTest, PushChassisConfigSuccessWithTrunks) {
   EXPECT_CALL(*bcm_sdk_mock_, StartDiagShellServer())
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, SetPortOptions(0, 1, _))
-      .Times(3)
-      .WillRepeatedly(Return(::util::OkStatus()));
+      .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               RegisterLinkscanEventWriter(
                   _, BcmSdkInterface::kLinkscanEventWriterPriorityHigh))
@@ -4528,8 +4527,7 @@ TEST_P(BcmChassisManagerTest, GetPortStateAfterConfigPushAndLinkEvent) {
   EXPECT_CALL(*bcm_sdk_mock_, StartDiagShellServer())
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_, SetPortOptions(0, 34, _))
-      .Times(2)
-      .WillRepeatedly(Return(::util::OkStatus()));
+      .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*bcm_sdk_mock_,
               RegisterLinkscanEventWriter(
                   _, BcmSdkInterface::kLinkscanEventWriterPriorityHigh))
@@ -5236,8 +5234,7 @@ TEST_P(BcmChassisManagerTest, TestSetPortAdminStateViaConfigPush) {
   }
 
   EXPECT_CALL(*bcm_sdk_mock_, SetPortOptions(0, 34, _))
-      .Times(2)
-      .WillRepeatedly(Return(::util::OkStatus()));
+      .WillOnce(Return(::util::OkStatus()));
 
   ASSERT_OK(VerifyChassisConfig(config));
   ASSERT_OK(PushChassisConfig(config));


### PR DESCRIPTION
Removing the dependency on ONLP transceiver events on BCM platforms widens the range of supported base OSs. As a downside we now have to assume transceivers are always present by default.
This change is in preparation for #932, but separate to make a later fix easier.