### PR TITLE
Implement digest config `max_timeout` on Tofino

### DIFF
--- a/stratum/hal/lib/barefoot/bf_sde_interface.h
+++ b/stratum/hal/lib/barefoot/bf_sde_interface.h
@@ -518,12 +518,12 @@ class BfSdeInterface {
   // invocation.
   virtual ::util::Status InsertDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 table_id) = 0;
+      uint32 table_id, absl::Duration max_timeout) = 0;
 
   // Modifies/configures a digest instance.
   virtual ::util::Status ModifyDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 table_id) = 0;
+      uint32 table_id, absl::Duration max_timeout) = 0;
 
   // Deletes a digest instance.
   virtual ::util::Status DeleteDigest(
@@ -531,11 +531,12 @@ class BfSdeInterface {
       uint32 table_id) = 0;
 
   // Reads the data from a digest, or all digests if table ID is 0.
-  // The table ID must be a BfRt table ID, not P4Runtime. This is a noop until
-  // digest parameters are implemented.
+  // The table ID must be a BfRt table ID, not P4Runtime. max_timeout contains
+  // the device-wide learn timeout for the given device.
   virtual ::util::Status ReadDigests(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 table_id, std::vector<uint32>* digest_ids) = 0;
+      uint32 table_id, std::vector<uint32>* digest_ids,
+      absl::Duration* max_timeout) = 0;
 
   // Synchronizes the driver cached counter values with the current hardware
   // state for a given BfRt table.

--- a/stratum/hal/lib/barefoot/bf_sde_mock.h
+++ b/stratum/hal/lib/barefoot/bf_sde_mock.h
@@ -332,26 +332,27 @@ class BfSdeMock : public BfSdeInterface {
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id, TableDataInterface* table_data));
-  MOCK_METHOD3(
+  MOCK_METHOD4(
       InsertDigest,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
-                     uint32 table_id));
-  MOCK_METHOD3(
+                     uint32 table_id, absl::Duration max_timeout));
+  MOCK_METHOD4(
       ModifyDigest,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
-                     uint32 table_id));
+                     uint32 table_id, absl::Duration max_timeout));
   MOCK_METHOD3(
       DeleteDigest,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
                      uint32 table_id));
-  MOCK_METHOD4(
+  MOCK_METHOD5(
       ReadDigests,
       ::util::Status(int device,
                      std::shared_ptr<BfSdeInterface::SessionInterface> session,
-                     uint32 table_id, std::vector<uint32>* digest_ids));
+                     uint32 table_id, std::vector<uint32>* digest_ids,
+                     absl::Duration* max_timeout));
   MOCK_METHOD4(
       SynchronizeCounters,
       ::util::Status(int device,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -356,17 +356,19 @@ class BfSdeWrapper : public BfSdeInterface {
       LOCKS_EXCLUDED(data_lock_);
   ::util::Status InsertDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
+      uint32 table_id, absl::Duration max_timeout)
+      LOCKS_EXCLUDED(data_lock_) override;
   ::util::Status ModifyDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
+      uint32 table_id, absl::Duration max_timeout)
+      LOCKS_EXCLUDED(data_lock_) override;
   ::util::Status DeleteDigest(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
       uint32 table_id) LOCKS_EXCLUDED(data_lock_) override;
   ::util::Status ReadDigests(
       int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
-      uint32 table_id, std::vector<uint32>* digest_ids) override
-      LOCKS_EXCLUDED(data_lock_);
+      uint32 table_id, std::vector<uint32>* digest_ids,
+      absl::Duration* max_timeout) override LOCKS_EXCLUDED(data_lock_);
 
   ::util::StatusOr<uint32> GetBfRtId(uint32 p4info_id) const override
       LOCKS_EXCLUDED(data_lock_);

--- a/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager_test.cc
@@ -477,13 +477,15 @@ TEST_F(BfrtTableManagerTest, InsertDigestEntrySuccess) {
   EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4DigestId))
       .WillOnce(Return(kBfRtTableId));
   // TODO(max): figure out how to expect the session mock here.
-  EXPECT_CALL(*bf_sde_wrapper_mock_, InsertDigest(kDevice1, _, kBfRtTableId))
+  EXPECT_CALL(
+      *bf_sde_wrapper_mock_,
+      InsertDigest(kDevice1, _, kBfRtTableId, absl::Nanoseconds(1000000000)))
       .WillOnce(Return(::util::OkStatus()));
 
   const std::string kDigestEntryText = R"pb(
     digest_id: 401732455
     config {
-      ack_timeout_ns: 1000000000
+      ack_timeout_ns: 2000000000
       max_timeout_ns: 1000000000
       max_list_size: 100
     }
@@ -507,13 +509,15 @@ TEST_F(BfrtTableManagerTest, ModifyDigestEntrySuccess) {
   EXPECT_CALL(*bf_sde_wrapper_mock_, GetBfRtId(kP4DigestId))
       .WillOnce(Return(kBfRtTableId));
   // TODO(max): figure out how to expect the session mock here.
-  EXPECT_CALL(*bf_sde_wrapper_mock_, ModifyDigest(kDevice1, _, kBfRtTableId))
+  EXPECT_CALL(
+      *bf_sde_wrapper_mock_,
+      ModifyDigest(kDevice1, _, kBfRtTableId, absl::Nanoseconds(1000000000)))
       .WillOnce(Return(::util::OkStatus()));
 
   const std::string kDigestEntryText = R"pb(
     digest_id: 401732455
     config {
-      ack_timeout_ns: 1000000000
+      ack_timeout_ns: 2000000000
       max_timeout_ns: 1000000000
       max_list_size: 100
     }


### PR DESCRIPTION
This PR extends the digest implementation by adding limited support for the `max_timeout` digest config parameter. Caveats:
- resolution on the device is in microseconds, not nanoseconds
- maximum allowed value on a wedge65x is around 3.5 seconds
- only one device-wide timeout value is supported. It applies to all digests.
- digest modify calls succeed even if the digest entry is not inserted