### PR TITLE
Switch to custom BMv2 repo for digest support

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -78,6 +78,7 @@ RUN git clone https://github.com/p4lang/PI.git /tmp/PI && \
 
 ARG BMV2_COMMIT
 ENV BMV2_INSTALL /usr/local
+# TODO(max): switch back to upstream repo once merged
 RUN git clone https://github.com/pudelkoM/behavioral-model.git /tmp/bmv2 && \
     cd /tmp/bmv2 && git checkout ${BMV2_COMMIT} && \
     ./autogen.sh && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@
 
 ARG BAZELISK_VERSION=1.8.0
 ARG PI_COMMIT=a5fd855d4b3293e23816ef6154e83dc6621aed6a
-ARG BMV2_COMMIT=b0fb01ecacbf3a7d7f0c01e2f149b0c6a957f779
+ARG BMV2_COMMIT=8dc5c15516220efe278315407e5d7dde8d703e8a
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/buster/  llvm-toolchain-buster-11 main"
 
@@ -78,7 +78,7 @@ RUN git clone https://github.com/p4lang/PI.git /tmp/PI && \
 
 ARG BMV2_COMMIT
 ENV BMV2_INSTALL /usr/local
-RUN git clone https://github.com/p4lang/behavioral-model.git /tmp/bmv2 && \
+RUN git clone https://github.com/pudelkoM/behavioral-model.git /tmp/bmv2 && \
     cd /tmp/bmv2 && git checkout ${BMV2_COMMIT} && \
     ./autogen.sh && \
     ./configure --without-targets --with-pi --disable-elogger \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@
 
 ARG BAZELISK_VERSION=1.8.0
 ARG PI_COMMIT=a5fd855d4b3293e23816ef6154e83dc6621aed6a
-ARG BMV2_COMMIT=8dc5c15516220efe278315407e5d7dde8d703e8a
+ARG BMV2_COMMIT=8e8a192fc58e2e994f4c82a34496ec6833bf0d50
 ARG JDK_URL=https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz
 ARG LLVM_REPO_NAME="deb http://apt.llvm.org/buster/  llvm-toolchain-buster-11 main"
 


### PR DESCRIPTION
This PR switches the BMv2 upstream repository to our fork with custom code enabling P4RT digests.