### PR TITLE
Allow passing in the gRPC port on mininet switch creation

### DIFF
--- a/tools/mininet/examples/trellis/topo/topo.py
+++ b/tools/mininet/examples/trellis/topo/topo.py
@@ -71,12 +71,12 @@ class LeafSpineTopo(Topo):
         Topo.__init__(self, *args, **kwargs)
 
         # Leaves
-        leaf1 = self.addSwitch('leaf1')  # gRPC 50001
-        leaf2 = self.addSwitch('leaf2')  # gRPC 50002
+        leaf1 = self.addSwitch('leaf1', grpcPort=50001)
+        leaf2 = self.addSwitch('leaf2', grpcPort=50002)
 
         # Spines
-        spine1 = self.addSwitch('spine1')  # gRPC 50003
-        spine2 = self.addSwitch('spine2')  # gRPC 50004
+        spine1 = self.addSwitch('spine1', grpcPort=50003)
+        spine2 = self.addSwitch('spine2', grpcPort=50004)
 
         # Links
         self.addLink(spine1, leaf1)

--- a/tools/mininet/stratum.py
+++ b/tools/mininet/stratum.py
@@ -102,11 +102,14 @@ class StratumBmv2Switch(Switch):
 
     def __init__(self, name, json=STRATUM_INIT_PIPELINE, loglevel="warn",
                  cpuport=DEFAULT_CPU_PORT, pipeconf=DEFAULT_PIPECONF,
-                 onosdevid=None, adminstate=True,
+                 onosdevid=None, adminstate=True, grpcPort=None,
                  **kwargs):
         Switch.__init__(self, name, **kwargs)
-        self.grpcPort = StratumBmv2Switch.nextGrpcPort
-        StratumBmv2Switch.nextGrpcPort += 1
+        if grpcPort is not None:
+          self.grpcPort = grpcPort
+        else:
+          self.grpcPort = StratumBmv2Switch.nextGrpcPort
+          StratumBmv2Switch.nextGrpcPort += 1
         self.cpuPort = cpuport
         self.json = json
         self.loglevel = loglevel


### PR DESCRIPTION
With this change it becomes possible to assign an explicit gRPC port to Stratum servers in Mininet. This makes topo scripts less brittle as ports are not assigned based on creation order anymore.