### PR TITLE
Make stratum_dpdk portable and bump p4-dpdk-target to latest version

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -108,3 +108,7 @@ License: Apache-2.0
 Files: NOTICE legal/NOTICE* legal/LICENSE*
 Copyright: No Copyright
 License: CC0-1.0
+
+Files: stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
+Copyright: 2023-present Intel Corporation
+License: Apache-2.0

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -278,7 +278,7 @@ def stratum_deps():
         http_archive(
             # name = "com_github_p4lang_p4_dpdk_target",
             name = "local_tdi_bin",
-            sha256 = "c58e7a3f13b12515bbcf0f784486125b9c605e54ca93fd920b262d18dbdac0cb",
+            sha256 = "5ae459cdd6ae60a4bb462cbbd815ec19dbe6596aedde8587aa4ee4d876ba393a",
             # TODO(max): host file somewhere more appropriate
             urls = ["https://github.com/stratum/sonic-base-image/releases/download/2022-08-12/p4-sde-0.1.0-install.tgz"],
             build_file = "@//bazel:external/dpdk.BUILD",

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -25,8 +25,7 @@ cc_library(
         "lib/libtdi_pna.so*",
         "lib/libtdi.so*",
         # DPDK libs
-        "lib/x86_64-linux-gnu/dpdk/pmds-22.2/*.so*",
-        "lib/x86_64-linux-gnu/librte_*.so*",
+        "lib/x86_64-linux-gnu/**/*.so*",
     ]),
     hdrs = glob([
         "include/bf_pal/*.h",
@@ -70,8 +69,7 @@ pkg_tar_with_symlinks(
         "lib/libtdi_pna.so*",
         "lib/libtdi.so*",
         # DPDK libs
-        "lib/x86_64-linux-gnu/dpdk/pmds-22.2/*.so*",
-        "lib/x86_64-linux-gnu/librte_*.so*",
+        "lib/x86_64-linux-gnu/**/*.so*",
     ]),
     mode = "0644",
     package_dir = "/usr",

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -25,7 +25,8 @@ cc_library(
         "lib/libtdi_pna.so*",
         "lib/libtdi.so*",
         # DPDK libs
-        "lib/x86_64-linux-gnu/**/*.so*",
+        "lib/x86_64-linux-gnu/dpdk/pmds-*/*.so*",
+        "lib/x86_64-linux-gnu/librte_*.so*",
     ]),
     hdrs = glob([
         "include/bf_pal/*.h",
@@ -44,6 +45,7 @@ cc_library(
         "include/tdi_rt/**/*.hpp",
         "include/tdi/**/*.h",
         "include/tdi/**/*.hpp",
+
     ]),
     linkopts = [
         "-lpthread",
@@ -69,7 +71,8 @@ pkg_tar_with_symlinks(
         "lib/libtdi_pna.so*",
         "lib/libtdi.so*",
         # DPDK libs
-        "lib/x86_64-linux-gnu/**/*.so*",
+        "lib/x86_64-linux-gnu/dpdk/pmds-*/*.so*",
+        "lib/x86_64-linux-gnu/librte_*.so*",
     ]),
     mode = "0644",
     package_dir = "/usr",
@@ -82,6 +85,9 @@ pkg_tar_with_symlinks(
         "share/bf_rt_shared/**",
         "share/cli/xml/**",
         "share/target_sys/**",
+        # rte_* hdrs are required to enable the SWX compile mode
+        "include/rte_*.h",
+        "include/generic/rte_*.h",
     ]),
     mode = "0644",
     package_dir = "/usr",

--- a/bazel/external/dpdk.BUILD
+++ b/bazel/external/dpdk.BUILD
@@ -45,7 +45,6 @@ cc_library(
         "include/tdi_rt/**/*.hpp",
         "include/tdi/**/*.h",
         "include/tdi/**/*.hpp",
-
     ]),
     linkopts = [
         "-lpthread",
@@ -85,7 +84,7 @@ pkg_tar_with_symlinks(
         "share/bf_rt_shared/**",
         "share/cli/xml/**",
         "share/target_sys/**",
-        # rte_* hdrs are required to enable the SWX compile mode
+        # rte_* hdrs are required to enable the SWX compile mode.
         "include/rte_*.h",
         "include/generic/rte_*.h",
     ]),

--- a/stratum/hal/bin/tdi/dpdk/BUILD
+++ b/stratum/hal/bin/tdi/dpdk/BUILD
@@ -125,6 +125,7 @@ pkg_deb(
         "libatomic1",
         "libpcap0.8",
         "libelf-dev",
+        "libjansson-dev",
     ],
     description = "The Stratum package for the P4 DPDK software platform",
     homepage = "https://stratumproject.org/",

