### PR TITLE
Check presence of forwarding pipeline in P4RT read/write RPCs

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -506,23 +506,24 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
     return ::grpc::Status(ToGrpcCode(status.status().CanonicalCode()),
                           status.status().error_message());
   }
-  p4::v1::ForwardingPipelineConfig config = status.ConsumeValueOrDie();
+  const ::p4::v1::ForwardingPipelineConfig& config = status.ValueOrDie();
 
   switch (req->response_type()) {
-    case p4::v1::GetForwardingPipelineConfigRequest::ALL: {
+    case ::p4::v1::GetForwardingPipelineConfigRequest::ALL: {
       *resp->mutable_config() = config;
       break;
     }
-    case p4::v1::GetForwardingPipelineConfigRequest::COOKIE_ONLY: {
+    case ::p4::v1::GetForwardingPipelineConfigRequest::COOKIE_ONLY: {
       *resp->mutable_config()->mutable_cookie() = config.cookie();
       break;
     }
-    case p4::v1::GetForwardingPipelineConfigRequest::P4INFO_AND_COOKIE: {
+    case ::p4::v1::GetForwardingPipelineConfigRequest::P4INFO_AND_COOKIE: {
       *resp->mutable_config()->mutable_p4info() = config.p4info();
       *resp->mutable_config()->mutable_cookie() = config.cookie();
       break;
     }
-    case p4::v1::GetForwardingPipelineConfigRequest::DEVICE_CONFIG_AND_COOKIE: {
+    case ::p4::v1::GetForwardingPipelineConfigRequest::
+        DEVICE_CONFIG_AND_COOKIE: {
       *resp->mutable_config()->mutable_p4_device_config() =
           config.p4_device_config();
       *resp->mutable_config()->mutable_cookie() = config.cookie();
@@ -680,7 +681,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
 }
 
 ::util::Status P4Service::AddOrModifyController(
-    uint64 node_id, const p4::v1::MasterArbitrationUpdate& update,
+    uint64 node_id, const ::p4::v1::MasterArbitrationUpdate& update,
     p4runtime::SdnConnection* controller) {
   // To be called by all the threads handling controller connections.
   absl::WriterMutexLock l(&controller_lock_);
@@ -747,7 +748,7 @@ void P4Service::RemoveController(uint64 node_id,
 }
 
 bool P4Service::IsWritePermitted(uint64 node_id,
-                                 const p4::v1::WriteRequest& req) const {
+                                 const ::p4::v1::WriteRequest& req) const {
   absl::ReaderMutexLock l(&controller_lock_);
   auto it = node_id_to_controller_manager_.find(node_id);
   if (it == node_id_to_controller_manager_.end()) return false;
@@ -756,7 +757,7 @@ bool P4Service::IsWritePermitted(uint64 node_id,
 
 bool P4Service::IsWritePermitted(
     uint64 node_id,
-    const p4::v1::SetForwardingPipelineConfigRequest& req) const {
+    const ::p4::v1::SetForwardingPipelineConfigRequest& req) const {
   absl::ReaderMutexLock l(&controller_lock_);
   auto it = node_id_to_controller_manager_.find(node_id);
   if (it == node_id_to_controller_manager_.end()) return false;
@@ -772,7 +773,7 @@ bool P4Service::IsMasterController(
   return it->second.AllowRequest(role_name, election_id).ok();
 }
 
-::util::StatusOr<p4::v1::ForwardingPipelineConfig>
+::util::StatusOr<::p4::v1::ForwardingPipelineConfig>
 P4Service::DoGetForwardingPipelineConfig(uint64 node_id) const {
   absl::ReaderMutexLock l(&config_lock_);
   if (forwarding_pipeline_configs_ == nullptr ||

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -303,6 +303,13 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
                           "Invalid device ID.");
   }
 
+  // Check that a forwarding config is present.
+  auto ret = DoGetForwardingPipelineConfig(node_id);
+  if (!ret.ok()) {
+    return ::grpc::Status(ToGrpcCode(ret.status().CanonicalCode()),
+                          ret.status().error_message());
+  }
+
   // Require valid election_id for Write.
   absl::uint128 election_id =
       absl::MakeUint128(req->election_id().high(), req->election_id().low());
@@ -338,9 +345,18 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   RETURN_IF_NOT_AUTHORIZED(auth_policy_checker_, P4Service, Read, context);
 
   if (!req->entities_size()) return ::grpc::Status::OK;
-  if (req->device_id() == 0) {
+  // device_id is nothing but the node_id specified in the config for the node.
+  uint64 node_id = req->device_id();
+  if (node_id == 0) {
     return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
                           "Invalid device ID.");
+  }
+
+  // Check that a forwarding config is present.
+  auto ret = DoGetForwardingPipelineConfig(node_id);
+  if (!ret.ok()) {
+    return ::grpc::Status(ToGrpcCode(ret.status().CanonicalCode()),
+                          ret.status().error_message());
   }
 
   ServerWriterWrapper<::p4::v1::ReadResponse> wrapper(writer);
@@ -349,12 +365,12 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   ::util::Status status =
       switch_interface_->ReadForwardingEntries(*req, &wrapper, &details);
   if (!status.ok()) {
-    LOG(ERROR) << "Failed to read forwarding entries from node "
-               << req->device_id() << ": " << status.error_message();
+    LOG(ERROR) << "Failed to read forwarding entries from node " << node_id
+               << ": " << status.error_message();
   }
 
   // Log debug info for future debugging.
-  LogReadRequest(req->device_id(), *req, details, timestamp);
+  LogReadRequest(node_id, *req, details, timestamp);
 
   return ToGrpcStatus(status, details);
 }
@@ -485,40 +501,31 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
                           "Invalid device ID.");
   }
 
-  absl::ReaderMutexLock l(&config_lock_);
-  if (forwarding_pipeline_configs_ == nullptr ||
-      forwarding_pipeline_configs_->node_id_to_config_size() == 0) {
-    return ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION,
-                          "No valid forwarding pipeline config has been pushed "
-                          "for any node so far.");
+  auto status = DoGetForwardingPipelineConfig(node_id);
+  if (!status.ok()) {
+    return ::grpc::Status(ToGrpcCode(status.status().CanonicalCode()),
+                          status.status().error_message());
   }
-  auto it = forwarding_pipeline_configs_->node_id_to_config().find(node_id);
-  if (it == forwarding_pipeline_configs_->node_id_to_config().end()) {
-    return ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION,
-                          absl::StrCat("Invalid node id or no valid forwarding "
-                                       "pipeline config has been pushed for "
-                                       "node ",
-                                       node_id, " yet."));
-  }
+  p4::v1::ForwardingPipelineConfig config = status.ConsumeValueOrDie();
 
   switch (req->response_type()) {
     case p4::v1::GetForwardingPipelineConfigRequest::ALL: {
-      *resp->mutable_config() = it->second;
+      *resp->mutable_config() = config;
       break;
     }
     case p4::v1::GetForwardingPipelineConfigRequest::COOKIE_ONLY: {
-      *resp->mutable_config()->mutable_cookie() = it->second.cookie();
+      *resp->mutable_config()->mutable_cookie() = config.cookie();
       break;
     }
     case p4::v1::GetForwardingPipelineConfigRequest::P4INFO_AND_COOKIE: {
-      *resp->mutable_config()->mutable_p4info() = it->second.p4info();
-      *resp->mutable_config()->mutable_cookie() = it->second.cookie();
+      *resp->mutable_config()->mutable_p4info() = config.p4info();
+      *resp->mutable_config()->mutable_cookie() = config.cookie();
       break;
     }
     case p4::v1::GetForwardingPipelineConfigRequest::DEVICE_CONFIG_AND_COOKIE: {
       *resp->mutable_config()->mutable_p4_device_config() =
-          it->second.p4_device_config();
-      *resp->mutable_config()->mutable_cookie() = it->second.cookie();
+          config.p4_device_config();
+      *resp->mutable_config()->mutable_cookie() = config.cookie();
       break;
     }
     default:
@@ -763,6 +770,25 @@ bool P4Service::IsMasterController(
   auto it = node_id_to_controller_manager_.find(node_id);
   if (it == node_id_to_controller_manager_.end()) return false;
   return it->second.AllowRequest(role_name, election_id).ok();
+}
+
+::util::StatusOr<p4::v1::ForwardingPipelineConfig>
+P4Service::DoGetForwardingPipelineConfig(uint64 node_id) const {
+  absl::ReaderMutexLock l(&config_lock_);
+  if (forwarding_pipeline_configs_ == nullptr ||
+      forwarding_pipeline_configs_->node_id_to_config_size() == 0) {
+    return MAKE_ERROR(ERR_FAILED_PRECONDITION)
+           << "No valid forwarding pipeline config has been pushed for any "
+           << "node so far.";
+  }
+  auto it = forwarding_pipeline_configs_->node_id_to_config().find(node_id);
+  if (it == forwarding_pipeline_configs_->node_id_to_config().end()) {
+    return MAKE_ERROR(ERR_FAILED_PRECONDITION)
+           << "Invalid node id or no valid forwarding pipeline config has been "
+           << "pushed for node " << node_id << " yet.";
+  }
+
+  return it->second;
 }
 
 void* P4Service::StreamResponseReceiveThreadFunc(void* arg) {

--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -160,6 +160,11 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
       const absl::optional<absl::uint128>& election_id) const
       LOCKS_EXCLUDED(controller_lock_);
 
+  // Return the stored forwarding pipeline for the given node.
+  ::util::StatusOr<p4::v1::ForwardingPipelineConfig>
+  DoGetForwardingPipelineConfig(uint64 node_id) const
+      LOCKS_EXCLUDED(config_lock_);
+
   // Thread function for handling stream response RX.
   static void* StreamResponseReceiveThreadFunc(void* arg)
       LOCKS_EXCLUDED(controller_lock_);

--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -136,7 +136,7 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
   // takes the lock. After successful completion of this function, the
   // SdnControllerManager will have the master controller stream for packet I/O.
   ::util::Status AddOrModifyController(
-      uint64 node_id, const p4::v1::MasterArbitrationUpdate& update,
+      uint64 node_id, const ::p4::v1::MasterArbitrationUpdate& update,
       p4runtime::SdnConnection* controller) LOCKS_EXCLUDED(controller_lock_);
 
   // Removes an existing controller from the controller manager given its
@@ -147,10 +147,10 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
 
   // Returns true if given (election_id, role) for a Write request belongs to
   // the master controller stream for a node given by its node ID.
-  bool IsWritePermitted(uint64 node_id, const p4::v1::WriteRequest& req) const
+  bool IsWritePermitted(uint64 node_id, const ::p4::v1::WriteRequest& req) const
       LOCKS_EXCLUDED(controller_lock_);
   bool IsWritePermitted(uint64 node_id,
-                        const p4::v1::SetForwardingPipelineConfigRequest& req)
+                        const ::p4::v1::SetForwardingPipelineConfigRequest& req)
       const LOCKS_EXCLUDED(controller_lock_);
 
   // Returns true if the given role and election_id belongs to the master
@@ -161,7 +161,7 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
       LOCKS_EXCLUDED(controller_lock_);
 
   // Return the stored forwarding pipeline for the given node.
-  ::util::StatusOr<p4::v1::ForwardingPipelineConfig>
+  ::util::StatusOr<::p4::v1::ForwardingPipelineConfig>
   DoGetForwardingPipelineConfig(uint64 node_id) const
       LOCKS_EXCLUDED(config_lock_);
 

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -131,7 +131,6 @@ class P4ServiceTest
     ASSERT_TRUE(p4_service_->forwarding_pipeline_configs_ == nullptr);
     p4_service_->forwarding_pipeline_configs_ =
         absl::make_unique<ForwardingPipelineConfigs>();
-    ForwardingPipelineConfigs configs;
     const std::string& configs_text = absl::Substitute(
         kForwardingPipelineConfigsTemplate, kNodeId1, kNodeId2);
     ASSERT_OK(ParseProtoFromString(

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -126,6 +126,18 @@ class P4ServiceTest
     }
   }
 
+  void SetTestForwardingPipelineConfigs() {
+    absl::WriterMutexLock l(&p4_service_->config_lock_);
+    ASSERT_TRUE(p4_service_->forwarding_pipeline_configs_ == nullptr);
+    p4_service_->forwarding_pipeline_configs_ =
+        absl::make_unique<ForwardingPipelineConfigs>();
+    ForwardingPipelineConfigs configs;
+    const std::string& configs_text = absl::Substitute(
+        kForwardingPipelineConfigsTemplate, kNodeId1, kNodeId2);
+    ASSERT_OK(ParseProtoFromString(
+        configs_text, p4_service_->forwarding_pipeline_configs_.get()));
+  }
+
   void AddFakeMasterController(
       uint64 node_id, p4runtime::SdnConnection* controller,
       const P4RoleConfig& role_config = GetRoleConfig()) {
@@ -706,6 +718,7 @@ TEST_P(P4ServiceTest, SetForwardingPipelineConfigFailureForRoleProhibited) {
 }
 
 TEST_P(P4ServiceTest, WriteSuccess) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ServerContext server_context;
   StreamMessageReaderWriterMock stream;
   p4runtime::SdnConnection controller(&server_context, &stream);
@@ -739,6 +752,7 @@ TEST_P(P4ServiceTest, WriteSuccess) {
 }
 
 TEST_P(P4ServiceTest, WriteSuccessForNoUpdatesToWrite) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::WriteRequest req;
   ::p4::v1::WriteResponse resp;
@@ -754,6 +768,7 @@ TEST_P(P4ServiceTest, WriteSuccessForNoUpdatesToWrite) {
 }
 
 TEST_P(P4ServiceTest, WriteFailureForNoDeviceId) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::WriteRequest req;
   ::p4::v1::WriteResponse resp;
@@ -770,6 +785,7 @@ TEST_P(P4ServiceTest, WriteFailureForNoDeviceId) {
 }
 
 TEST_P(P4ServiceTest, WriteFailureForNoElectionId) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::WriteRequest req;
   ::p4::v1::WriteResponse resp;
@@ -787,6 +803,7 @@ TEST_P(P4ServiceTest, WriteFailureForNoElectionId) {
 }
 
 TEST_P(P4ServiceTest, WriteFailureWhenNonMaster) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::WriteRequest req;
   ::p4::v1::WriteResponse resp;
@@ -806,6 +823,7 @@ TEST_P(P4ServiceTest, WriteFailureWhenNonMaster) {
 }
 
 TEST_P(P4ServiceTest, WriteFailureWhenWriteForwardingEntriesFails) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ServerContext server_context;
   StreamMessageReaderWriterMock stream;
   p4runtime::SdnConnection controller(&server_context, &stream);
@@ -854,6 +872,7 @@ TEST_P(P4ServiceTest, WriteFailureWhenWriteForwardingEntriesFails) {
 }
 
 TEST_P(P4ServiceTest, WriteFailureForAuthError) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::WriteRequest req;
   ::p4::v1::WriteResponse resp;
@@ -871,6 +890,7 @@ TEST_P(P4ServiceTest, WriteFailureForAuthError) {
 }
 
 TEST_P(P4ServiceTest, WriteFailureWhenSwitchNotInitializedError) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ServerContext server_context;
   StreamMessageReaderWriterMock stream;
   p4runtime::SdnConnection controller(&server_context, &stream);
@@ -905,6 +925,7 @@ TEST_P(P4ServiceTest, WriteFailureWhenSwitchNotInitializedError) {
 }
 
 TEST_P(P4ServiceTest, ReadSuccess) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::ReadRequest req;
   ::p4::v1::ReadResponse resp;
@@ -946,6 +967,7 @@ TEST_P(P4ServiceTest, ReadSuccessForNoEntitiesToRead) {
 }
 
 TEST_P(P4ServiceTest, ReadFailureForNoDeviceId) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::ReadRequest req;
   ::p4::v1::ReadResponse resp;
@@ -964,6 +986,7 @@ TEST_P(P4ServiceTest, ReadFailureForNoDeviceId) {
 }
 
 TEST_P(P4ServiceTest, ReadFailureWhenReadForwardingEntriesFails) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::ReadRequest req;
   ::p4::v1::ReadResponse resp;
@@ -1002,6 +1025,7 @@ TEST_P(P4ServiceTest, ReadFailureWhenReadForwardingEntriesFails) {
 }
 
 TEST_P(P4ServiceTest, ReadFailureForAuthError) {
+  SetTestForwardingPipelineConfigs();
   ::grpc::ClientContext context;
   ::p4::v1::ReadRequest req;
   ::p4::v1::ReadResponse resp;


### PR DESCRIPTION
This change adds a check on Read and Write RPCs to verify the presence of a forwarding pipeline, as required by the P4RT spec. `ERR_FAILED_PRECONDITION` is returned in those cases. Additional unit tests created to test for this behavior.

Closes #1048 