### PR TITLE
Make Barefoot `chassis_lock` truly global

### DIFF
--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -39,6 +39,7 @@ stratum_cc_library(
     hdrs = ["bfrt_switch.h"],
     deps = [
         ":bf_chassis_manager",
+        ":bf_global_vars",
         ":bf_sde_interface",
         ":bfrt_node",
         "//stratum/glue:integral_types",
@@ -75,11 +76,21 @@ stratum_cc_test(
 )
 
 stratum_cc_library(
+    name = "bf_global_vars",
+    srcs = ["bf_global_vars.cc"],
+    hdrs = ["bf_global_vars.h"],
+    deps = [
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+stratum_cc_library(
     name = "bf_chassis_manager",
     srcs = ["bf_chassis_manager.cc"],
     hdrs = ["bf_chassis_manager.h"],
     copts = ["-Wno-thread-safety-analysis"],  # TODO(antonin)
     deps = [
+        ":bf_global_vars",
         ":bf_sde_interface",
         ":bfrt_constants",
         "//stratum/glue:integral_types",
@@ -264,6 +275,7 @@ stratum_cc_library(
     hdrs = ["bfrt_node.h"],
     deps = [
         ":bf_cc_proto",
+        ":bf_global_vars",
         ":bf_pipeline_utils",
         ":bfrt_counter_manager",
         ":bfrt_p4runtime_translator",
@@ -334,6 +346,7 @@ stratum_cc_library(
     hdrs = ["bfrt_table_manager.h"],
     deps = [
         ":bf_cc_proto",
+        ":bf_global_vars",
         ":bf_sde_interface",
         ":bfrt_p4runtime_translator",
         ":utils",
@@ -443,6 +456,7 @@ stratum_cc_library(
     hdrs = ["bfrt_packetio_manager.h"],
     deps = [
         ":bf_cc_proto",
+        ":bf_global_vars",
         ":bf_sde_interface",
         ":bfrt_p4runtime_translator",
         "//stratum/glue:integral_types",

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -32,8 +32,6 @@ namespace barefoot {
 using PortStatusEvent = BfSdeInterface::PortStatusEvent;
 using TransceiverEvent = PhalInterface::TransceiverEvent;
 
-ABSL_CONST_INIT absl::Mutex chassis_lock(absl::kConstInit);
-
 /* static */
 constexpr int BfChassisManager::kMaxPortStatusEventDepth;
 /* static */
@@ -83,7 +81,18 @@ BfChassisManager::BfChassisManager()
       phal_interface_(nullptr),
       bf_sde_interface_(nullptr) {}
 
-BfChassisManager::~BfChassisManager() = default;
+BfChassisManager::~BfChassisManager() {
+  // NOTE: We should not detach any device or unregister any handler in the
+  // deconstructor as phal_interface_ or bf_sde_interface_ can be deleted before
+  // this class. Make sure you call Shutdown() before deleting the class
+  // instance.
+  if (initialized_) {
+    LOG(ERROR) << "Deleting BfChassisManager while initialized_ is still "
+               << "true. You did not call Shutdown() before deleting the class "
+               << "instance. This can lead to unexpected behavior.";
+  }
+  CleanupInternalState();
+}
 
 ::util::Status BfChassisManager::AddPortHelper(
     uint64 node_id, int device, uint32 sdk_port_id,
@@ -1228,10 +1237,9 @@ void BfChassisManager::ReadPortStatusEvents(
   PortStatusEvent event;
   do {
     // Check switch shutdown.
-    // TODO(max): This check should be on the shutdown variable.
     {
       absl::ReaderMutexLock l(&chassis_lock);
-      if (!initialized_) break;
+      if (shutdown) break;
     }
     // Block on the next linkscan event message from the Channel.
     int code = reader->Read(&event, absl::InfiniteDuration()).error_code();
@@ -1252,11 +1260,10 @@ void BfChassisManager::PortStatusEventHandler(int device, int port,
                                               PortState new_state,
                                               absl::Time time_last_changed) {
   absl::WriterMutexLock l(&chassis_lock);
-  // TODO(max): check for shutdown here
-  // if (shutdown) {
-  //   VLOG(1) << "The class is already shutdown. Exiting.";
-  //   return;
-  // }
+  if (shutdown) {
+    VLOG(1) << "The class is already shutdown. Exiting.";
+    return;
+  }
 
   // Update the state.
   const uint64* node_id = gtl::FindOrNull(device_to_node_id_, device);
@@ -1306,10 +1313,9 @@ void BfChassisManager::ReadTransceiverEvents(
     const std::unique_ptr<ChannelReader<TransceiverEvent>>& reader) {
   do {
     // Check switch shutdown.
-    // TODO(max): This check should be on the shutdown variable.
     {
       absl::ReaderMutexLock l(&chassis_lock);
-      if (!initialized_) break;
+      if (shutdown) break;
     }
     TransceiverEvent event;
     // Block on the next transceiver event message from the Channel.
@@ -1329,6 +1335,10 @@ void BfChassisManager::ReadTransceiverEvents(
 void BfChassisManager::TransceiverEventHandler(int slot, int port,
                                                HwState new_state) {
   absl::WriterMutexLock l(&chassis_lock);
+  if (shutdown) {
+    VLOG(1) << "The class is already shutdown. Exiting.";
+    return;
+  }
 
   PortKey xcvr_port_key(slot, port);
   LOG(INFO) << "Transceiver event for port " << xcvr_port_key.ToString() << ": "
@@ -1444,6 +1454,7 @@ void BfChassisManager::TransceiverEventHandler(int slot, int port,
              << "Failed to create transceiver event thread. Err: " << ret
              << ".";
     }
+
     // We don't care about the return value of the thread. It should exit once
     // the Channel is closed in UnregisterEventWriters().
     ret = pthread_detach(xcvr_event_reader_tid);

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.h
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.h
@@ -13,6 +13,7 @@
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
 #include "stratum/glue/integral_types.h"
+#include "stratum/hal/lib/barefoot/bf_global_vars.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 #include "stratum/hal/lib/common/gnmi_events.h"
 #include "stratum/hal/lib/common/phal_interface.h"
@@ -23,9 +24,6 @@
 namespace stratum {
 namespace hal {
 namespace barefoot {
-
-// Lock which protects chassis state across the entire switch.
-extern absl::Mutex chassis_lock;
 
 // The "BfChassisManager" class encapsulates all the chassis-related
 // functionalities needed in BfSwitch/BfrtSwitch class. This class is in charge

--- a/stratum/hal/lib/barefoot/bf_global_vars.cc
+++ b/stratum/hal/lib/barefoot/bf_global_vars.cc
@@ -1,0 +1,17 @@
+// Copyright 2023-present Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/barefoot/bf_global_vars.h"
+
+#include "absl/synchronization/mutex.h"
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+ABSL_CONST_INIT absl::Mutex chassis_lock(absl::kConstInit);
+bool shutdown = false;
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/barefoot/bf_global_vars.h
+++ b/stratum/hal/lib/barefoot/bf_global_vars.h
@@ -1,0 +1,25 @@
+// Copyright 2023-present Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_BAREFOOT_BF_GLOBAL_VARS_H_
+#define STRATUM_HAL_LIB_BAREFOOT_BF_GLOBAL_VARS_H_
+
+#include "absl/synchronization/mutex.h"
+
+namespace stratum {
+
+namespace hal {
+namespace barefoot {
+
+// Lock which governs chassis state (ports, etc.) across the entire switch.
+extern absl::Mutex chassis_lock;
+
+// Flag indicating if the switch has been shut down. Initialized to false.
+extern bool shutdown;
+
+}  // namespace barefoot
+}  // namespace hal
+
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_BAREFOOT_BF_GLOBAL_VARS_H_

--- a/stratum/hal/lib/barefoot/bfrt_node.h
+++ b/stratum/hal/lib/barefoot/bfrt_node.h
@@ -13,6 +13,7 @@
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/barefoot/bf.pb.h"
+#include "stratum/hal/lib/barefoot/bf_global_vars.h"
 #include "stratum/hal/lib/barefoot/bfrt_counter_manager.h"
 #include "stratum/hal/lib/barefoot/bfrt_p4runtime_translator.h"
 #include "stratum/hal/lib/barefoot/bfrt_packetio_manager.h"
@@ -45,7 +46,7 @@ class BfrtNode {
   virtual ::util::Status CommitForwardingPipelineConfig() LOCKS_EXCLUDED(lock_);
   virtual ::util::Status VerifyForwardingPipelineConfig(
       const ::p4::v1::ForwardingPipelineConfig& config) const;
-  virtual ::util::Status Shutdown() LOCKS_EXCLUDED(lock_);
+  virtual ::util::Status Shutdown() LOCKS_EXCLUDED(chassis_lock, lock_);
   virtual ::util::Status Freeze() LOCKS_EXCLUDED(lock_);
   virtual ::util::Status Unfreeze() LOCKS_EXCLUDED(lock_);
   virtual ::util::Status WriteForwardingEntries(

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -309,9 +309,14 @@ class BitBuffer {
     if (!initialized_)
       return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
     reader = ChannelReader<std::string>::Create(packet_receive_channel_);
+    if (!reader) return MAKE_ERROR(ERR_INTERNAL) << "Failed to create reader.";
   }
 
   while (true) {
+    {
+      absl::ReaderMutexLock l(&chassis_lock);
+      if (shutdown) break;
+    }
     std::string buffer;
     int code = reader->Read(&buffer, absl::InfiniteDuration()).error_code();
     if (code == ERR_CANCELLED) break;

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.h
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.h
@@ -16,6 +16,7 @@
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/barefoot/bf.pb.h"
+#include "stratum/hal/lib/barefoot/bf_global_vars.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 #include "stratum/hal/lib/barefoot/bfrt_p4runtime_translator.h"
 #include "stratum/hal/lib/common/common.pb.h"

--- a/stratum/hal/lib/barefoot/bfrt_switch.h
+++ b/stratum/hal/lib/barefoot/bfrt_switch.h
@@ -11,6 +11,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 #include "stratum/hal/lib/barefoot/bf_chassis_manager.h"
+#include "stratum/hal/lib/barefoot/bf_global_vars.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 #include "stratum/hal/lib/barefoot/bfrt_node.h"
 #include "stratum/hal/lib/common/phal_interface.h"

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.h
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.h
@@ -14,6 +14,7 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/barefoot/bf.pb.h"
+#include "stratum/hal/lib/barefoot/bf_global_vars.h"
 #include "stratum/hal/lib/barefoot/bf_sde_interface.h"
 #include "stratum/hal/lib/barefoot/bfrt_p4runtime_translator.h"
 #include "stratum/hal/lib/common/common.pb.h"
@@ -203,7 +204,7 @@ class BfrtTableManager {
   // Handles received digest lists, converts them to P4Runtime and hands them
   // over the registered receive writer.
   ::util::Status HandleDigestList()
-      LOCKS_EXCLUDED(lock_, digest_list_writer_lock_);
+      LOCKS_EXCLUDED(lock_, digest_list_writer_lock_, chassis_lock);
 
   // Digest list handle thread function.
   static void* DigestListThreadFunc(void* arg);

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -122,7 +122,7 @@ BcmSwitch::~BcmSwitch() {}
 ::util::Status BcmSwitch::Shutdown() {
   // The shutdown flag must be checked on all read or write accesses to
   // state protected by chassis_lock, whether within RPC executions or
-  // event handler threas.
+  // event handler threads.
   {
     absl::WriterMutexLock l(&chassis_lock);
     shutdown = true;


### PR DESCRIPTION
This allows for proper shutdown condition checking in other threads. 

Also addressed in this PR is a race condition in the `BfrtTableManager::HandleDigestList()` function, where the channel could be closed and deleted before we create the reader. This reader then is a `nullptr` which we did not check for.