### PR TITLE
Add digest support in `P4InfoManager`

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -36,7 +36,8 @@ P4InfoManager::P4InfoManager(const ::p4::config::v1::P4Info& p4_info)
       meter_map_("Meter"),
       direct_meter_map_("Direct-Meter"),
       value_set_map_("ValueSet"),
-      register_map_("Register") {}
+      register_map_("Register"),
+      digest_map_("Digest") {}
 
 P4InfoManager::P4InfoManager()
     : table_map_("Table"),
@@ -47,7 +48,8 @@ P4InfoManager::P4InfoManager()
       meter_map_("Meter"),
       direct_meter_map_("Direct-Meter"),
       value_set_map_("ValueSet"),
-      register_map_("Register") {}
+      register_map_("Register"),
+      digest_map_("Digest") {}
 
 P4InfoManager::~P4InfoManager() {}
 
@@ -82,6 +84,8 @@ P4InfoManager::~P4InfoManager() {}
       status, value_set_map_.BuildMaps(p4_info_.value_sets(), preamble_cb));
   APPEND_STATUS_IF_ERROR(
       status, register_map_.BuildMaps(p4_info_.registers(), preamble_cb));
+  APPEND_STATUS_IF_ERROR(
+      status, digest_map_.BuildMaps(p4_info_.digests(), preamble_cb));
 
   APPEND_STATUS_IF_ERROR(status, VerifyTableXrefs());
 
