### PR TITLE
Emit clang coverage reports for gcov version 8+

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,7 @@ coverage:
   status:
     project:
       default:
-        target: 77%
+        target: 76%
     patch: false
 
 parsers:

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -67,6 +67,7 @@ STRATUM_COMPILER_ERRORS_GCC = [
     "-Wno-error=maybe-uninitialized",  # GCC detects some false positives
 ]
 STRATUM_COMPILER_ERRORS_LLVM = [
+    "-Xclang -coverage-version='800*'",  # Target correct gcov version
     "-Werror=implicit-fallthrough",  # TODO(max): move to common after gcc 7
     "-Werror=inconsistent-missing-destructor-override",
     "-Werror=overloaded-virtual",


### PR DESCRIPTION
Updating the base OS to Debian 10 also updated the `gcov` tool. By default, `clang` emits coverage reports in the [4.8 format](https://github.com/bazelbuild/bazel/issues/5881#issuecomment-645054093), which is not compatible with the version installed now (8.3). This is fixed by adding a flag to emit reports in the right format.