### PR TITLE
Implement P4RT role config read permissions

### DIFF
--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -153,7 +153,9 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
                         const ::p4::v1::SetForwardingPipelineConfigRequest& req)
       const LOCKS_EXCLUDED(controller_lock_);
 
-  bool IsReadPermitted(uint64 node_id, const p4::v1::ReadRequest& req) const
+  // Returns true if given role for a Read request is allowed to read the
+  // requested entities.
+  bool IsReadPermitted(uint64 node_id, const ::p4::v1::ReadRequest& req) const
       LOCKS_EXCLUDED(controller_lock_);
 
   // Returns true if the given role and election_id belongs to the master
@@ -168,9 +170,10 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
   DoGetForwardingPipelineConfig(uint64 node_id) const
       LOCKS_EXCLUDED(config_lock_);
 
-  p4::v1::ReadRequest ExpandWildcardsInReadRequest(
-      const p4::v1::ReadRequest& req,
-      const p4::config::v1::P4Info& p4info) const
+  // Expands a generic wildcard request into individual entity wildcard reads.
+  ::p4::v1::ReadRequest ExpandWildcardsInReadRequest(
+      const ::p4::v1::ReadRequest& req,
+      const ::p4::config::v1::P4Info& p4info) const
       LOCKS_EXCLUDED(controller_lock_);
 
   // Thread function for handling stream response RX.

--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -153,6 +153,9 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
                         const ::p4::v1::SetForwardingPipelineConfigRequest& req)
       const LOCKS_EXCLUDED(controller_lock_);
 