@@ -176,6 +180,16 @@ P4InfoManager::FindRegisterByID(uint32 register_id) const {
 ::util::StatusOr<const ::p4::config::v1::Register>
 P4InfoManager::FindRegisterByName(const std::string& register_name) const {
   return register_map_.FindByName(register_name);
+}
+
+::util::StatusOr<const ::p4::config::v1::Digest> P4InfoManager::FindDigestByID(
+    uint32 digest_id) const {
+  return digest_map_.FindByID(digest_id);
+}
+
+::util::StatusOr<const ::p4::config::v1::Digest>
+P4InfoManager::FindDigestByName(const std::string& digest_name) const {
+  return digest_map_.FindByName(digest_name);
 }
 
 ::util::StatusOr<P4Annotation> P4InfoManager::GetSwitchStackAnnotations(
@@ -290,6 +304,7 @@ void P4InfoManager::DumpNamesToIDs() const {
   direct_meter_map_.DumpNamesToIDs();
   value_set_map_.DumpNamesToIDs();
   register_map_.DumpNamesToIDs();
+  digest_map_.DumpNamesToIDs();
 }
 
 ::util::Status P4InfoManager::VerifyRequiredObjects() {

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -104,6 +104,10 @@ class P4InfoManager {
       uint32 register_id) const;
   virtual ::util::StatusOr<const ::p4::config::v1::Register> FindRegisterByName(
       const std::string& register_name) const;
+  virtual ::util::StatusOr<const ::p4::config::v1::Digest> FindDigestByID(
+      uint32 digest_id) const;
+  virtual ::util::StatusOr<const ::p4::config::v1::Digest> FindDigestByName(
+      const std::string& digest_name) const;
 
   // GetSwitchStackAnnotations attempts to parse any @switchstack annotations
   // in the input object's P4Info Preamble.  If the P4 object has multiple
@@ -278,6 +282,7 @@ class P4InfoManager {
   P4ResourceMap<::p4::config::v1::DirectMeter> direct_meter_map_;
   P4ResourceMap<::p4::config::v1::ValueSet> value_set_map_;
   P4ResourceMap<::p4::config::v1::Register> register_map_;
+  P4ResourceMap<::p4::config::v1::Digest> digest_map_;
 
   // These containers verify that all P4 names and IDs are unique across all
   // types of resources that have an embedded Preamble.

--- a/stratum/hal/lib/p4/p4_info_manager_test.cc
+++ b/stratum/hal/lib/p4/p4_info_manager_test.cc
@@ -38,6 +38,7 @@ class P4InfoManagerTest : public testing::Test {
   static const int kFirstRegisterID = 40000000;
   static const int kFirstDirectCounterID = 50000000;
   static const int kFirstDirectMeterID = 60000000;
+  static const int kFirstDigestID = 70000000;
 
   // The default constructor creates p4_test_manager_ with empty p4_test_info_.
   P4InfoManagerTest() : p4_test_manager_(new P4InfoManager(p4_test_info_)) {}
@@ -82,6 +83,9 @@ class P4InfoManagerTest : public testing::Test {
     SetUpTestP4Meters();
     SetUpTestP4ValueSets();
     SetUpTestP4Registers();
+    SetUpTestP4DirectCounters();
+    SetUpTestP4DirectMeters();
+    SetUpTestP4Digests();
   }
 
   void SetUpTestP4Tables(bool need_actions = true) {
@@ -175,9 +179,17 @@ class P4InfoManagerTest : public testing::Test {
   void SetUpTestP4DirectMeters() {
     // TODO(unknown): Tests get only one basic direct meter preamble at
     // present.
-    auto new_counter = p4_test_info_.add_direct_meters();
-    new_counter->mutable_preamble()->set_id(kFirstDirectMeterID);
-    new_counter->mutable_preamble()->set_name("Direct-Meter-1");
+    auto new_meter = p4_test_info_.add_direct_meters();
+    new_meter->mutable_preamble()->set_id(kFirstDirectMeterID);
+    new_meter->mutable_preamble()->set_name("Direct-Meter-1");
+    SetUpNewP4Info();
+  }
+
+  void SetUpTestP4Digests() {
+    // TODO(unknown): Tests get only one basic digest preamble at present.
+    auto new_digest = p4_test_info_.add_digests();
+    new_digest->mutable_preamble()->set_id(kFirstDigestID);
+    new_digest->mutable_preamble()->set_name("Digest-1");
     SetUpNewP4Info();
   }
 
@@ -579,7 +591,7 @@ TEST_F(P4InfoManagerTest, TestFindCounterUnknownID) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// Verifies lookup failure with an unknown unknown counter name.
+// Verifies lookup failure with an unknown counter name.
 TEST_F(P4InfoManagerTest, TestFindCounterUnknownName) {
   SetUpTestP4Counters();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -618,7 +630,7 @@ TEST_F(P4InfoManagerTest, TestFindMeterUnknownID) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// Verifies lookup failure with an unknown unknown meter name.
+// Verifies lookup failure with an unknown meter name.
 TEST_F(P4InfoManagerTest, TestFindMeterUnknownName) {
   SetUpTestP4Meters();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -658,7 +670,7 @@ TEST_F(P4InfoManagerTest, TestFindValueSetUnknownID) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// Verifies lookup failure with an unknown unknown meter name.
+// Verifies lookup failure with an unknown value set name.
 TEST_F(P4InfoManagerTest, TestFindValueSetUnknownName) {
   SetUpTestP4ValueSets();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -669,7 +681,7 @@ TEST_F(P4InfoManagerTest, TestFindValueSetUnknownName) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// All valid value sets in p4_test_info_ should have successful name/ID
+// All valid registers in p4_test_info_ should have successful name/ID
 // lookups, and the returned data should match the value set's original
 // p4_test_info_ entry.
 TEST_F(P4InfoManagerTest, TestFindRegister) {
@@ -687,7 +699,7 @@ TEST_F(P4InfoManagerTest, TestFindRegister) {
   }
 }
 
-// Verifies lookup failure with an unknown value set ID.
+// Verifies lookup failure with an unknown register ID.
 TEST_F(P4InfoManagerTest, TestFindRegisterUnknownID) {
   SetUpTestP4Registers();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -698,7 +710,7 @@ TEST_F(P4InfoManagerTest, TestFindRegisterUnknownID) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// Verifies lookup failure with an unknown unknown meter name.
+// Verifies lookup failure with an unknown register name.
 TEST_F(P4InfoManagerTest, TestFindRegisterUnknownName) {
   SetUpTestP4Registers();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -738,7 +750,7 @@ TEST_F(P4InfoManagerTest, TestFindDirectCounterUnknownID) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// Verifies lookup failure with an unknown unknown direct counter name.
+// Verifies lookup failure with an unknown direct counter name.
 TEST_F(P4InfoManagerTest, TestFindDirectCounterUnknownName) {
   SetUpTestP4DirectCounters();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -767,7 +779,7 @@ TEST_F(P4InfoManagerTest, TestFindDirectMeter) {
   }
 }
 
-// Verifies lookup failure with an unknown counter ID.
+// Verifies lookup failure with an unknown direct meter ID.
 TEST_F(P4InfoManagerTest, TestFindDirectMeterUnknownID) {
   SetUpTestP4DirectMeters();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -778,11 +790,50 @@ TEST_F(P4InfoManagerTest, TestFindDirectMeterUnknownID) {
   EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
 }
 
-// Verifies lookup failure with an unknown unknown direct meter name.
+// Verifies lookup failure with an unknown direct meter name.
 TEST_F(P4InfoManagerTest, TestFindDirectMeterUnknownName) {
   SetUpTestP4DirectMeters();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
   auto status = p4_test_manager_->FindDirectMeterByName("unknown-meter");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(ERR_INVALID_P4_INFO, status.status().error_code());
+  EXPECT_FALSE(status.status().error_message().empty());
+  EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
+}
+
+// All valid digests in p4_test_info_ should have successful name/ID
+// lookups, and the returned data should match the digest's original
+// p4_test_info_ entry.
+TEST_F(P4InfoManagerTest, TestFindDigest) {
+  SetUpTestP4Digests();
+  ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
+  for (const auto& digest : p4_test_info_.digests()) {
+    auto id_status = p4_test_manager_->FindDigestByID(digest.preamble().id());
+    EXPECT_TRUE(id_status.ok());
+    EXPECT_TRUE(ProtoEqual(digest, id_status.ValueOrDie()));
+    auto name_status =
+        p4_test_manager_->FindDigestByName(digest.preamble().name());
+    EXPECT_TRUE(name_status.ok());
+    EXPECT_TRUE(ProtoEqual(digest, name_status.ValueOrDie()));
+  }
+}
+
+// Verifies lookup failure with an unknown digest ID.
+TEST_F(P4InfoManagerTest, TestFindDigestUnknownID) {
+  SetUpTestP4Digests();
+  ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
+  auto status = p4_test_manager_->FindDigestByID(0x9abcd);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(ERR_INVALID_P4_INFO, status.status().error_code());
+  EXPECT_FALSE(status.status().error_message().empty());
+  EXPECT_THAT(status.status().error_message(), HasSubstr("not found"));
+}
+
+// Verifies lookup failure with an unknown digest name.
+TEST_F(P4InfoManagerTest, TestFindDigestUnknownName) {
+  SetUpTestP4Digests();
+  ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
+  auto status = p4_test_manager_->FindDigestByName("unknown-digest");
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(ERR_INVALID_P4_INFO, status.status().error_code());
   EXPECT_FALSE(status.status().error_message().empty());


### PR DESCRIPTION
This PR adds initial support for handling `Digest` entities in the `P4InfoManager`.
Additionally, some copy&paste naming errors are fixed.