### PR TITLE
Implement P4RT role config write request filtering

### DIFF
--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -968,6 +968,7 @@ TEST_P(P4ServiceTest, WriteFailureWhenWritingToExclusiveTable) {
     GTEST_SKIP();
   }
 
+  SetTestForwardingPipelineConfigs();
   ::grpc::ServerContext server_context;
   StreamMessageReaderWriterMock stream;
   p4runtime::SdnConnection controller(&server_context, &stream);

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -981,9 +981,9 @@ TEST_P(P4ServiceTest, WriteFailureWhenWritingToExclusiveTable) {
   req.mutable_election_id()->set_high(absl::Uint128High64(kElectionId1));
   req.mutable_election_id()->set_low(absl::Uint128Low64(kElectionId1));
   req.set_role(role_name_);
-  ::p4::v1::Update* update = req.add_updates();
-  update->set_type(::p4::v1::Update::INSERT);
-  update->mutable_entity()->mutable_table_entry()->set_table_id(1234);
+  req.add_updates()->set_type(::p4::v1::Update::INSERT);
+  req.mutable_updates(0)->mutable_entity()->mutable_table_entry()->set_table_id(
+      1234);
 
   EXPECT_CALL(*auth_policy_checker_mock_, Authorize("P4Service", "Write", _))
       .WillOnce(Return(::util::OkStatus()));

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -960,7 +960,7 @@ TEST_P(P4ServiceTest, WriteFailureForNoPipeline) {
   EXPECT_TRUE(status.error_details().empty());
 }
 
-TEST_P(P4ServiceTest, WriteFailureWhenWritingToExclusiveTable) {
+TEST_P(P4ServiceTest, WriteFailureForWritingOutsideRoleAllowedTable) {
   // This test is specific to role configs.
   if (role_name_.empty()) {
     GTEST_SKIP();

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -256,7 +256,6 @@ class P4ServiceTest
   static constexpr absl::uint128 kElectionId2 = 2222;
   static constexpr absl::uint128 kElectionId3 = 1212;
   static constexpr uint32 kTableId1 = 12;
-  static constexpr uint32 kTableId2 = 25;
   static constexpr uint64 kCookie1 = 123;
   static constexpr uint64 kCookie2 = 321;
   OperationMode mode_;
@@ -290,7 +289,6 @@ constexpr absl::uint128 P4ServiceTest::kElectionId1;
 constexpr absl::uint128 P4ServiceTest::kElectionId2;
 constexpr absl::uint128 P4ServiceTest::kElectionId3;
 constexpr uint32 P4ServiceTest::kTableId1;
-constexpr uint32 P4ServiceTest::kTableId2;
 
 TEST_P(P4ServiceTest, ColdbootSetupSuccessForSavedConfigs) {
   if (mode_ == OPERATION_MODE_COUPLED) return;
@@ -985,7 +983,7 @@ TEST_P(P4ServiceTest, WriteFailureWhenWritingToExclusiveTable) {
   req.set_role(role_name_);
   ::p4::v1::Update* update = req.add_updates();
   update->set_type(::p4::v1::Update::INSERT);
-  update->mutable_entity()->mutable_table_entry()->set_table_id(kTableId2);
+  update->mutable_entity()->mutable_table_entry()->set_table_id(1234);
 
   EXPECT_CALL(*auth_policy_checker_mock_, Authorize("P4Service", "Write", _))
       .WillOnce(Return(::util::OkStatus()));

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -80,7 +80,6 @@ uint32_t GetP4IdFromEntity(const ::p4::v1::Entity& entity) {
       return entity.action_profile_member().action_profile_id();
     case ::p4::v1::Entity::kActionProfileGroup:
       return entity.action_profile_group().action_profile_id();
-    // case ::p4::v1::Entity::kPacketReplicationEngineEntry:
     case ::p4::v1::Entity::kDirectCounterEntry:
       return entity.direct_counter_entry().table_entry().table_id();
     case ::p4::v1::Entity::kCounterEntry:
@@ -90,6 +89,7 @@ uint32_t GetP4IdFromEntity(const ::p4::v1::Entity& entity) {
     case ::p4::v1::Entity::kMeterEntry:
       return entity.meter_entry().meter_id();
     case ::p4::v1::Entity::kDirectMeterEntry:
+    case ::p4::v1::Entity::kPacketReplicationEngineEntry:
     case ::p4::v1::Entity::kValueSetEntry:
     case ::p4::v1::Entity::kDigestEntry:
     default:
@@ -101,7 +101,6 @@ uint32_t GetP4IdFromEntity(const ::p4::v1::Entity& entity) {
 grpc::Status VerifyP4IdsArePermitted(
     const absl::optional<P4RoleConfig>& role_config,
     const ::p4::v1::WriteRequest& request) {
-  // TODO(max): is empty role config an error?
   if (!role_config.has_value()) return grpc::Status::OK;
 
   for (const auto& update : request.updates()) {
@@ -145,9 +144,7 @@ grpc::Status VerifyRoleConfig(
     const absl::optional<P4RoleConfig>& role_config,
     const absl::flat_hash_map<absl::optional<std::string>,
                               absl::optional<P4RoleConfig>>& existing_configs) {
-  if (!role_config.has_value()) {
-    return grpc::Status::OK;
-  }
+  if (!role_config.has_value()) return grpc::Status::OK;
 
   for (const auto& e : existing_configs) {
     if (!e.second.has_value()) {

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -137,7 +137,7 @@ bool VerifyStreamMessageNotFiltered(
           return true;
         }
       }
-      VLOG(2) << "Discarding PacketIn " << response.packet().ShortDebugString()
+      VLOG(1) << "Discarding PacketIn " << response.packet().ShortDebugString()
               << " because it did not match the role config filter: "
               << role_config->packet_in_filter().ShortDebugString() << ".";
       return false;  // No packet filter match, discard.

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -476,7 +476,7 @@ grpc::Status SdnControllerManager::AllowRequest(
     role_name = request.role();
   }
 
-  {
+  if (role_name) {
     absl::MutexLock l(&lock_);
     grpc::Status status = VerifyRoleCanAccessIds(
         role_name, GetP4IdsFromRequest(request), role_config_by_name_);

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -70,63 +70,6 @@ grpc::Status VerifyElectionIdIsActive(
                       "Election ID is not active for the role.");
 }
 
-uint32_t GetP4IdFromEntity(const ::p4::v1::Entity& entity) {
-  switch (entity.entity_case()) {
-    case ::p4::v1::Entity::kTableEntry:
-      return entity.table_entry().table_id();
-    case ::p4::v1::Entity::kExternEntry:
-      return entity.extern_entry().extern_id();
-    case ::p4::v1::Entity::kActionProfileMember:
-      return entity.action_profile_member().action_profile_id();
-    case ::p4::v1::Entity::kActionProfileGroup:
-      return entity.action_profile_group().action_profile_id();
-    case ::p4::v1::Entity::kDirectCounterEntry:
-      return entity.direct_counter_entry().table_entry().table_id();
-    case ::p4::v1::Entity::kCounterEntry:
-      return entity.counter_entry().counter_id();
-    case ::p4::v1::Entity::kRegisterEntry:
-      return entity.register_entry().register_id();
-    case ::p4::v1::Entity::kMeterEntry:
-      return entity.meter_entry().meter_id();
-    case ::p4::v1::Entity::kDirectMeterEntry:
-    case ::p4::v1::Entity::kPacketReplicationEngineEntry:
-    case ::p4::v1::Entity::kValueSetEntry:
-    case ::p4::v1::Entity::kDigestEntry:
-    default:
-      LOG(ERROR) << "Unsupported entity type: " << entity.ShortDebugString();
-      return 0;
-  }
-}
-
-grpc::Status VerifyRoleCanAccessIds(
-    const absl::optional<std::string>& role_name,
-    const p4::v1::WriteRequest& request,
-    const absl::flat_hash_map<absl::optional<std::string>,
-                              absl::optional<P4RoleConfig>>& role_configs) {
-  const auto& role_config = role_configs.find(role_name);
-  if (role_config == role_configs.end()) {
-    return grpc::Status(grpc::StatusCode::NOT_FOUND, "Unknown role.");
-  }
-  if (!role_config->second.has_value()) return grpc::Status::OK;
-  for (const auto& update : request.updates()) {
-    uint32_t id = GetP4IdFromEntity(update.entity());
-    if (std::find(role_config->second->exclusive_p4_ids().begin(),
-                  role_config->second->exclusive_p4_ids().end(),
-                  id) != role_config->second->exclusive_p4_ids().end()) {
-      continue;
-    }
-    if (std::find(role_config->second->shared_p4_ids().begin(),
-                  role_config->second->shared_p4_ids().end(),
-                  id) != role_config->second->shared_p4_ids().end()) {
-      continue;
-    }
-    return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
-                        "Role is not allowed to access this entity.");
-  }
-
-  return grpc::Status::OK;
-}
-
 grpc::Status VerifyRoleCanPushPipeline(
     const absl::optional<std::string>& role_name,
     const absl::flat_hash_map<absl::optional<std::string>,
@@ -238,6 +181,16 @@ std::vector<uint32_t> GetP4IdsFromRequest(const p4::v1::ReadRequest& request) {
   std::vector<uint32_t> ids;
   for (const auto& entity : request.entities()) {
     uint32_t id = GetP4IdFromEntity(entity);
+    if (id) ids.push_back(id);
+  }
+
+  return ids;
+}
+
+std::vector<uint32_t> GetP4IdsFromRequest(const p4::v1::WriteRequest& request) {
+  std::vector<uint32_t> ids;
+  for (const auto& update : request.updates()) {
+    uint32_t id = GetP4IdFromEntity(update.entity());
     if (id) ids.push_back(id);
   }
 
@@ -525,8 +478,8 @@ grpc::Status SdnControllerManager::AllowRequest(
 
   {
     absl::MutexLock l(&lock_);
-    grpc::Status status =
-        VerifyRoleCanAccessIds(role_name, request, role_config_by_name_);
+    grpc::Status status = VerifyRoleCanAccessIds(
+        role_name, GetP4IdsFromRequest(request), role_config_by_name_);
     if (!status.ok()) {
       return status;
     }


### PR DESCRIPTION
This PR implements P4RT role config write permissions filtering. Clients can use the list of IDs in the role config to limit their write access to certain P4 entities.