### PR TITLE
Return more detailed errors to P4Runtime clients

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -176,6 +176,20 @@ P4Service::~P4Service() {}
 
 namespace {
 
+// Run a command that returns a ::grpc::Status.  If the called code returns an
+// error status, return that status up out of this method too.
+//
+// Example:
+//   RETURN_IF_GRPC_ERROR(DoGrpcThings(4));
+#define RETURN_IF_GRPC_ERROR(expr)                                           \
+  do {                                                                       \
+    /* Using _status below to avoid capture problems if expr is "status". */ \
+    const ::grpc::Status _status = (expr);                                   \
+    if (ABSL_PREDICT_FALSE(!_status.ok())) {                                 \
+      return _status;                                                        \
+    }                                                                        \
+  } while (0)
+
 // TODO(unknown): This needs to be changed later per p4 runtime error
 // reporting scheme.
 ::grpc::Status ToGrpcStatus(const ::util::Status& status,
@@ -319,10 +333,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   }
 
   // Verify the request comes from the primary connection.
-  if (!IsWritePermitted(node_id, *req)) {
-    return ::grpc::Status(::grpc::StatusCode::PERMISSION_DENIED,
-                          "Write from non-master is not permitted.");
-  }
+  RETURN_IF_GRPC_ERROR(IsWritePermitted(req->device_id(), *req));
 
   std::vector<::util::Status> results = {};
   absl::Time timestamp = absl::Now();
@@ -374,10 +385,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   }
 
   // Verify the request only contains entities allowed by the role config.
-  if (!IsReadPermitted(req->device_id(), *req)) {
-    return ::grpc::Status(::grpc::StatusCode::PERMISSION_DENIED,
-                          "Read is not permitted.");
-  }
+  RETURN_IF_GRPC_ERROR(IsReadPermitted(req->device_id(), *req));
 
   ServerWriterWrapper<::p4::v1::ReadResponse> wrapper(writer);
   std::vector<::util::Status> details = {};
@@ -422,13 +430,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   // election_id and the role of the client matches those of the master.
   // According to the P4Runtime specification, only master can perform
   // SetForwardingPipelineConfig RPC.
-  if (!IsWritePermitted(node_id, *req)) {
-    return ::grpc::Status(
-        ::grpc::StatusCode::PERMISSION_DENIED,
-        absl::StrCat("SetForwardingPipelineConfig from non-master is not "
-                     "permitted for node ",
-                     node_id, "."));
-  }
+  RETURN_IF_GRPC_ERROR(IsWritePermitted(req->device_id(), *req));
 
   ::util::Status status = ::util::OkStatus();
   switch (req->action()) {
@@ -749,7 +751,8 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
            << " controllers for node (aka device) with ID " << node_id << ".";
   }
 
