### PR TITLE
Implement shared IDs in P4RT role config

### DIFF
--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -2092,6 +2092,7 @@ TEST_P(P4ServiceTest, StreamChannelFailureForRoleConfigOnDefaultRole) {
   EXPECT_EQ(0, GetNumberOfConnections());
 }
 
+// TODO: needs shared IDs test
 TEST_P(P4ServiceTest, StreamChannelFailureForOverlappingExclusiveRoles) {
   ::grpc::ClientContext context1;
   ::grpc::ClientContext context2;

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -2141,8 +2141,8 @@ TEST_P(P4ServiceTest, StreamChannelFailureForOverlappingExclusiveRoles) {
   ASSERT_EQ(::google::rpc::OK, resp.arbitration().status().code());
 
   //----------------------------------------------------------------------------
-  // Controller #2 connects and sends a role config that has overlapping IDs
-  // with controller #1.
+  // Controller #2 connects and sends a role config that has overlapping
+  // exclusive IDs with controller #1.
   req.mutable_arbitration()->set_device_id(kNodeId1);
   req.mutable_arbitration()->mutable_election_id()->set_high(
       absl::Uint128High64(kElectionId1));
@@ -2170,7 +2170,7 @@ TEST_P(P4ServiceTest, StreamChannelFailureForOverlappingSharedRoles) {
   ::p4::v1::StreamMessageRequest req;
   ::p4::v1::StreamMessageResponse resp;
 
-  // Role configs with overlapping exclusive IDs.
+  // Role configs with overlapping shared IDs.
   constexpr char kRoleConfigText1[] = R"pb(
       exclusive_p4_ids: 12
       shared_p4_ids: 79

--- a/stratum/hal/lib/common/p4_service_test.cc
+++ b/stratum/hal/lib/common/p4_service_test.cc
@@ -2092,7 +2092,6 @@ TEST_P(P4ServiceTest, StreamChannelFailureForRoleConfigOnDefaultRole) {
   EXPECT_EQ(0, GetNumberOfConnections());
 }
 
-// TODO: needs shared IDs test
 TEST_P(P4ServiceTest, StreamChannelFailureForOverlappingExclusiveRoles) {
   ::grpc::ClientContext context1;
   ::grpc::ClientContext context2;

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -119,8 +119,11 @@ grpc::Status VerifyRoleConfig(
     std::set_intersection(new_ids.begin(), new_ids.end(), existing_ids.begin(),
                           existing_ids.end(), std::back_inserter(common_ids));
     if (!common_ids.empty()) {
-      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          "Role config contains overlapping exclusive IDs.");
+      return grpc::Status(
+          grpc::StatusCode::INVALID_ARGUMENT,
+          absl::StrCat("Role config ", PrettyPrintRoleName(role_name),
+                       " contains exclusive IDs that overlap "
+                       "with existing exclusive IDs."));
     }
     // Ensure new exclusive IDs and existing shared IDs do not overlap.
     std::vector<uint32_t> existing_shared_ids(e.second->shared_p4_ids().begin(),
@@ -131,8 +134,11 @@ grpc::Status VerifyRoleConfig(
         new_ids.begin(), new_ids.end(), existing_shared_ids.begin(),
         existing_shared_ids.end(), std::back_inserter(common_ids));
     if (!common_ids.empty()) {
-      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          "Role config contains overlapping exclusive IDs.");
+      return grpc::Status(
+          grpc::StatusCode::INVALID_ARGUMENT,
+          absl::StrCat("Role config ", PrettyPrintRoleName(role_name),
+                       " contains exclusive IDs that overlap "
+                       "with existing shared IDs."));
     }
     // Ensure new shared IDs and existing exclusive IDs do not overlap.
     std::vector<uint32_t> new_shared_ids(role_config->shared_p4_ids().begin(),
@@ -143,17 +149,22 @@ grpc::Status VerifyRoleConfig(
                           existing_ids.begin(), existing_ids.end(),
                           std::back_inserter(common_ids));
     if (!common_ids.empty()) {
-      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          "Role config contains overlapping exclusive IDs.");
+      return grpc::Status(
+          grpc::StatusCode::INVALID_ARGUMENT,
+          absl::StrCat("Role config ", PrettyPrintRoleName(role_name),
+                       " contains shared IDs that overlap "
+                       "with existing exclusive IDs."));
     }
   }
 
   // Verify that PacketIns are enabled when a PacketIn filter is configured.
   if (!role_config->receives_packet_ins() &&
       role_config->has_packet_in_filter()) {
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                        "Role config contains a PacketIn filter, but disables "
-                        "PacketIn delivery.");
+    return grpc::Status(
+        grpc::StatusCode::INVALID_ARGUMENT,
+        absl::StrCat("Role config ", PrettyPrintRoleName(role_name),
+                     " contains a PacketIn filter, but disables "
+                     "PacketIn delivery."));
   }
 
   // TODO(max): verify packet filters for valid metadata


### PR DESCRIPTION
This PR adds support for shared IDs inside the P4RT role config.