### PR TITLE
Implement `receives_packet_ins` check of P4RT role config

### DIFF
--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -1653,6 +1653,63 @@ TEST_P(P4ServiceTest, StreamChannelSuccess) {
   ASSERT_EQ(0, GetNumberOfConnections());
 }
 
+TEST_P(P4ServiceTest, StreamChannelSuccessForFilteredPacketIn) {
+  ::grpc::ClientContext context;
+  ::p4::v1::StreamMessageRequest req;
+  ::p4::v1::StreamMessageResponse resp;
+
+  // Role config with disabled PacketIns.
+  constexpr char kRoleConfigNoPacketInsText[] = R"pb(
+      receives_packet_ins: false
+  )pb";
+  P4RoleConfig role_config_no_packet_ins;
+  CHECK_OK(ParseProtoFromString(kRoleConfigNoPacketInsText,
+                                &role_config_no_packet_ins));
+
+  // Sample packet. We dont care about payload.
+  ::p4::v1::PacketIn packet;
+  ASSERT_OK(ParseProtoFromString(kTestPacketMetadata3, packet.add_metadata()));
+
+  EXPECT_CALL(*auth_policy_checker_mock_,
+              Authorize("P4Service", "StreamChannel", _))
+      .WillRepeatedly(Return(::util::OkStatus()));
+  EXPECT_CALL(*switch_mock_, RegisterStreamMessageResponseWriter(kNodeId1, _))
+      .WillOnce(Return(::util::OkStatus()));
+
+  // The Controller connects and becomes master with a role.
+  std::unique_ptr<ClientStreamChannelReaderWriter> stream =
+      stub_->StreamChannel(&context);
+  req.mutable_arbitration()->set_device_id(kNodeId1);
+  req.mutable_arbitration()->mutable_election_id()->set_high(
+      absl::Uint128High64(kElectionId1));
+  req.mutable_arbitration()->mutable_election_id()->set_low(
+      absl::Uint128Low64(kElectionId1));
+  req.mutable_arbitration()->mutable_role()->set_name(kRoleName1);
+  req.mutable_arbitration()->mutable_role()->mutable_config()->PackFrom(
+      role_config_no_packet_ins);
+  ASSERT_TRUE(stream->Write(req));
+
+  // Read the mastership info back.
+  ASSERT_TRUE(stream->Read(&resp));
+  ASSERT_EQ(absl::Uint128High64(kElectionId1),
+            resp.arbitration().election_id().high());
+  ASSERT_EQ(absl::Uint128Low64(kElectionId1),
+            resp.arbitration().election_id().low());
+  ASSERT_EQ(::google::rpc::OK, resp.arbitration().status().code());
+  ASSERT_EQ(1, GetNumberOfActiveConnections(kNodeId1));
+
+  // We receive some packet from CPU. This will be dropped as the Controller
+  // disabled PacketIns.
+  OnPacketReceive(packet);
+
+  // Now the Controller disconnects. We ensure the packet was not sent to it.
+  stream->WritesDone();
+  ASSERT_FALSE(stream->Read(&resp));
+  ASSERT_TRUE(stream->Finish().ok());
+  ASSERT_EQ(0, GetNumberOfActiveConnections(kNodeId1));
+  ASSERT_EQ(0, GetNumberOfConnections());
+}
+
 TEST_P(P4ServiceTest, StreamChannelFailureForDuplicateElectionId) {
   ::grpc::ClientContext context1;
   ::grpc::ClientContext context2;
@@ -2096,7 +2153,6 @@ TEST_P(P4ServiceTest, StreamChannelFailureForInvalidRoleConfigPacketInFlag) {
     }
     receives_packet_ins: false
   )pb";
-
   P4RoleConfig role_config;
   CHECK_OK(ParseProtoFromString(kRoleConfigText, &role_config));
 

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -2062,11 +2062,6 @@ TEST_P(P4ServiceTest, StreamChannelFailureForRoleConfigOnDefaultRole) {
 }
 
 TEST_P(P4ServiceTest, StreamChannelFailureForOverlappingExclusiveRoles) {
-  // This test is specific to role configs.
-  if (role_name_.empty()) {
-    GTEST_SKIP();
-  }
-
   ::grpc::ClientContext context1;
   ::grpc::ClientContext context2;
   ::grpc::ClientContext context3;
@@ -2140,11 +2135,6 @@ TEST_P(P4ServiceTest, StreamChannelFailureForOverlappingExclusiveRoles) {
 }
 
 TEST_P(P4ServiceTest, StreamChannelFailureForInvalidRoleConfigPacketInFlag) {
-  // This test is specific to role configs.
-  if (role_name_.empty()) {
-    GTEST_SKIP();
-  }
-
   // Role config with filter but disabled PacketIns.
   constexpr char kRoleConfigText[] = R"pb(
     packet_in_filter {

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -123,7 +123,7 @@ grpc::Status VerifyRoleConfig(
     }
   }
 
-  // Verify that PacketIns are enabled when a PacketIns filter is configured.
+  // Verify that PacketIns are enabled when a PacketIn filter is configured.
   if (!role_config->receives_packet_ins() &&
       role_config->has_packet_in_filter()) {
     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -126,9 +126,9 @@ grpc::Status VerifyRoleConfig(
   // Verify that PacketIns are enabled when a PacketIns filter is configured.
   if (!role_config->receives_packet_ins() &&
       role_config->has_packet_in_filter()) {
-    return grpc::Status(
-        grpc::StatusCode::INVALID_ARGUMENT,
-        "Role config disables PacketIns, but configures a PacketIn filter.");
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                        "Role config contains a PacketIn filter, but disables "
+                        "PacketIn delivery.");
   }
 
   // TODO(max): verify packet filters for valid metadata

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -99,6 +99,7 @@ grpc::Status VerifyRoleConfig(
                               absl::optional<P4RoleConfig>>& existing_configs) {
   if (!role_config.has_value()) return grpc::Status::OK;
 
+  // Verify that requested IDs are not exclusive to other roles already.
   for (const auto& e : existing_configs) {
     if (!e.second.has_value()) {
       continue;
@@ -122,6 +123,14 @@ grpc::Status VerifyRoleConfig(
     }
   }
 
+  // Verify that PacketIns are enabled when a PacketIns filter is configured.
+  if (!role_config->receives_packet_ins() &&
+      role_config->has_packet_in_filter()) {
+    return grpc::Status(
+        grpc::StatusCode::INVALID_ARGUMENT,
+        "Role config disables PacketIns, but configures a PacketIn filter.");
+  }
+
   // TODO(max): verify packet filters for valid metadata
 
   return grpc::Status::OK;
@@ -134,6 +143,7 @@ bool VerifyStreamMessageNotFiltered(
 
   switch (response.update_case()) {
     case p4::v1::StreamMessageResponse::kPacket: {
+      if (!role_config->receives_packet_ins()) return false;
       if (!role_config->has_packet_in_filter()) return true;
       for (const auto& metadata : response.packet().metadata()) {
         if (role_config->packet_in_filter().metadata_id() ==


### PR DESCRIPTION
This PR enables the `receives_packet_ins` field of P4RT role configs and adds tests to verify this. 