### PR TITLE
Add `libatomic1` deb dependency for clang builds

### DIFF
--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -152,6 +152,7 @@ pkg_deb(
     data = ":stratum_bfrt_data",
     depends = [
         "kmod",
+        "libatomic1",
         "libedit2",
         "libexpat1",
         "libssl1.1",

--- a/stratum/hal/bin/bcm/standalone/BUILD
+++ b/stratum/hal/bin/bcm/standalone/BUILD
@@ -194,6 +194,7 @@ pkg_deb(
     data = ":stratum_bcm_opennsa_all",
     depends = [
         "kmod",
+        "libatomic1",
         "libboost-thread1.67.0",
         "libedit2",
         "libjudydebian1",
@@ -219,6 +220,7 @@ pkg_deb(
     data = ":stratum_bcm_sdklt_all",
     depends = [
         "kmod",
+        "libatomic1",
         "libboost-thread1.67.0",
         "libedit2",
         "libjudydebian1",

--- a/stratum/hal/bin/bmv2/BUILD
+++ b/stratum/hal/bin/bmv2/BUILD
@@ -90,6 +90,7 @@ pkg_deb(
     architecture = "amd64",
     data = ":stratum_bmv2_data",
     depends = [
+        "libatomic1",
         "libboost-filesystem1.67.0",
         "libboost-program-options1.67.0",
         "libboost-thread1.67.0",


### PR DESCRIPTION
This is an implicit dependency for binaries built with clang on Debian 10.