### PR TITLE
Use port numbers of Mininet interfaces in chassis_config

### DIFF
--- a/tools/mininet/stratum.py
+++ b/tools/mininet/stratum.py
@@ -170,9 +170,8 @@ nodes {{
   index: 1
 }}\n""".format(name=self.name, nodeId=self.nodeId)
 
-        intf_number = 1
-        for intf_name in self.intfNames():
-            if intf_name == 'lo':
+        for port_num, intf in sorted(self.intfs.items()):
+            if intf.name == "lo":
                 continue
             config = config + """singleton_ports {{
   id: {intfNumber}
@@ -185,8 +184,7 @@ nodes {{
     admin_state: ADMIN_STATE_{adminState}
   }}
   node: {nodeId}
-}}\n""".format(intfName=intf_name, intfNumber=intf_number, nodeId=self.nodeId, adminState=self.adminState)
-            intf_number += 1
+}}\n""".format(intfName=intf.name, intfNumber=port_num, nodeId=self.nodeId, adminState=self.adminState)
 
         return config
 


### PR DESCRIPTION
This PR enables using arbitrary port numbers of Mininet interfaces in the chassis config instead of auto-generated numbers. With this change a user can specify port number in the Mininet topo script:

```python
_intf = Intf( "veth0", node=leaf1, port=500)
```

The port in the chassis config will be initialized with ID=500. Without this change, the interface ID depends on number of interfaces attached to a switch. 

Existing deployments shouldn't be affected by this PR since default Mininet port number allocation is consistent with the current approach (start numbering from 1): https://github.com/mininet/mininet/blob/master/mininet/node.py#L443. 
