### PR TITLE
Include Credo firmware in Stratum-bfrt package for Wedge100bf-65x

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -106,6 +106,14 @@ pkg_tar(
     strip_prefix = "barefoot-bin",
 )
 
+pkg_tar(
+    name = "bf_bin",
+    srcs = ["barefoot-bin/bin/credo_firmware.bin"],
+    mode = "0644",
+    package_dir = "/usr",
+    strip_prefix = "barefoot-bin",
+)
+
 # This string setting is templated with the correct version string by reading
 # the $SDE_INSTALL/share/VERSION file. Then one of the config settings below
 # will match and can be used with select().

--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -107,8 +107,10 @@ pkg_tar(
 )
 
 pkg_tar(
-    name = "bf_bin",
-    srcs = ["barefoot-bin/bin/credo_firmware.bin"],
+    name = "bf_binary_files",
+    srcs = [
+        "barefoot-bin/bin/credo_firmware.bin",  # firmware for retimers in the 65x
+    ],
     mode = "0644",
     package_dir = "/usr",
     strip_prefix = "barefoot-bin",

--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -121,10 +121,10 @@ pkg_tar(
         ":stratum_configs",
         ":stratum_shareable_files",
         ":systemd_service",
+        "@local_barefoot_bin//:bf_binary_files",
         "@local_barefoot_bin//:bf_library_files",
         "@local_barefoot_bin//:bf_shareable_files",
         "@local_barefoot_bin//:kernel_module",
-        "@local_barefoot_bin//:bf_bin",
     ],
 )
 

--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -124,6 +124,7 @@ pkg_tar(
         "@local_barefoot_bin//:bf_library_files",
         "@local_barefoot_bin//:bf_shareable_files",
         "@local_barefoot_bin//:kernel_module",
+        "@local_barefoot_bin//:bf_bin",
     ],
 )
 


### PR DESCRIPTION
Wedge100BF-65x requires "credo_firmware.bin" to set up the retimer hardware when using the BSP. Startup will failed if this file does not exists.