-  grpc::Status status = it->second.HandleArbitrationUpdate(update, controller);
+  ::grpc::Status status =
+      it->second.HandleArbitrationUpdate(update, controller);
   if (!status.ok()) {
     return ::util::Status(static_cast<::util::error::Code>(status.error_code()),
                           status.error_message());
@@ -767,29 +770,37 @@ void P4Service::RemoveController(uint64 node_id,
   it->second.Disconnect(connection);
 }
 
-bool P4Service::IsWritePermitted(uint64 node_id,
-                                 const ::p4::v1::WriteRequest& req) const {
+::grpc::Status P4Service::IsWritePermitted(
+    uint64 node_id, const ::p4::v1::WriteRequest& req) const {
   absl::ReaderMutexLock l(&controller_lock_);
   auto it = node_id_to_controller_manager_.find(node_id);
-  if (it == node_id_to_controller_manager_.end()) return false;
-  return it->second.AllowRequest(req).ok();
+  if (it == node_id_to_controller_manager_.end())
+    return ::grpc::Status(
+        grpc::StatusCode::PERMISSION_DENIED,
+        absl::StrCat("Write from non-master is not permitted for node ",
+                     node_id, "."));
+  return it->second.AllowRequest(req);
 }
 
-bool P4Service::IsWritePermitted(
+::grpc::Status P4Service::IsWritePermitted(
     uint64 node_id,
     const ::p4::v1::SetForwardingPipelineConfigRequest& req) const {
   absl::ReaderMutexLock l(&controller_lock_);
   auto it = node_id_to_controller_manager_.find(node_id);
-  if (it == node_id_to_controller_manager_.end()) return false;
-  return it->second.AllowRequest(req).ok();
+  if (it == node_id_to_controller_manager_.end())
+    return ::grpc::Status(
+        grpc::StatusCode::PERMISSION_DENIED,
+        absl::StrCat("Write from non-master is not permitted for node ",
+                     node_id, "."));
+  return it->second.AllowRequest(req);
 }
 
-bool P4Service::IsReadPermitted(uint64 node_id,
-                                const p4::v1::ReadRequest& req) const {
+::grpc::Status P4Service::IsReadPermitted(
+    uint64 node_id, const p4::v1::ReadRequest& req) const {
   absl::ReaderMutexLock l(&controller_lock_);
   auto it = node_id_to_controller_manager_.find(node_id);
-  if (it == node_id_to_controller_manager_.end()) return true;
-  return it->second.AllowRequest(req).ok();
+  if (it == node_id_to_controller_manager_.end()) return ::grpc::Status::OK;
+  return it->second.AllowRequest(req);
 }
 
 bool P4Service::IsMasterController(

--- a/stratum/hal/lib/common/p4_service.h
+++ b/stratum/hal/lib/common/p4_service.h
@@ -147,15 +147,18 @@ class P4Service final : public ::p4::v1::P4Runtime::Service {
 
   // Returns true if given (election_id, role) for a Write request belongs to
   // the master controller stream for a node given by its node ID.
-  bool IsWritePermitted(uint64 node_id, const ::p4::v1::WriteRequest& req) const
+  ::grpc::Status IsWritePermitted(uint64 node_id,
+                                  const ::p4::v1::WriteRequest& req) const
       LOCKS_EXCLUDED(controller_lock_);
-  bool IsWritePermitted(uint64 node_id,
-                        const ::p4::v1::SetForwardingPipelineConfigRequest& req)
-      const LOCKS_EXCLUDED(controller_lock_);
+  ::grpc::Status IsWritePermitted(
+      uint64 node_id,
+      const ::p4::v1::SetForwardingPipelineConfigRequest& req) const
+      LOCKS_EXCLUDED(controller_lock_);
 
   // Returns true if given role for a Read request is allowed to read the
   // requested entities.
-  bool IsReadPermitted(uint64 node_id, const ::p4::v1::ReadRequest& req) const
+  ::grpc::Status IsReadPermitted(uint64 node_id,
+                                 const ::p4::v1::ReadRequest& req) const
       LOCKS_EXCLUDED(controller_lock_);
 
   // Returns true if the given role and election_id belongs to the master

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -710,7 +710,8 @@ TEST_P(P4ServiceTest, SetForwardingPipelineConfigFailureForRoleProhibited) {
   ::grpc::Status status =
       p4_service_->SetForwardingPipelineConfig(&context, &request, &response);
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.error_message(), HasSubstr("not permitted"));
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("not allowed to push pipelines"));
 
   ASSERT_OK(p4_service_->Teardown());
   CheckForwardingPipelineConfigs(nullptr, 0 /*ignored*/);
@@ -992,7 +993,8 @@ TEST_P(P4ServiceTest, WriteFailureForWritingOutsideRoleAllowedTable) {
   ::grpc::Status status = stub_->Write(&context, req, &resp);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(::grpc::StatusCode::PERMISSION_DENIED, status.error_code());
-  EXPECT_THAT(status.error_message(), HasSubstr("not permitted"));
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("is not allowed to access entity"));
   EXPECT_TRUE(status.error_details().empty());
 }
 
@@ -1219,7 +1221,8 @@ TEST_P(P4ServiceTest, ReadFailureForRoleProhibited) {
   ::grpc::Status status = reader->Finish();
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(ERR_PERMISSION_DENIED, status.error_code());
-  EXPECT_THAT(status.error_message(), HasSubstr("Read is not permitted"));
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("is not allowed to access entity"));
   EXPECT_TRUE(status.error_details().empty());
 }
 
@@ -1727,7 +1730,8 @@ TEST_P(P4ServiceTest, StreamChannelFailureForDuplicateElectionId) {
   EXPECT_FALSE(stream1->Read(&resp));
   ::grpc::Status status = stream1->Finish();
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.error_message(), HasSubstr("Election ID is already used"));
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("is already used by another connection"));
   EXPECT_TRUE(status.error_details().empty());
 }
 

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -48,9 +48,11 @@ grpc::Status VerifyElectionIdIsUnused(
     if (connection == current_connection) continue;
     if (connection->GetRoleName() == role_name &&
         connection->GetElectionId() == election_id) {
-      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          "Election ID is already used by another connection "
-                          "with the same role.");
+      return grpc::Status(
+          grpc::StatusCode::INVALID_ARGUMENT,
+          absl::StrCat("Election ID ", PrettyPrintElectionId(election_id),
+                       " is already used by another connection "
+                       "with the same role."));
     }
   }
   return grpc::Status::OK;
@@ -66,8 +68,10 @@ grpc::Status VerifyElectionIdIsActive(
       return grpc::Status::OK;
     }
   }
-  return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
-                      "Election ID is not active for the role.");
+  return grpc::Status(
+      grpc::StatusCode::PERMISSION_DENIED,
+      absl::StrCat("Election ID ", PrettyPrintElectionId(election_id),
+                   " is not active for the role."));
 }
 
 grpc::Status VerifyRoleCanPushPipeline(
@@ -81,7 +85,8 @@ grpc::Status VerifyRoleCanPushPipeline(
   if (!role_config->second.has_value()) return grpc::Status::OK;
   if (!role_config->second->can_push_pipeline()) {
     return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
-                        "Role not allowed to push pipelines.");
+                        absl::StrCat("Role ", PrettyPrintRoleName(role_name),
+                                     " is not allowed to push pipelines."));
   }
 
   return grpc::Status::OK;
@@ -222,9 +227,11 @@ grpc::Status VerifyRoleCanAccessIds(
       continue;
     }
     VLOG(1) << "Role " << PrettyPrintRoleName(role_name)
-            << " not allowed to access " << id << ".";
-    return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
-                        "Role is not allowed to access this entity.");
+            << " not allowed to access entity with ID " << id << ".";
+    return grpc::Status(
+        grpc::StatusCode::PERMISSION_DENIED,
+        absl::StrCat("Role ", PrettyPrintRoleName(role_name),
+                     " is not allowed to access entity with ID ", id, "."));
   }
 
   return grpc::Status::OK;


### PR DESCRIPTION
With this change the P4Service passes errors from the lower layers upwards, instead of creating them itself. This allows for more rich error messages to be returned to clients.