### PR TITLE
First stab at weekly docker build with Stratum-bfrt

### DIFF
--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -105,9 +105,8 @@ harbor_push: &harbor_push
 
 docker_set_tag_env: &docker_set_tag_env
   run:
-    name: Set the DOCKER_TAG env var dynamically
+    name: Set the DOCKER_TAG env var dynamically based on the release_type parameter
     command: |
-      echo << parameters.release_type >>
       if [[ << parameters.release_type >> == "weekly" ]]; then
         echo 'export DOCKER_TAG=$(date "+%y.%m.%d")' >> "$BASH_ENV"
       elif [[ << parameters.release_type >> == "latest" ]]; then
@@ -325,22 +324,24 @@ jobs:
         type: string
       release_type:
         description: "The type of release to tag this build with"
-        type: enum
-        enum: ["latest", "weekly"]
+        type: string
+        # type: enum
+        # enum: ["latest", "weekly"]
         default: "latest"
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/barefoot/docker
       - DOCKER_FILE: Dockerfile
-      - DOCKER_IMG: stratumproject/stratum-bfrt:latest-<< parameters.sde_version >>
+      - DOCKER_IMG: stratumproject/stratum-bfrt:<< parameters.release_type >>-<< parameters.sde_version >>
       - CC: clang
       - CXX: clang++
       - SDE_INSTALL_TAR: /tmp/bf-sde-tars/bf-sde-<< parameters.sde_version >>-install.tgz
     steps:
       - setup_remote_docker
       - checkout
-      - *docker_set_tag_env
+      # - *docker_set_tag_env
+      # - run: echo $DOCKER_TAG
       - run: echo << parameters.release_type >>
-      - run: echo $DOCKER_TAG
+      - run: echo $DOCKER_IMG
       - run: exit 1
       - *restore_bazel_cache
       - *fetch_sde_tars
@@ -454,7 +455,7 @@ workflows:
           release_type: "latest"
       - publish-docker-stratum-bfrt:
           sde_version: "9.7.0"
-          release_type: "weekly"
+          release_type: "DATE_YY_MM_DD"
   weekly_publish:
     triggers:
       - schedule:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -103,6 +103,20 @@ harbor_push: &harbor_push
     name: Push Docker image to harbor
     command: docker push registry.aetherproject.org/$HARBOR_IMG
 
+docker_set_tag_env: &docker_set_tag_env
+  run:
+    name: Set the DOCKER_TAG env var dynamically
+    command: |
+      echo << parameters.release_type >>
+      if [[ << parameters.release_type >> == "weekly" ]]; then
+        echo 'export DOCKER_TAG=$(date "+%y.%m.%d")' >> "$BASH_ENV"
+      elif [[ << parameters.release_type >> == "latest" ]]; then
+        echo 'export DOCKER_TAG=latest' >> "$BASH_ENV"
+      else
+        echo "Unknown release type: << parameters.release_type >>"
+        exit 1
+      fi
+
 jobs:
 
   # Build targets and run unit tests.
@@ -309,6 +323,11 @@ jobs:
       sde_version:
         description: "BF SDE version to build with"
         type: string
+      release_type:
+        description: "The type of release to tag this build with"
+        type: enum
+        enum: ["latest", "weekly"]
+        default: "latest"
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/barefoot/docker
       - DOCKER_FILE: Dockerfile
@@ -319,6 +338,10 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
+      - *docker_set_tag_env
+      - run: echo << parameters.release_type >>
+      - run: echo $DOCKER_TAG
+      - run: exit 1
       - *restore_bazel_cache
       - *fetch_sde_tars
       - *set_bazelrc
@@ -426,6 +449,12 @@ workflows:
             - publish-docker-build
       - license-check
       - markdown-style-check
+      - publish-docker-stratum-bfrt:
+          sde_version: "9.7.0"
+          release_type: "latest"
+      - publish-docker-stratum-bfrt:
+          sde_version: "9.7.0"
+          release_type: "weekly"
   weekly_publish:
     triggers:
       - schedule:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -103,18 +103,6 @@ harbor_push: &harbor_push
     name: Push Docker image to harbor
     command: docker push registry.aetherproject.org/$HARBOR_IMG
 
-docker_set_tag_env: &docker_set_tag_env
-  run:
-    name: Set the DOCKER_TAG env var dynamically based on the release_type parameter
-    command: |
-      if [[ << parameters.release_type >> == "weekly" ]]; then
-        echo 'export DOCKER_TAG=$(date "+%y.%m.%d")' >> "$BASH_ENV"
-      elif [[ << parameters.release_type >> == "latest" ]]; then
-        echo 'export DOCKER_TAG=latest' >> "$BASH_ENV"
-      else
-        echo "Unknown release type: << parameters.release_type >>"
-        exit 1
-      fi
 
 jobs:
 