--- a/stratum/hal/bin/tdi/dpdk/BUILD
+++ b/stratum/hal/bin/tdi/dpdk/BUILD
@@ -126,6 +126,7 @@ pkg_deb(
         "libpcap0.8",
         "libelf-dev",
         "libjansson-dev",
+        "gcc",
     ],
     description = "The Stratum package for the P4 DPDK software platform",
     homepage = "https://stratumproject.org/",

--- a/stratum/hal/bin/tdi/dpdk/build-p4-sde.sh
+++ b/stratum/hal/bin/tdi/dpdk/build-p4-sde.sh
@@ -51,6 +51,7 @@ python3 $tmpdir/p4-dpdk-target/tools/setup/install_dep.py
 
 cd $SDE/p4-dpdk-target
 git submodule update --init --recursive --force
+git apply --ignore-whitespace "$THIS_DIR"/patch/01-enable-generic-isa.patch
 ./autogen.sh
 autoreconf
 ./configure --prefix=$SDE_INSTALL

--- a/stratum/hal/bin/tdi/dpdk/build-p4-sde.sh
+++ b/stratum/hal/bin/tdi/dpdk/build-p4-sde.sh
@@ -6,6 +6,7 @@ set -ex
 THIS_DIR=$( cd $(dirname "${BASH_SOURCE[0]}") >/dev/null 2>&1 && pwd )
 STRATUM_ROOT=${STRATUM_ROOT:-"$( cd "$THIS_DIR/../../../../.." >/dev/null 2>&1 && pwd )"}
 JOBS=${JOBS:-4}
