### PR TITLE
Allow external Bfrt TAP interface creation and custom names

### DIFF
--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -445,11 +445,12 @@ workflows:
           requires:
             - publish-docker-build
       - publish-docker-stratum-bfrt:
-          requires:
-            - publish-docker-build
+          # requires:
+          #   - publish-docker-build
           matrix:
             parameters:
-              sde_version: ["9.7.0", "9.7.1", "9.7.2", "9.8.0", "9.9.0", "9.10.0"]
+              # sde_version: ["9.7.0", "9.7.1", "9.7.2", "9.8.0", "9.9.0", "9.10.0"]
+              sde_version: ["9.10.0"]
       - publish-docker-stratum-tools:
           requires:
             - publish-docker-build

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -445,12 +445,11 @@ workflows:
           requires:
             - publish-docker-build
       - publish-docker-stratum-bfrt:
-          # requires:
-          #   - publish-docker-build
+          requires:
+            - publish-docker-build
           matrix:
             parameters:
-              # sde_version: ["9.7.0", "9.7.1", "9.7.2", "9.8.0", "9.9.0", "9.10.0"]
-              sde_version: ["9.10.0"]
+              sde_version: ["9.7.0", "9.7.1", "9.7.2", "9.8.0", "9.9.0", "9.10.0"]
       - publish-docker-stratum-tools:
           requires:
             - publish-docker-build


### PR DESCRIPTION
This PR is a followup to #1069 to make it usable in more scenarios. In particular, it is now possible to bind to an existing TAP interface created outside of Stratum. This allows for a more persistent setup where a Stratum restart does not remove the interface. Further, we also check for the canonical TUN/TAP device path in addition the the Tofino specific one. This is useful for simulated environments and tests.