### PR TITLE
Remove `incompatible_enable_bfrt_legacy_bytestring_responses` flag

### DIFF
--- a/stratum/hal/bin/barefoot/README.run.md
+++ b/stratum/hal/bin/barefoot/README.run.md
@@ -647,17 +647,6 @@ To exit the BF CLI or the BF Shell, use `exit`. Note that using `Ctrl+C` will
 end the BF Shell without closing the telnet session. To exit the telnet session,
 press `Ctrl` and `]` to escape from the session and type `quit` to exit telnet.
 
-### P4Runtime canonical byte strings
-
-P4Runtime defines a [canonical byte string representation](https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html#sec-bytestrings)
-for binary data in proto messages such as TableEntries and PacketIn/Outs. In
-short, it requires that the binary strings must not contain redundant bytes,
- i.e., `\x00\xab` vs `\xab`. For Stratum-bfrt the
-`-incompatible_enable_bfrt_legacy_bytestring_responses` flag toggles this
-behavior. **This flag will be removed in a future release and canonical byte
-strings will be the default.**
-
-
 ### Experimental P4Runtime translation support
 
 The `stratum_bfrt` target supports P4Runtime translation which helps to translate

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -11,11 +11,6 @@
 #include "gmock/gmock.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 
-DEFINE_bool(incompatible_enable_bfrt_legacy_bytestring_responses, false,
-            "Enables the legacy padded byte string format in P4Runtime "
-            "responses for Stratum-bfrt. The strings are left unchanged from "
-            "the underlying SDE.");
-
 namespace stratum {
 namespace hal {
 namespace barefoot {

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -45,10 +45,6 @@ int switch_pci_sysfs_str_get(char* name, size_t name_size);
 
 DEFINE_string(bfrt_sde_config_dir, "/var/run/stratum/bfrt_config",
               "The dir used by the SDE to load the device configuration.");
-DEFINE_bool(incompatible_enable_bfrt_legacy_bytestring_responses, false,
-            "Enables the legacy padded byte string format in P4Runtime "
-            "responses for Stratum-bfrt. The strings are left unchanged from "
-            "the underlying SDE.");
 
 namespace stratum {
 namespace hal {
@@ -632,9 +628,7 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
-  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-    *value = ByteStringToP4RuntimeByteString(*value);
-  }
+  *value = ByteStringToP4RuntimeByteString(*value);
 
   return ::util::OkStatus();
 }
@@ -652,10 +646,8 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValueandMask(
       id, value->size(), reinterpret_cast<uint8*>(gtl::string_as_array(value)),
       reinterpret_cast<uint8*>(gtl::string_as_array(mask))));
-  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-    *value = ByteStringToP4RuntimeByteString(*value);
-    *mask = ByteStringToP4RuntimeByteString(*mask);
-  }
+  *value = ByteStringToP4RuntimeByteString(*value);
+  *mask = ByteStringToP4RuntimeByteString(*mask);
 
   return ::util::OkStatus();
 }
@@ -671,9 +663,7 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValueLpm(
       id, prefix->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(prefix)), prefix_length));
-  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-    *prefix = ByteStringToP4RuntimeByteString(*prefix);
-  }
+  *prefix = ByteStringToP4RuntimeByteString(*prefix);
 
   return ::util::OkStatus();
 }
@@ -691,10 +681,8 @@ template <typename T>
   RETURN_IF_BFRT_ERROR(table_key_->getValueRange(
       id, low->size(), reinterpret_cast<uint8*>(gtl::string_as_array(low)),
       reinterpret_cast<uint8*>(gtl::string_as_array(high))));
-  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-    *low = ByteStringToP4RuntimeByteString(*low);
-    *high = ByteStringToP4RuntimeByteString(*high);
-  }
+  *low = ByteStringToP4RuntimeByteString(*low);
+  *high = ByteStringToP4RuntimeByteString(*high);
 
   return ::util::OkStatus();
 }
@@ -769,9 +757,7 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   RETURN_IF_BFRT_ERROR(table_data_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
-  if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-    *value = ByteStringToP4RuntimeByteString(*value);
-  }
+  *value = ByteStringToP4RuntimeByteString(*value);
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
+++ b/stratum/hal/lib/barefoot/bfrt_p4runtime_translator.cc
@@ -14,8 +14,6 @@
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/error.pb.h"
 
-DECLARE_bool(incompatible_enable_bfrt_legacy_bytestring_responses);
-
 namespace stratum {
 namespace hal {
 namespace barefoot {
@@ -699,10 +697,7 @@ BfrtP4RuntimeTranslator::TranslateP4Info(
         << "Could not find singleton port for sdk port " << sdk_port_id << ".";
     const uint32 port_id = sdk_port_to_singleton_port_[sdk_port_id];
     std::string port_id_bytes = Uint32ToByteStream(port_id);
-    if (FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-      port_id_bytes = P4RuntimeByteStringToPaddedByteString(
-          port_id_bytes, NumBitsToNumBytes(bit_width));
-    }
+
     return port_id_bytes;
   }
 }

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -17,8 +17,6 @@
 #include "stratum/hal/lib/p4/utils.h"
 #include "stratum/lib/utils.h"
 
-DECLARE_bool(incompatible_enable_bfrt_legacy_bytestring_responses);
-
 namespace stratum {
 namespace hal {
 namespace barefoot {
@@ -275,11 +273,8 @@ class BitBuffer {
   for (const auto& p : packetin_header_) {
     auto metadata = packet->add_metadata();
     metadata->set_metadata_id(p.first);
-    metadata->set_value(bit_buf.PopField(p.second));
-    if (!FLAGS_incompatible_enable_bfrt_legacy_bytestring_responses) {
-      *metadata->mutable_value() =
-          ByteStringToP4RuntimeByteString(metadata->value());
-    }
+    metadata->set_value(
+        ByteStringToP4RuntimeByteString(bit_buf.PopField(p.second)));
     VLOG(1) << "Encoded PacketIn metadata field with id " << p.first
             << " bitwidth " << p.second << " value 0x"
             << StringToHex(metadata->value());


### PR DESCRIPTION
This change removes the legacy flag to enable P4RT padded byte string responses from Stratum-bfrt.