### PR TITLE
Decrease `num_controller_connections_` even if there is no controller manager

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -733,10 +733,10 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
 void P4Service::RemoveController(uint64 node_id,
                                  p4runtime::SdnConnection* connection) {
   absl::WriterMutexLock l(&controller_lock_);
+  --num_controller_connections_;
   auto it = node_id_to_controller_manager_.find(node_id);
   if (it == node_id_to_controller_manager_.end()) return;
   it->second.Disconnect(connection);
-  --num_controller_connections_;
 }
 
 bool P4Service::IsWritePermitted(uint64 node_id,


### PR DESCRIPTION
This change fixes a bug where the `num_controller_connections_` counter in `P4Service` is not decremented correctly when there is no controller manager. This can happen after startup when the first P4RT stream connection setup attempt fails due to, e.g., an invalid election ID. The tests are amended to now check for the correctness of the counter.