+P4_DPDK_TARGET_COMMIT=199d418f5fcfaca7fb7992d4867e72b39ebe6e31
 
 print_help() {
 echo "
@@ -40,11 +41,8 @@ pip3 install distro meson
 # Build the P4 TDI SDE
 tmpdir="$(mktemp -d /tmp/p4_sde.XXXXXX)"
 pushd $tmpdir
-# TODO: needs commit hash pinning
-git clone --depth=1 --recursive https://github.com/p4lang/target-utils utils
-git clone --depth=1 --recursive https://github.com/p4lang/target-syslibs syslibs
-git clone --depth=1 --recursive https://github.com/p4lang/p4-dpdk-target p4-dpdk-target
-git clone --depth=1 --recursive https://github.com/ipdk-io/networking-recipe ipdk-dpdk
+git clone --recursive https://github.com/p4lang/p4-dpdk-target p4-dpdk-target
+pushd p4-dpdk-target && git checkout ${P4_DPDK_TARGET_COMMIT} && popd
 
 source $tmpdir/p4-dpdk-target/tools/setup/p4sde_env_setup.sh $tmpdir
 python3 $tmpdir/p4-dpdk-target/tools/setup/install_dep.py
@@ -52,6 +50,9 @@ python3 $tmpdir/p4-dpdk-target/tools/setup/install_dep.py
 cd $SDE/p4-dpdk-target
 git submodule update --init --recursive --force
 git apply --ignore-whitespace "$THIS_DIR"/patch/01-enable-generic-isa.patch
+pushd src/lld/dpdk/dpdk_src
+git apply --ignore-whitespace "$THIS_DIR"/patch/02-disable-crc-sse42.patch
+popd
 ./autogen.sh
 autoreconf
 ./configure --prefix=$SDE_INSTALL

--- a/stratum/hal/bin/tdi/dpdk/dpdk_skip_p4.conf
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_skip_p4.conf
@@ -31,6 +31,7 @@
                 {
                     "program-name": "dummy",
                     "cpu_numa_node": "0",
+                    "sai_default_init": false,
                     "p4_pipelines": [
                         {
                             "p4_pipeline_name": "pipe",

--- a/stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
+++ b/stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
@@ -1,0 +1,25 @@
+diff --git a/src/lld/dpdk/Makefile.am b/src/lld/dpdk/Makefile.am
+index 8cc21b3..c0f5f17 100644
+--- a/src/lld/dpdk/Makefile.am
++++ b/src/lld/dpdk/Makefile.am
+@@ -3,9 +3,15 @@ all:
+ 	$(shell ./apply_patch.sh > /dev/null 2>&1)
+ 	stat dpdk_src/build > /dev/null 2>&1 || \
+         (cd dpdk_src && meson -Dprefix=$(prefix) -Dtests=false -Ddefault_library=shared \
+-	 -Dexamples='' -Denable_kmods=false -Denable_docs=false -Denable_driver_sdk=false \
++	 -Dexamples='' -Denable_kmods=false -Denable_docs=false -Denable_driver_sdk=false -Dcpu_instruction_set=nehalem \
+ 	 -Ddisable_drivers=dma/*,raw/*,compress/*,crypto/*,event/*,baseband/* -Dbuildtype=release build && \
+-	cd build && ninja -j4 && ninja install)
++	cd build && \
++    sed -e 's/RTE_CPUFLAG_AVX512BW\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_AVX512CD\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_AVX512DQ\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_AVX512F\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_AVX512VL\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_AVX512VL\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_PCLMULQDQ\,//' -i rte_build_config.h && \
++    sed -e 's/RTE_CPUFLAG_AVX\,//' -i rte_build_config.h && \
++	ninja -j4 && ninja install)
+ 	$(MAKE) -C infra install_dir=$(prefix)
+ 	cp infra/build/dpdk_infra.so $(libdir)/libdpdk_infra.so
+ install:

--- a/stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
+++ b/stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
@@ -1,13 +1,15 @@
 diff --git a/src/lld/dpdk/Makefile.am b/src/lld/dpdk/Makefile.am
-index 8cc21b3..38065dc 100644
+index 8cc21b3..42f70f7 100644
 --- a/src/lld/dpdk/Makefile.am
 +++ b/src/lld/dpdk/Makefile.am
-@@ -3,7 +3,7 @@ all:
+@@ -3,8 +3,8 @@ all:
  	$(shell ./apply_patch.sh > /dev/null 2>&1)
  	stat dpdk_src/build > /dev/null 2>&1 || \
          (cd dpdk_src && meson -Dprefix=$(prefix) -Dtests=false -Ddefault_library=shared \
 -	 -Dexamples='' -Denable_kmods=false -Denable_docs=false -Denable_driver_sdk=false \
+-	 -Ddisable_drivers=dma/*,raw/*,compress/*,crypto/*,event/*,baseband/* -Dbuildtype=release build && \
 +	 -Dexamples='' -Denable_kmods=false -Denable_docs=false -Denable_driver_sdk=false -Dcpu_instruction_set=nehalem \
- 	 -Ddisable_drivers=dma/*,raw/*,compress/*,crypto/*,event/*,baseband/* -Dbuildtype=release build && \
++	 -Ddisable_drivers=dma/*,raw/*,compress/*,crypto/*,event/*,baseband/* -Dbuildtype=debug build && \
  	cd build && ninja -j4 && ninja install)
  	$(MAKE) -C infra install_dir=$(prefix)
+ 	cp infra/build/dpdk_infra.so $(libdir)/libdpdk_infra.so

--- a/stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
+++ b/stratum/hal/bin/tdi/dpdk/patch/01-enable-generic-isa.patch
@@ -1,25 +1,13 @@
 diff --git a/src/lld/dpdk/Makefile.am b/src/lld/dpdk/Makefile.am
-index 8cc21b3..c0f5f17 100644
+index 8cc21b3..38065dc 100644
 --- a/src/lld/dpdk/Makefile.am
 +++ b/src/lld/dpdk/Makefile.am
-@@ -3,9 +3,15 @@ all:
+@@ -3,7 +3,7 @@ all:
  	$(shell ./apply_patch.sh > /dev/null 2>&1)
  	stat dpdk_src/build > /dev/null 2>&1 || \
          (cd dpdk_src && meson -Dprefix=$(prefix) -Dtests=false -Ddefault_library=shared \
 -	 -Dexamples='' -Denable_kmods=false -Denable_docs=false -Denable_driver_sdk=false \
 +	 -Dexamples='' -Denable_kmods=false -Denable_docs=false -Denable_driver_sdk=false -Dcpu_instruction_set=nehalem \
  	 -Ddisable_drivers=dma/*,raw/*,compress/*,crypto/*,event/*,baseband/* -Dbuildtype=release build && \
--	cd build && ninja -j4 && ninja install)
-+	cd build && \
-+    sed -e 's/RTE_CPUFLAG_AVX512BW\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_AVX512CD\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_AVX512DQ\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_AVX512F\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_AVX512VL\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_AVX512VL\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_PCLMULQDQ\,//' -i rte_build_config.h && \
-+    sed -e 's/RTE_CPUFLAG_AVX\,//' -i rte_build_config.h && \
-+	ninja -j4 && ninja install)
+ 	cd build && ninja -j4 && ninja install)
  	$(MAKE) -C infra install_dir=$(prefix)
- 	cp infra/build/dpdk_infra.so $(libdir)/libdpdk_infra.so
- install:


### PR DESCRIPTION
This PR makes `stratum_dpdk` more portable and enables running it on VMs by using `nehalem` CPU instruction set. 