### PR TITLE
Add Ethernet CPU ports to Wedge100-32x chassis config

### DIFF
--- a/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/chassis_config.pb.txt
+++ b/stratum/hal/config/x86-64-accton-wedge100bf-32x-r0/chassis_config.pb.txt
@@ -360,3 +360,27 @@ singleton_ports {
   }
   node: 1
 }
+singleton_ports {
+  id: 3300
+  name: "33/0"
+  slot: 1
+  port: 33
+  channel: 1
+  speed_bps: 10000000000
+  config_params {
+    admin_state: ADMIN_STATE_ENABLED
+  }
+  node: 1
+}
+singleton_ports {
+  id: 3302
+  name: "33/2"
+  slot: 1
+  port: 33
+  channel: 3
+  speed_bps: 10000000000
+  config_params {
+    admin_state: ADMIN_STATE_ENABLED
+  }
+  node: 1
+}


### PR DESCRIPTION
We already enabled those ETH ports in the 32Q, this makes the default configs more similar. Note that the Ethernet CPU ports might have to be enabled in the BIOS to show up.