### PR TITLE
Handle role configs in `SdnControllerManager`

### DIFF
--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -5,6 +5,7 @@
 #include "stratum/hal/lib/common/p4_service.h"
 
 #include <memory>
+#include <tuple>
 
 #include "absl/memory/memory.h"
 #include "absl/numeric/int128.h"

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -108,8 +108,24 @@ grpc::Status SdnControllerManager::HandleArbitrationUpdate(
   // If the role name is not set then we assume the connection is a 'root'
   // connection.
   absl::optional<std::string> role_name;
+  absl::optional<P4RoleConfig> role_config;
   if (update.has_role() && !update.role().name().empty()) {
     role_name = update.role().name();
+  }
+
+  if (update.has_role() && update.role().has_config()) {
+    P4RoleConfig rc;
+    if (!update.role().config().UnpackTo(&rc)) {
+      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                          absl::StrCat("Unknown role config."));
+    }
+    role_config = rc;
+  }
+
+  if (!role_name.has_value() && role_config.has_value()) {
+    return grpc::Status(
+        grpc::StatusCode::INVALID_ARGUMENT,
+        absl::StrCat("Cannot set a role config for the default role."));
   }
 
   const auto old_election_id_for_connection = controller->GetElectionId();
@@ -193,6 +209,8 @@ grpc::Status SdnControllerManager::HandleArbitrationUpdate(
 
   if (connection_is_new_primary) {
     election_id_past_for_role = new_election_id_for_connection;
+    // Update the configuration for this controllers role.
+    role_config_by_name_[role_name] = role_config;
     // The spec demands we send a notifcation even if the old & new primary
     // match.
     InformConnectionsAboutPrimaryChange(role_name);

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -374,7 +374,7 @@ void SdnControllerManager::SendArbitrationResponse(SdnConnection* connection) {
         role_config_by_name_[connection->GetRoleName()];
     if (role_config.has_value()) {
       arbitration->mutable_role()->mutable_config()->PackFrom(
-          role_config_by_name_.at(connection->GetRoleName()).value());
+          role_config.value());
     }
   }
 

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -117,15 +117,14 @@ grpc::Status SdnControllerManager::HandleArbitrationUpdate(
     P4RoleConfig rc;
     if (!update.role().config().UnpackTo(&rc)) {
       return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          absl::StrCat("Unknown role config."));
+                          "Unknown role config.");
     }
     role_config = rc;
   }
 
   if (!role_name.has_value() && role_config.has_value()) {
-    return grpc::Status(
-        grpc::StatusCode::INVALID_ARGUMENT,
-        absl::StrCat("Cannot set a role config for the default role."));
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                        "Cannot set a role config for the default role.");
   }
 
   const auto old_election_id_for_connection = controller->GetElectionId();

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -371,6 +371,12 @@ void SdnControllerManager::SendArbitrationResponse(SdnConnection* connection) {
   if (connection->GetRoleName().has_value()) {
     *arbitration->mutable_role()->mutable_name() =
         connection->GetRoleName().value();
+    absl::optional<P4RoleConfig> role_config =
+        role_config_by_name_[connection->GetRoleName()];
+    if (role_config.has_value()) {
+      arbitration->mutable_role()->mutable_config()->PackFrom(
+          role_config_by_name_.at(connection->GetRoleName()).value());
+    }
   }
 
   // Populate the election ID with the highest accepted value.

--- a/stratum/lib/p4runtime/sdn_controller_manager.h
+++ b/stratum/lib/p4runtime/sdn_controller_manager.h
@@ -14,6 +14,7 @@
 #include "absl/status/status.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
+#include "stratum/public/proto/p4_role_config.pb.h"
 
 namespace stratum {
 namespace p4runtime {
@@ -140,6 +141,10 @@ class SdnControllerManager {
   //    valid, but it cannot ever be primary (i.e. the controller can force a
   //    connection to be a backup).
   std::vector<SdnConnection*> connections_ ABSL_GUARDED_BY(lock_);
+
+  // We maintain a map of the latest role config set for a given role.
+  absl::flat_hash_map<absl::optional<std::string>, absl::optional<P4RoleConfig>>
+      role_config_by_name_ ABSL_GUARDED_BY(lock_);
 
   // We maintain a map of the highest election IDs that have been selected for
   // the primary connection of a role. Once an election ID is set all new


### PR DESCRIPTION
This PR modifies the `SdnControllerManager` to accept, validate and store role configs for clients. No enforcement of the actual role config policies is done at this point.