@@ -325,8 +313,6 @@ jobs:
       release_type:
         description: "The type of release to tag this build with"
         type: string
-        # type: enum
-        # enum: ["latest", "weekly"]
         default: "latest"
     environment:
       - DOCKER_SCOPE: stratum/hal/bin/barefoot/docker
@@ -338,8 +324,6 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      # - *docker_set_tag_env
-      # - run: echo $DOCKER_TAG
       - run: echo << parameters.release_type >>
       - run: echo $DOCKER_IMG
       - run: exit 1
@@ -456,7 +440,7 @@ workflows:
       - publish-docker-stratum-bfrt:
           sde_version: "9.7.0"
           release_type: "DATE_YY_MM_DD"
-  weekly_publish:
+  weekly_docker_publish:
     triggers:
       - schedule:
           cron: "0,15,30,45 * * * *" # every 15 mins
@@ -466,7 +450,11 @@ workflows:
                 - main
                 - cron-ci
     jobs:
-      - publish-docker-build
+      - publish-docker-stratum-bfrt:
+          release_type: "DATE_YY_MM_DD"
+          matrix:
+            parameters:
+              sde_version: ["9.7.0", "9.7.1", "9.7.2", "9.8.0", "9.9.0", "9.10.0"]
   docker_publish:
     jobs:
       - publish-docker-build:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -426,7 +426,18 @@ workflows:
             - publish-docker-build
       - license-check
       - markdown-style-check
-  docker-publish:
+  weekly_publish:
+    triggers:
+      - schedule:
+          cron: "0,15,30,45 * * * *" # every 15 mins
+          filters:
+            branches:
+              only:
+                - main
+                - cron-ci
+    jobs:
+      - publish-docker-build
+  docker_publish:
     jobs:
       - publish-docker-build:
           filters:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -103,7 +103,6 @@ harbor_push: &harbor_push
     name: Push Docker image to harbor
     command: docker push registry.aetherproject.org/$HARBOR_IMG
 
-
 jobs:
 
   # Build targets and run unit tests.
@@ -324,9 +323,6 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      - run: echo << parameters.release_type >>
-      - run: echo $DOCKER_IMG
-      - run: exit 1
       - *restore_bazel_cache
       - *fetch_sde_tars
       - *set_bazelrc
@@ -434,12 +430,6 @@ workflows:
             - publish-docker-build
       - license-check
       - markdown-style-check
-      - publish-docker-stratum-bfrt:
-          sde_version: "9.7.0"
-          release_type: "latest"
-      - publish-docker-stratum-bfrt:
-          sde_version: "9.7.0"
-          release_type: "DATE_YY_MM_DD"
   weekly_docker_publish:
     triggers:
       - schedule:
@@ -448,7 +438,6 @@ workflows:
             branches:
               only:
                 - main
-                - cron-ci
     jobs:
       - publish-docker-stratum-bfrt:
           release_type: "DATE_YY_MM_DD"

--- a/.circleci/generate-config.sh
+++ b/.circleci/generate-config.sh
@@ -10,4 +10,8 @@ if [[ "$CIRCLE_BRANCH" != "main" ]] && [[ -n $DOCKER_LOGIN ]]; then
     STRATUM_BUILDER_IMAGE="stratumproject/build-ci:$DOCKERFILE_SHA"
 fi
 
-sed "s#STRATUM_BUILDER_IMAGE#$STRATUM_BUILDER_IMAGE#g" "$STRATUM_ROOT/.circleci/config_template.yml"
+DATE_YY_MM_DD=$(date "+%y.%m.%d")
+
+sed -e "s#STRATUM_BUILDER_IMAGE#$STRATUM_BUILDER_IMAGE#g" \
+    -e "s#DATE_YY_MM_DD#$DATE_YY_MM_DD#g" \
+  "$STRATUM_ROOT/.circleci/config_template.yml"


### PR DESCRIPTION
This PR explores the concept of publishing the existing weekly docker images from CircleCI instead of jenkins.
In this first attempt, we introduce a `release_type` parameter either set to `latest` or the date in `YY.MM.DD` form. This results in the same docker tag structure used now.
The interval is kept short for testing, and will be fixed later if this approach works. (Needs to be merged to master to trigger)