### PR TITLE
Add `tunctl` tool to Stratum-bfrt Debian package

### DIFF
--- a/stratum/hal/bin/barefoot/BUILD
+++ b/stratum/hal/bin/barefoot/BUILD
@@ -158,6 +158,7 @@ pkg_deb(
         "libssl1.1",
         "systemd",
         "telnet",
+        "uml-utilities",  # for `tunctl` and CPU port workaround
     ] + sde_bsp_debian_deps,
     description = "The Stratum package for Barefoot Tofino-based platform",
     homepage = "https://stratumproject.org/",


### PR DESCRIPTION
This allows using the tool to create and delete TUN/TAP interfaces from inside the container.