### PR TITLE
Implement digest support in Stratum-bfrt

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -37,6 +37,17 @@ class BfSdeInterface {
     absl::Time time_last_changed;
   };
 
+  // Digest and DigestList encapsulate digest information received from the
+  // device. We use plain data types to decouple this from SDE internal types
+  // and object lifetimes.
+  struct DigestList {
+    using Digest = std::vector<std::string>;
+    int device;
+    uint32 digest_id;
+    std::vector<Digest> digests;
+    absl::Time timestamp;
+  };
+
   // SessionInterface is a proxy class for BfRt sessions. Most API calls require
   // an active session. It also allows batching requests for performance.
   class SessionInterface {
@@ -258,6 +269,15 @@ class BfSdeInterface {
   // Unregisters the writer registered to this device by
   // RegisterPacketReceiveWriter().
   virtual ::util::Status UnregisterPacketReceiveWriter(int device) = 0;
+
+  // Registers a writer to be invoked when we receive a digest list from the
+  // ASIC. There can only be one writer per device.
+  virtual ::util::Status RegisterDigestListWriter(
+      int device, std::unique_ptr<ChannelWriter<DigestList>> writer) = 0;
+
+  // Unregisters the writer registered to this device by
+  // RegisterDigestListWriter().
+  virtual ::util::Status UnregisterDigestListWriter(int device) = 0;
 
   // Create a new multicast node with the given parameters. Returns the newly
   // allocated node id.
@@ -490,6 +510,21 @@ class BfSdeInterface {
   virtual ::util::Status GetDefaultTableEntry(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id, TableDataInterface* table_data) = 0;
+
+  // Inserts/configures a digest instance.
+  virtual ::util::Status InsertDigestEntry(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id) = 0;
+
+  // Modifies/configures a digest instance.
+  virtual ::util::Status ModifyDigestEntry(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id) = 0;
+
+  // Deletes a digest instance.
+  virtual ::util::Status DeleteDigestEntry(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id) = 0;
 
   // Synchronizes the driver cached counter values with the current hardware
   // state for a given BfRt table.

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -516,19 +516,26 @@ class BfSdeInterface {
   // Inserts/configures a digest instance. The session is used in digest
   // callbacks and must be persistent, i.e. still active at the time of callback
   // invocation.
-  virtual ::util::Status InsertDigestEntry(
+  virtual ::util::Status InsertDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) = 0;
 
   // Modifies/configures a digest instance.
-  virtual ::util::Status ModifyDigestEntry(
+  virtual ::util::Status ModifyDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) = 0;
 
   // Deletes a digest instance.
-  virtual ::util::Status DeleteDigestEntry(
+  virtual ::util::Status DeleteDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) = 0;
+
+  // Reads the data from a digest, or all digests if table ID is 0.
+  // The table ID must be a BfRt table ID, not P4Runtime. This is a noop until
+  // digest parameters are implemented.
+  virtual ::util::Status ReadDigests(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id, std::vector<uint32>* digest_ids) = 0;
 
   // Synchronizes the driver cached counter values with the current hardware
   // state for a given BfRt table.

--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -41,6 +41,8 @@ class BfSdeInterface {
   // device. We use plain data types to decouple this from SDE internal types
   // and object lifetimes.
   struct DigestList {
+    // A single digest is an array of byte strings containing the digest fields
+    // in the same order as defined in the P4 program.
     using Digest = std::vector<std::string>;
     int device;
     uint32 digest_id;
@@ -511,7 +513,9 @@ class BfSdeInterface {
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id, TableDataInterface* table_data) = 0;
 
-  // Inserts/configures a digest instance.
+  // Inserts/configures a digest instance. The session is used in digest
+  // callbacks and must be persistent, i.e. still active at the time of callback
+  // invocation.
   virtual ::util::Status InsertDigestEntry(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) = 0;

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -333,20 +333,25 @@ class BfSdeMock : public BfSdeInterface {
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id, TableDataInterface* table_data));
   MOCK_METHOD3(
-      InsertDigestEntry,
+      InsertDigest,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id));
   MOCK_METHOD3(
-      ModifyDigestEntry,
+      ModifyDigest,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id));
   MOCK_METHOD3(
-      DeleteDigestEntry,
+      DeleteDigest,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id));
+  MOCK_METHOD4(
+      ReadDigests,
+      ::util::Status(int device,
+                     std::shared_ptr<BfSdeInterface::SessionInterface> session,
+                     uint32 table_id, std::vector<uint32>* digest_ids));
   MOCK_METHOD4(
       SynchronizeCounters,
       ::util::Status(int device,

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -114,6 +114,11 @@ class BfSdeMock : public BfSdeInterface {
       ::util::Status(int device,
                      std::unique_ptr<ChannelWriter<std::string>> writer));
   MOCK_METHOD1(UnregisterPacketReceiveWriter, ::util::Status(int device));
+  MOCK_METHOD2(
+      RegisterDigestListWriter,
+      ::util::Status(int device,
+                     std::unique_ptr<ChannelWriter<DigestList>> writer));
+  MOCK_METHOD1(UnregisterDigestListWriter, ::util::Status(int device));
   MOCK_METHOD5(CreateMulticastNode,
                ::util::StatusOr<uint32>(
                    int device,
@@ -327,6 +332,21 @@ class BfSdeMock : public BfSdeInterface {
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id, TableDataInterface* table_data));
+  MOCK_METHOD3(
+      InsertDigestEntry,
+      ::util::Status(int device,
+                     std::shared_ptr<BfSdeInterface::SessionInterface> session,
+                     uint32 table_id));
+  MOCK_METHOD3(
+      ModifyDigestEntry,
+      ::util::Status(int device,
+                     std::shared_ptr<BfSdeInterface::SessionInterface> session,
+                     uint32 table_id));
+  MOCK_METHOD3(
+      DeleteDigestEntry,
+      ::util::Status(int device,
+                     std::shared_ptr<BfSdeInterface::SessionInterface> session,
+                     uint32 table_id));
   MOCK_METHOD4(
       SynchronizeCounters,
       ::util::Status(int device,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -2079,7 +2079,10 @@ bf_status_t BfSdeWrapper::BfDigestCallback(
     const std::shared_ptr<bfrt::BfRtSession> session,
     std::vector<std::unique_ptr<bfrt::BfRtLearnData>> learn_data,
     bf_rt_learn_msg_hdl* const learn_msg_hdl, const void* cookie) {
+  // We only need to grab the first learn object, as this callback is not
+  // invoked with "mixed" digests. All will be from the same digests ID.
   const bfrt::BfRtLearn* learn;
+  if (learn_data.empty()) return BF_SUCCESS;
   auto bf_status = learn_data.front()->getParent(&learn);
   if (bf_status != BF_SUCCESS) {
     LOG(ERROR) << "failed to get parent of learn data: " << bf_status << ".";

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -12,6 +12,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 #include "bf_rt/bf_rt_init.hpp"
+#include "bf_rt/bf_rt_learn.hpp"
 #include "bf_rt/bf_rt_session.hpp"
 #include "bf_rt/bf_rt_table.hpp"
 #include "bf_rt/bf_rt_table_key.hpp"
@@ -193,6 +194,11 @@ class BfSdeWrapper : public BfSdeInterface {
   ::util::Status RegisterPacketReceiveWriter(
       int device, std::unique_ptr<ChannelWriter<std::string>> writer) override;
   ::util::Status UnregisterPacketReceiveWriter(int device) override;
+  ::util::Status RegisterDigestListWriter(
+      int device, std::unique_ptr<ChannelWriter<DigestList>> writer) override
+      LOCKS_EXCLUDED(digest_list_callback_lock_);
+  ::util::Status UnregisterDigestListWriter(int device) override
+      LOCKS_EXCLUDED(digest_list_callback_lock_);
   ::util::StatusOr<uint32> CreateMulticastNode(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       int mc_replication_id, const std::vector<uint32>& mc_lag_ids,
@@ -348,6 +354,15 @@ class BfSdeWrapper : public BfSdeInterface {
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id, TableDataInterface* table_data) override
       LOCKS_EXCLUDED(data_lock_);
+  ::util::Status InsertDigestEntry(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
+  ::util::Status ModifyDigestEntry(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
+  ::util::Status DeleteDigestEntry(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
 
   ::util::StatusOr<uint32> GetBfRtId(uint32 p4info_id) const override
       LOCKS_EXCLUDED(data_lock_);
@@ -378,6 +393,15 @@ class BfSdeWrapper : public BfSdeInterface {
   ::util::Status HandlePacketRx(bf_dev_id_t device, bf_pkt* pkt,
                                 bf_pkt_rx_ring_t rx_ring)
       LOCKS_EXCLUDED(packet_rx_callback_lock_);
+
+  // Writes a received digest list to the registered writer. Called from the SDE
+  // callback function.
+  ::util::Status HandleDigestList(
+      const bf_rt_target_t& bf_dev_tgt,
+      const std::shared_ptr<bfrt::BfRtSession> session,
+      const bfrt::BfRtLearn* learn,
+      std::vector<std::unique_ptr<bfrt::BfRtLearnData>>* learn_data)
+      LOCKS_EXCLUDED(digest_list_callback_lock_);
 
   // Called whenever a port status event is received from SDK. It forwards the
   // port status event to the module who registered a callback by calling
@@ -414,18 +438,28 @@ class BfSdeWrapper : public BfSdeInterface {
   // Mutex protecting the packet rx writer map.
   mutable absl::Mutex packet_rx_callback_lock_;
 
+  // Mutex protecting the digest list writer map.
+  mutable absl::Mutex digest_list_callback_lock_;
+
   // RW mutex lock for protecting the pipeline state.
   mutable absl::Mutex data_lock_;
 
-  // Callback registed with the SDE for Tx notifications.
+  // Callback registered with the SDE for Tx notifications.
   static bf_status_t BfPktTxNotifyCallback(bf_dev_id_t device,
                                            bf_pkt_tx_ring_t tx_ring,
                                            uint64 tx_cookie, uint32 status);
 
-  // Callback registed with the SDE for Rx notifications.
+  // Callback registered with the SDE for Rx notifications.
   static bf_status_t BfPktRxNotifyCallback(bf_dev_id_t device, bf_pkt* pkt,
                                            void* cookie,
                                            bf_pkt_rx_ring_t rx_ring);
+
+  // Callback registered with the SDE for digest list notifications.
+  static bf_status_t BfDigestCallback(
+      const bf_rt_target_t& bf_dev_tgt,
+      const std::shared_ptr<bfrt::BfRtSession> session,
+      std::vector<std::unique_ptr<bfrt::BfRtLearnData>> learn_data,
+      bf_rt_learn_msg_hdl* const learn_msg_hdl, const void* cookie);
 
   // Common code for multicast group handling.
   ::util::Status WriteMulticastGroup(
@@ -487,6 +521,10 @@ class BfSdeWrapper : public BfSdeInterface {
   // Map from device ID to packet receive writer.
   absl::flat_hash_map<int, std::unique_ptr<ChannelWriter<std::string>>>
       device_to_packet_rx_writer_ GUARDED_BY(packet_rx_callback_lock_);
+
+  // Map from device ID to digest list receive writer.
+  absl::flat_hash_map<int, std::unique_ptr<ChannelWriter<DigestList>>>
+      device_to_digest_list_writer_ GUARDED_BY(digest_list_callback_lock_);
 
   // Map from device ID to vector of all allocated PPGs.
   absl::flat_hash_map<int, std::vector<bf_tm_ppg_hdl>> device_to_ppg_handles_

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -354,15 +354,19 @@ class BfSdeWrapper : public BfSdeInterface {
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id, TableDataInterface* table_data) override
       LOCKS_EXCLUDED(data_lock_);
-  ::util::Status InsertDigestEntry(
+  ::util::Status InsertDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
-  ::util::Status ModifyDigestEntry(
+  ::util::Status ModifyDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
-  ::util::Status DeleteDigestEntry(
+  ::util::Status DeleteDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
+  ::util::Status ReadDigests(
+      int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      uint32 table_id, std::vector<uint32>* digest_ids) override
+      LOCKS_EXCLUDED(data_lock_);
 
   ::util::StatusOr<uint32> GetBfRtId(uint32 p4info_id) const override
       LOCKS_EXCLUDED(data_lock_);

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -352,9 +352,15 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
         details->push_back(status);
         break;
       }
+      case ::p4::v1::Entity::kDigestEntry: {
+        auto status = bfrt_table_manager_->ReadDigestEntry(
+            session, entity.digest_entry(), writer);
+        success &= status.ok();
+        details->push_back(status);
+        break;
+      }
       case ::p4::v1::Entity::kDirectMeterEntry:
       case ::p4::v1::Entity::kValueSetEntry:
-      case ::p4::v1::Entity::kDigestEntry:
       default: {
         success = false;
         details->push_back(MAKE_ERROR(ERR_UNIMPLEMENTED)

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -168,7 +168,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   auto status = ::util::OkStatus();
   // TODO(max): Check if we need to de-init the ASIC or SDE
   // TODO(max): Enable other Shutdown calls once implemented.
-  // APPEND_STATUS_IF_ERROR(status, bfrt_table_manager_->Shutdown());
+  APPEND_STATUS_IF_ERROR(status, bfrt_table_manager_->Shutdown());
   APPEND_STATUS_IF_ERROR(status, bfrt_packetio_manager_->Shutdown());
   // APPEND_STATUS_IF_ERROR(status, bfrt_pre_manager_->Shutdown());
   // APPEND_STATUS_IF_ERROR(status, bfrt_counter_manager_->Shutdown());
@@ -241,9 +241,12 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
             session, update.type(), update.entity().meter_entry());
         break;
       }
+      case ::p4::v1::Entity::kDigestEntry:
+        status = bfrt_table_manager_->WriteDigestEntry(
+            session, update.type(), update.entity().digest_entry());
+        break;
       case ::p4::v1::Entity::kDirectMeterEntry:
       case ::p4::v1::Entity::kValueSetEntry:
-      case ::p4::v1::Entity::kDigestEntry:
       default:
         status = MAKE_ERROR(ERR_UNIMPLEMENTED)
                  << "Unsupported entity type: " << update.ShortDebugString();
@@ -380,8 +383,17 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
       std::make_shared<ProtoOneofWriterWrapper<::p4::v1::StreamMessageResponse,
                                                ::p4::v1::PacketIn>>(
           writer, &::p4::v1::StreamMessageResponse::mutable_packet);
+  RETURN_IF_ERROR(
+      bfrt_packetio_manager_->RegisterPacketReceiveWriter(packet_in_writer));
 
-  return bfrt_packetio_manager_->RegisterPacketReceiveWriter(packet_in_writer);
+  auto digest_list_writer =
+      std::make_shared<ProtoOneofWriterWrapper<::p4::v1::StreamMessageResponse,
+                                               ::p4::v1::DigestList>>(
+          writer, &::p4::v1::StreamMessageResponse::mutable_digest);
+  RETURN_IF_ERROR(
+      bfrt_table_manager_->RegisterDigestListWriter(digest_list_writer));
+
+  return ::util::OkStatus();
 }
 
 ::util::Status BfrtNode::UnregisterStreamMessageResponseWriter() {
@@ -404,6 +416,9 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
     case ::p4::v1::StreamMessageRequest::kPacket: {
       return bfrt_packetio_manager_->TransmitPacket(req.packet());
     }
+    case ::p4::v1::StreamMessageRequest::kDigestAck:
+      // TODO(max): implement digest ack handling.
+      return ::util::OkStatus();
     default:
       return MAKE_ERROR(ERR_UNIMPLEMENTED)
              << "Unsupported StreamMessageRequest " << req.ShortDebugString()

--- a/stratum/hal/lib/barefoot/bfrt_node_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node_test.cc
@@ -1466,16 +1466,15 @@ TEST_F(BfrtNodeTest, HandleStreamMessageRequest_Invalid) {
                   StratumErrorSpace(), ERR_UNIMPLEMENTED, "Unsupported")));
 }
 
-// HandleStreamMessageRequest() should reject StreamMessageRequests with digest
-// acks.
+// HandleStreamMessageRequest() should blindly accept StreamMessageRequests with
+// digest acks.
 TEST_F(BfrtNodeTest, HandleStreamMessageRequest_DigestAck) {
   ASSERT_NO_FATAL_FAILURE(PushChassisConfigWithCheck());
   ::p4::v1::StreamMessageRequest req;
   req.mutable_digest_ack();
 
-  EXPECT_THAT(HandleStreamMessageRequest(req),
-              DerivedFromStatus(::util::Status(
-                  StratumErrorSpace(), ERR_UNIMPLEMENTED, "Unsupported")));
+  // TODO(max): extend once we actually implement digest acks.
+  EXPECT_OK(HandleStreamMessageRequest(req));
 }
 
 // HandleStreamMessageRequest() should reject StreamMessageRequests with

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -31,6 +31,7 @@ BfrtTableManager::BfrtTableManager(
     OperationMode mode, BfSdeInterface* bf_sde_interface,
     BfrtP4RuntimeTranslator* bfrt_p4runtime_translator, int device)
     : mode_(mode),
+      digest_rx_thread_id_(),
       bf_sde_interface_(ABSL_DIE_IF_NULL(bf_sde_interface)),
       bfrt_p4runtime_translator_(ABSL_DIE_IF_NULL(bfrt_p4runtime_translator)),
       p4_info_manager_(nullptr),
@@ -38,6 +39,7 @@ BfrtTableManager::BfrtTableManager(
 
 BfrtTableManager::BfrtTableManager()
     : mode_(OPERATION_MODE_STANDALONE),
+      digest_rx_thread_id_(),
       bf_sde_interface_(nullptr),
       bfrt_p4runtime_translator_(nullptr),
       p4_info_manager_(nullptr),
@@ -63,12 +65,75 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
   RETURN_IF_ERROR(p4_info_manager->InitializeAndVerify());
   p4_info_manager_ = std::move(p4_info_manager);
 
+  if (digest_rx_thread_id_ == 0) {
+    digest_list_receive_channel_ =
+        Channel<BfSdeInterface::DigestList>::Create(128);
+    int ret = pthread_create(&digest_rx_thread_id_, nullptr,
+                             &BfrtTableManager::DigestListThreadFunc, this);
+    if (ret != 0) {
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Failed to spawn digest list RX thread for device with ID "
+             << device_ << ". Err: " << ret << ".";
+    }
+    RETURN_IF_ERROR(bf_sde_interface_->RegisterDigestListWriter(
+        device_, ChannelWriter<BfSdeInterface::DigestList>::Create(
+                     digest_list_receive_channel_)));
+  }
+  // TODO: Move session handling into wrapper.
+  ASSIGN_OR_RETURN(digest_list_session_, bf_sde_interface_->CreateSession());
+
   return ::util::OkStatus();
 }
 
 ::util::Status BfrtTableManager::VerifyForwardingPipelineConfig(
     const ::p4::v1::ForwardingPipelineConfig& config) const {
-  // TODO(unknown): Implement if needed.
+  for (const auto& digest : config.p4info().digests()) {
+    RET_CHECK(digest.type_spec().has_struct_())
+        << "Only struct-like digests type specs are supported: "
+        << digest.ShortDebugString();
+  }
+
+  return ::util::OkStatus();
+}
+
+::util::Status BfrtTableManager::Shutdown() {
+  ::util::Status status;
+  {
+    absl::WriterMutexLock l(&digest_list_writer_lock_);
+    digest_list_writer_ = nullptr;
+  }
+
+  {
+    absl::WriterMutexLock l(&lock_);
+    if (digest_rx_thread_id_ != 0) {
+      APPEND_STATUS_IF_ERROR(
+          status, bf_sde_interface_->UnregisterDigestListWriter(device_));
+      if (!digest_list_receive_channel_ ||
+          !digest_list_receive_channel_->Close()) {
+        ::util::Status error = MAKE_ERROR(ERR_INTERNAL)
+                               << "Digest list channel is already closed.";
+        APPEND_STATUS_IF_ERROR(status, error);
+      }
+    }
+    digest_list_receive_channel_.reset();
+  }
+  // TODO(max): we release the locks between closing the channel and joining the
+  // thread to prevent deadlocks with the RX handler. But there might still be a
+  // bug hiding here.
+  {
+    absl::ReaderMutexLock l(&lock_);
+    if (digest_rx_thread_id_ != 0 &&
+        pthread_join(digest_rx_thread_id_, nullptr) != 0) {
+      ::util::Status error = MAKE_ERROR(ERR_INTERNAL)
+                             << "Failed to join thread "
+                             << digest_rx_thread_id_;
+      APPEND_STATUS_IF_ERROR(status, error);
+    }
+  }
+  {
+    absl::WriterMutexLock l(&lock_);
+    digest_rx_thread_id_ = 0;
+  }
   return ::util::OkStatus();
 }
 
@@ -437,6 +502,33 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
       table_data->GetCounterData(&bytes, &packets).ok()) {
     result.mutable_counter_data()->set_byte_count(bytes);
     result.mutable_counter_data()->set_packet_count(packets);
+  }
+
+  return result;
+}
+
+::util::StatusOr<::p4::v1::DigestList> BfrtTableManager::BuildP4DigestList(
+    const BfSdeInterface::DigestList& digest_list) {
+  absl::ReaderMutexLock l(&lock_);
+  ::p4::v1::DigestList result;
+
+  ASSIGN_OR_RETURN(auto p4_digest_id,
+                   bf_sde_interface_->GetP4InfoId(digest_list.digest_id));
+
+  ASSIGN_OR_RETURN(auto digest, p4_info_manager_->FindDigestByID(p4_digest_id));
+
+  result.set_digest_id(p4_digest_id);
+  result.set_list_id(123);  // currently not used, as digests are acked already.
+  result.set_timestamp(absl::ToUnixNanos(digest_list.timestamp));
+
+  digest.type_spec().struct_().name();
+
+  // Transform the SDE digest into a P4RT struct-like digest.
+  for (const auto& digest_entry : digest_list.digests) {
+    ::p4::v1::P4Data* data = result.add_data();
+    for (const auto& field : digest_entry) {
+      data->mutable_struct_()->add_members()->set_bitstring(field);
+    }
   }
 
   return result;
@@ -924,6 +1016,44 @@ BfrtTableManager::ReadDirectCounterEntry(
   return ::util::OkStatus();
 }
 
+::util::Status BfrtTableManager::WriteDigestEntry(
+    std::shared_ptr<BfSdeInterface::SessionInterface> session,
+    const ::p4::v1::Update::Type type,
+    const ::p4::v1::DigestEntry& digest_entry) {
+  absl::ReaderMutexLock l(&lock_);
+  const auto& translated_digest_entry = digest_entry;
+  // ASSIGN_OR_RETURN(const auto& translated_digest_entry,
+  //                  bfrt_p4runtime_translator_->TranslateDigestEntry(
+  //                      digest_entry, /*to_sdk=*/true));
+  RET_CHECK(translated_digest_entry.digest_id() != 0)
+      << "Missing digest id in DigestEntry "
+      << translated_digest_entry.ShortDebugString() << ".";
+
+  ASSIGN_OR_RETURN(uint32 table_id, bf_sde_interface_->GetBfRtId(
+                                        translated_digest_entry.digest_id()));
+
+  switch (type) {
+    case ::p4::v1::Update::INSERT:
+      RETURN_IF_ERROR(bf_sde_interface_->InsertDigestEntry(
+          device_, digest_list_session_, table_id));
+      break;
+    case ::p4::v1::Update::MODIFY:
+      RETURN_IF_ERROR(bf_sde_interface_->ModifyDigestEntry(
+          device_, digest_list_session_, table_id));
+      break;
+    case ::p4::v1::Update::DELETE:
+      RETURN_IF_ERROR(bf_sde_interface_->DeleteDigestEntry(
+          device_, digest_list_session_, table_id));
+      break;
+    default:
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Unsupported update type: " << type << " in digest entry "
+             << translated_digest_entry.ShortDebugString() << ".";
+  }
+
+  return ::util::OkStatus();
+}
+
 ::util::Status BfrtTableManager::WriteActionProfileMember(
     std::shared_ptr<BfSdeInterface::SessionInterface> session,
     const ::p4::v1::Update::Type type,
@@ -1148,6 +1278,71 @@ BfrtTableManager::ReadDirectCounterEntry(
   }
 
   return ::util::OkStatus();
+}
+
+::util::Status BfrtTableManager::RegisterDigestListWriter(
+    const std::shared_ptr<WriterInterface<::p4::v1::DigestList>>& writer) {
+  absl::WriterMutexLock l(&digest_list_writer_lock_);
+  digest_list_writer_ = writer;
+  return ::util::OkStatus();
+}
+
+::util::Status BfrtTableManager::UnregisterDigestListWriter() {
+  absl::WriterMutexLock l(&digest_list_writer_lock_);
+  digest_list_writer_ = nullptr;
+  return ::util::OkStatus();
+}
+
+::util::Status BfrtTableManager::HandleDigestList() {
+  std::unique_ptr<ChannelReader<BfSdeInterface::DigestList>> reader;
+  {
+    absl::ReaderMutexLock l(&lock_);
+    if (!digest_rx_thread_id_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    reader = ChannelReader<BfSdeInterface::DigestList>::Create(
+        digest_list_receive_channel_);
+  }
+
+  while (true) {
+    BfSdeInterface::DigestList digest_list;
+    int code =
+        reader->Read(&digest_list, absl::InfiniteDuration()).error_code();
+    if (code == ERR_CANCELLED) break;
+    if (code == ERR_ENTRY_NOT_FOUND) {
+      LOG(ERROR) << "Read with infinite timeout failed with ENTRY_NOT_FOUND.";
+      continue;
+    }
+
+    auto p4rt_digest_list = BuildP4DigestList(digest_list);
+    if (!p4rt_digest_list.ok()) {
+      LOG(ERROR) << "BuildP4DigestList failed: " << p4rt_digest_list.status();
+      continue;
+    }
+    // const auto& translated_packet_in =
+    //     bfrt_p4runtime_translator_->TranslatePacketIn(packet_in);
+    // if (!translated_packet_in.ok()) {
+    //   LOG(ERROR) << "TranslatePacketIn failed: " << status;
+    //   continue;
+    // }
+    VLOG(1) << "Handled DigestList: "
+            << p4rt_digest_list.ValueOrDie().ShortDebugString();
+    {
+      absl::WriterMutexLock l(&digest_list_writer_lock_);
+      digest_list_writer_->Write(p4rt_digest_list.ConsumeValueOrDie());
+    }
+  }
+
+  return ::util::OkStatus();
+}
+
+void* BfrtTableManager::DigestListThreadFunc(void* arg) {
+  BfrtTableManager* mgr = reinterpret_cast<BfrtTableManager*>(arg);
+  ::util::Status status = mgr->HandleDigestList();
+  if (!status.ok()) {
+    LOG(ERROR) << "Non-OK exit of handler thread for digest lists.";
+  }
+
+  return nullptr;
 }
 
 }  // namespace barefoot

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.h
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.h
@@ -38,6 +38,11 @@ class BfrtTableManager {
       const ::p4::v1::ForwardingPipelineConfig& config) const
       LOCKS_EXCLUDED(lock_);
 
+  // Performs coldboot shutdown. Note that there is no public Initialize().
+  // Initialization is done as part of PushForwardingPipelineConfig() if the
+  // class is not initialized by the time we push config.
+  virtual ::util::Status Shutdown() LOCKS_EXCLUDED(lock_);
+
   // Writes a table entry.
   virtual ::util::Status WriteTableEntry(
       std::shared_ptr<BfSdeInterface::SessionInterface> session,
@@ -68,6 +73,12 @@ class BfrtTableManager {
       std::shared_ptr<BfSdeInterface::SessionInterface> session,
       const ::p4::v1::Update::Type type,
       const ::p4::v1::MeterEntry& meter_entry) LOCKS_EXCLUDED(lock_);
+
+  // Writes a digest entry.
+  virtual ::util::Status WriteDigestEntry(
+      std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      const ::p4::v1::Update::Type type,
+      const ::p4::v1::DigestEntry& table_entry) LOCKS_EXCLUDED(lock_);
 
   // Writes an action profile member.
   virtual ::util::Status WriteActionProfileMember(
@@ -112,6 +123,16 @@ class BfrtTableManager {
       std::shared_ptr<BfSdeInterface::SessionInterface> session,
       const ::p4::v1::MeterEntry& meter_entry,
       WriterInterface<::p4::v1::ReadResponse>* writer) LOCKS_EXCLUDED(lock_);
+
+  // Registers a writer to be invoked when we receive a digest lst from the
+  // ASIC.
+  virtual ::util::Status RegisterDigestListWriter(
+      const std::shared_ptr<WriterInterface<::p4::v1::DigestList>>& writer)
+      LOCKS_EXCLUDED(digest_list_writer_lock_);
+
+  // Unregisters the digest list writer.
+  virtual ::util::Status UnregisterDigestListWriter()
+      LOCKS_EXCLUDED(digest_list_writer_lock_);
 
   // Creates a table manager instance.
   static std::unique_ptr<BfrtTableManager> CreateInstance(
@@ -169,6 +190,18 @@ class BfrtTableManager {
       const BfSdeInterface::TableDataInterface* table_data)
       SHARED_LOCKS_REQUIRED(lock_);
 
+  // Construct a P4RT digest list from a list of learn data.
+  ::util::StatusOr<::p4::v1::DigestList> BuildP4DigestList(
+      const BfSdeInterface::DigestList& digest_list) LOCKS_EXCLUDED(lock_);
+
+  // Handles received digest lists, converts them to P4Runtime and hands them
+  // over the registered receive writer.
+  ::util::Status HandleDigestList()
+      LOCKS_EXCLUDED(lock_, digest_list_writer_lock_);
+
+  // Digest list handle thread function.
+  static void* DigestListThreadFunc(void* arg);
+
   // Determines the mode of operation:
   // - OPERATION_MODE_STANDALONE: when Stratum stack runs independently and
   // therefore needs to do all the SDK initialization itself.
@@ -181,6 +214,25 @@ class BfrtTableManager {
 
   // Reader-writer lock used to protect access to pipeline state.
   mutable absl::Mutex lock_;
+
+  // Mutex lock for protecting digest_list_writer.
+  mutable absl::Mutex digest_list_writer_lock_;
+
+  // Stores the registered writer for DigestList.
+  std::shared_ptr<WriterInterface<::p4::v1::DigestList>> digest_list_writer_
+      GUARDED_BY(digest_list_writer_lock_);
+
+  // Stores the bfrt session used in digest list callbacks. We don't use this
+  // session to modify anything, but it is still required to be valid.
+  std::shared_ptr<BfSdeInterface::SessionInterface> digest_list_session_
+      GUARDED_BY(lock_);
+
+  // Buffer channel for digest lists coming from the SDE to this manager.
+  std::shared_ptr<Channel<BfSdeInterface::DigestList>>
+      digest_list_receive_channel_ GUARDED_BY(lock_);
+
+  // The ID of the RX thread which handles incoming digest lists from the SDE.
+  pthread_t digest_rx_thread_id_ GUARDED_BY(lock_);
 
   // Pointer to a BfSdeInterface implementation that wraps all the SDE calls.
   BfSdeInterface* bf_sde_interface_ = nullptr;  // not owned by this class.

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.h
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.h
@@ -124,6 +124,12 @@ class BfrtTableManager {
       const ::p4::v1::MeterEntry& meter_entry,
       WriterInterface<::p4::v1::ReadResponse>* writer) LOCKS_EXCLUDED(lock_);
 
+  // Read the data of a digest entry.
+  virtual ::util::Status ReadDigestEntry(
+      std::shared_ptr<BfSdeInterface::SessionInterface> session,
+      const ::p4::v1::DigestEntry& digest_entry,
+      WriterInterface<::p4::v1::ReadResponse>* writer) LOCKS_EXCLUDED(lock_);
+
   // Registers a writer to be invoked when we receive a digest lst from the
   // ASIC.
   virtual ::util::Status RegisterDigestListWriter(


### PR DESCRIPTION
This PR adds initial support for digests in Stratum-bfrt on Tofino. It has the following limitations:
- Automatic digests acknowledgment by Stratum. `DigestAck`s are accepted, but ignored.
- Digest configuration is not supported. The SDE defaults will be used. The rovided `config` is ignore and not returned on reads.
- Only struct-like digests are supported
- No P4Runtime metadata translation for digest data. Port numbers will be incorrect.