### PR TITLE
Implement P4RT role config `PacketIn` filtering

### DIFF
--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -119,6 +119,8 @@ grpc::Status VerifyRoleConfig(
     }
   }
 
+  // TODO(max): verify packet filters for valid metadata
+
   return grpc::Status::OK;
 }
 
@@ -523,11 +525,14 @@ absl::Status SdnControllerManager::SendStreamMessageToPrimary(
   for (const auto& connection : connections_) {
     absl::optional<absl::uint128> election_id_past_for_role =
         election_id_past_by_role_[connection->GetRoleName()];
+    LOG(WARNING) << 1;
     if (election_id_past_for_role.has_value() &&
         election_id_past_for_role == connection->GetElectionId()) {
+      LOG(WARNING) << 2;
       absl::optional<P4RoleConfig> role_config =
           role_config_by_name_[connection->GetRoleName()];
       if (VerifyStreamMessageNotFiltered(role_config, response)) {
+        LOG(WARNING) << 3;
         found_at_least_one_primary = true;
         connection->SendStreamMessageResponse(response);
       }

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -525,14 +525,11 @@ absl::Status SdnControllerManager::SendStreamMessageToPrimary(
   for (const auto& connection : connections_) {
     absl::optional<absl::uint128> election_id_past_for_role =
         election_id_past_by_role_[connection->GetRoleName()];
-    LOG(WARNING) << 1;
     if (election_id_past_for_role.has_value() &&
         election_id_past_for_role == connection->GetElectionId()) {
-      LOG(WARNING) << 2;
       absl::optional<P4RoleConfig> role_config =
           role_config_by_name_[connection->GetRoleName()];
       if (VerifyStreamMessageNotFiltered(role_config, response)) {
-        LOG(WARNING) << 3;
         found_at_least_one_primary = true;
         connection->SendStreamMessageResponse(response);
       }

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -122,6 +122,24 @@ grpc::Status VerifyRoleConfig(
   return grpc::Status::OK;
 }
 
+bool VerifyStreamMessageNotFiltered(
+    const absl::optional<P4RoleConfig>& role_config,
+    const p4::v1::StreamMessageResponse& response) {
+  if (!response.has_packet()) return true;    // Not a packet, allow.
+  if (!role_config.has_value()) return true;  // No filter rule set, allow.
+  if (!role_config->has_packet_in_filter()) return true;
+
+  for (const auto& metadata : response.packet().metadata()) {
+    if (role_config->packet_in_filter().metadata_id() ==
+            metadata.metadata_id() &&
+        role_config->packet_in_filter().value() == metadata.value()) {
+      return true;
+    }
+  }
+
+  return false;  // No filter match, discard.
+}
+
 }  // namespace
 
 void SdnConnection::SetElectionId(const absl::optional<absl::uint128>& id) {
@@ -502,10 +520,14 @@ absl::Status SdnControllerManager::SendStreamMessageToPrimary(
         election_id_past_by_role_[connection->GetRoleName()];
     if (election_id_past_for_role.has_value() &&
         election_id_past_for_role == connection->GetElectionId()) {
-      if (role_receives_packet_in_.contains(connection->GetRoleName())) {
+      absl::optional<P4RoleConfig> role_config =
+          role_config_by_name_[connection->GetRoleName()];
+      if (VerifyStreamMessageNotFiltered(role_config, response)) {
         found_at_least_one_primary = true;
         connection->SendStreamMessageResponse(response);
       }
+      // We don't report and error for packets getting filtered as this is
+      // expected operation.
     }
   }
 

--- a/stratum/lib/p4runtime/sdn_controller_manager.h
+++ b/stratum/lib/p4runtime/sdn_controller_manager.h
@@ -143,8 +143,14 @@ class SdnControllerManager {
   std::vector<SdnConnection*> connections_ ABSL_GUARDED_BY(lock_);
 
   // We maintain a map of the latest role config set for a given role.
+  //
+  // key:   role_name   (no value indicates the default/root role)
+  // value: role config (no value indicates unrestricted access)
   absl::flat_hash_map<absl::optional<std::string>, absl::optional<P4RoleConfig>>
-      role_config_by_name_ ABSL_GUARDED_BY(lock_);
+      role_config_by_name_ ABSL_GUARDED_BY(lock_){
+          {kP4RuntimeRoleSdnController, {}},
+          {absl::nullopt, {}},  // default role
+      };
 
   // We maintain a map of the highest election IDs that have been selected for
   // the primary connection of a role. Once an election ID is set all new
@@ -157,16 +163,6 @@ class SdnControllerManager {
   absl::flat_hash_map<absl::optional<std::string>,
                       absl::optional<absl::uint128>>
       election_id_past_by_role_ ABSL_GUARDED_BY(lock_);
-
-  // Placeholder for role_config which ideally would be passed
-  // via the MasterArbitration method.
-  //
-  // Contains the roles that will receive packet in messages.
-  // A copy of the packet will be sent to the primary for each role.
-  absl::flat_hash_set<absl::optional<std::string>> role_receives_packet_in_{
-      kP4RuntimeRoleSdnController,
-      absl::nullopt,  // default role
-  };
 };
 
 }  // namespace p4runtime

--- a/stratum/public/proto/p4_role_config.proto
+++ b/stratum/public/proto/p4_role_config.proto
@@ -17,13 +17,14 @@ package stratum;
 //      entities are also filtered out of Read responses.
 //  packet_in_filter - A single PacketFilter that is applied to incoming packets
 //      to determine whether this role should receive them. An empty list
-//      results in no filtering.
+//      results in no filtering. This is a positive filter, a packet must
+//      contain the exact specified value to be forwarded.
 //  receives_packet_ins - A toggle to set if this role should receive PacketIns.
 //  can_push_pipeline - Determines if this role is allowed to push a pipeline.
 message P4RoleConfig {
   message PacketFilter {
-    uint32 metadata_id = 1;
-    bytes value = 2;
+    uint32 metadata_id = 1;  // Must match an ID in the P4Info.
+    bytes value = 2;         // Must be given in full bitwidth.
   }
   repeated uint32 exclusive_p4_ids = 1;
   repeated uint32 shared_p4_ids = 2;


### PR DESCRIPTION
This PR implements `PacketIn` filtering via the role config `packet_in_filter` field. 