+  bool IsReadPermitted(uint64 node_id, const p4::v1::ReadRequest& req) const
+      LOCKS_EXCLUDED(controller_lock_);
+
   // Returns true if the given role and election_id belongs to the master
   // controller stream for a node given by its node ID.
   bool IsMasterController(
@@ -164,6 +167,11 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
   ::util::StatusOr<::p4::v1::ForwardingPipelineConfig>
   DoGetForwardingPipelineConfig(uint64 node_id) const
       LOCKS_EXCLUDED(config_lock_);
+
+  p4::v1::ReadRequest ExpandWildcardsInReadRequest(
+      const p4::v1::ReadRequest& req,
+      const p4::config::v1::P4Info& p4info) const
+      LOCKS_EXCLUDED(controller_lock_);
 
   // Thread function for handling stream response RX.
   static void* StreamResponseReceiveThreadFunc(void* arg)

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -527,15 +527,17 @@ p4::v1::ReadRequest SdnControllerManager::ExpandWildcardsInReadRequest(
     const p4::v1::ReadRequest& request,
     const p4::config::v1::P4Info& p4info) const {
   absl::MutexLock l(&lock_);
-  // Copy the request, except for the entities.
-  p4::v1::ReadRequest ret = request;
-  ret.clear_entities();
 
   absl::optional<std::string> role_name;
   if (!request.role().empty()) {
     role_name = request.role();
   }
 
+  // Copy the request, except for the entities.
+  p4::v1::ReadRequest ret = request;
+  ret.clear_entities();
+
+  // Next, expand wildcard reads into individual table reads.
   for (const auto& entity : request.entities()) {
     // Check if wildcard or single read.
     uint32_t id = GetP4IdFromEntity(entity);

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -169,11 +169,12 @@ uint32_t GetP4IdFromEntity(const ::p4::v1::Entity& entity) {
     case ::p4::v1::Entity::kMeterEntry:
       return entity.meter_entry().meter_id();
     case ::p4::v1::Entity::kDirectMeterEntry:
+      return entity.direct_meter_entry().table_entry().table_id();
     case ::p4::v1::Entity::kPacketReplicationEngineEntry:
     case ::p4::v1::Entity::kValueSetEntry:
     case ::p4::v1::Entity::kDigestEntry:
     default:
-      LOG(ERROR) << "Unsupported entity type: " << entity.ShortDebugString();
+      LOG(WARNING) << "Unsupported entity type: " << entity.ShortDebugString();
       return 0;
   }
 }
@@ -527,7 +528,7 @@ p4::v1::ReadRequest SdnControllerManager::ExpandWildcardsInReadRequest(
     const p4::config::v1::P4Info& p4info) const {
   absl::MutexLock l(&lock_);
   // Copy the request, except for the entities.
-  p4::v1::ReadRequest ret(request);
+  p4::v1::ReadRequest ret = request;
   ret.clear_entities();
 
   absl::optional<std::string> role_name;

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -522,7 +522,7 @@ int SdnControllerManager::ActiveConnections() const {
   return connections_.size();
 }
 
-p4::v1::ReadRequest SdnControllerManager::UnwildcardReadRequest(
+p4::v1::ReadRequest SdnControllerManager::ExpandWildcardsInReadRequest(
     const p4::v1::ReadRequest& request,
     const p4::config::v1::P4Info& p4info) const {
   absl::MutexLock l(&lock_);
@@ -550,7 +550,7 @@ p4::v1::ReadRequest SdnControllerManager::UnwildcardReadRequest(
                                      role_config_by_name_)
                   .ok()) {
             LOG(INFO) << "Allowed to access " << table.preamble().id();
-            p4::v1::Entity table_entry;
+            p4::v1::Entity table_entry = entity;
             table_entry.mutable_table_entry()->set_table_id(
                 table.preamble().id());
             *ret.add_entities() = table_entry;

--- a/stratum/lib/p4runtime/sdn_controller_manager.h
+++ b/stratum/lib/p4runtime/sdn_controller_manager.h
@@ -94,7 +94,7 @@ class SdnControllerManager {
   // Returns the number of currently active connections.
   int ActiveConnections() const ABSL_LOCKS_EXCLUDED(lock_);
 
-  p4::v1::ReadRequest UnwildcardReadRequest(
+  p4::v1::ReadRequest ExpandWildcardsInReadRequest(
       const p4::v1::ReadRequest& req,
       const p4::config::v1::P4Info& p4info) const ABSL_LOCKS_EXCLUDED(lock_);
 

--- a/stratum/lib/p4runtime/sdn_controller_manager.h
+++ b/stratum/lib/p4runtime/sdn_controller_manager.h
@@ -83,8 +83,9 @@ class SdnControllerManager {
   grpc::Status AllowRequest(const absl::optional<std::string>& role_name,
                             const absl::optional<absl::uint128>& election_id)
       const ABSL_LOCKS_EXCLUDED(lock_);
-
   grpc::Status AllowRequest(const p4::v1::WriteRequest& request) const
+      ABSL_LOCKS_EXCLUDED(lock_);
+  grpc::Status AllowRequest(const p4::v1::ReadRequest& request) const
       ABSL_LOCKS_EXCLUDED(lock_);
   grpc::Status AllowRequest(
       const p4::v1::SetForwardingPipelineConfigRequest& request) const
@@ -92,6 +93,10 @@ class SdnControllerManager {
 
   // Returns the number of currently active connections.
   int ActiveConnections() const ABSL_LOCKS_EXCLUDED(lock_);
+
+  p4::v1::ReadRequest UnwildcardReadRequest(
+      const p4::v1::ReadRequest& req,
+      const p4::config::v1::P4Info& p4info) const ABSL_LOCKS_EXCLUDED(lock_);
 
   absl::Status SendPacketInToPrimary(
       const p4::v1::StreamMessageResponse& response) ABSL_LOCKS_EXCLUDED(lock_);

--- a/stratum/lib/p4runtime/sdn_controller_manager.h
+++ b/stratum/lib/p4runtime/sdn_controller_manager.h
@@ -94,6 +94,7 @@ class SdnControllerManager {
   // Returns the number of currently active connections.
   int ActiveConnections() const ABSL_LOCKS_EXCLUDED(lock_);
 
+  // Expands a generic wildcard request into individual entity wildcard reads.
   p4::v1::ReadRequest ExpandWildcardsInReadRequest(
       const p4::v1::ReadRequest& req,
       const p4::config::v1::P4Info& p4info) const ABSL_LOCKS_EXCLUDED(lock_);


### PR DESCRIPTION
This PR implements P4RT role config read permissions and wildcard filtering. Clients can use the list of IDs in the role config to limit their read access to certain P4 entities. Wildcard reads under a role will get expanded and then filtered.