### PR TITLE
Enable setting packet direction per port

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -278,10 +278,9 @@ def stratum_deps():
         http_archive(
             # name = "com_github_p4lang_p4_dpdk_target",
             name = "local_tdi_bin",
-            # sha256 = "c58e7a3f13b12515bbcf0f784486125b9c605e54ca93fd920b262d18dbdac0cb",
+            sha256 = "c58e7a3f13b12515bbcf0f784486125b9c605e54ca93fd920b262d18dbdac0cb",
             # TODO(max): host file somewhere more appropriate
-            # urls = ["https://github.com/stratum/sonic-base-image/releases/download/2022-08-12/p4-sde-0.1.0-install.tgz"],
-            urls = ["file:///stratum/p4-sde-install.tgz"],
+            urls = ["https://github.com/stratum/sonic-base-image/releases/download/2022-08-12/p4-sde-0.1.0-install.tgz"],
             build_file = "@//bazel:external/dpdk.BUILD",
         )
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -278,9 +278,10 @@ def stratum_deps():
         http_archive(
             # name = "com_github_p4lang_p4_dpdk_target",
             name = "local_tdi_bin",
-            sha256 = "c58e7a3f13b12515bbcf0f784486125b9c605e54ca93fd920b262d18dbdac0cb",
+            # sha256 = "c58e7a3f13b12515bbcf0f784486125b9c605e54ca93fd920b262d18dbdac0cb",
             # TODO(max): host file somewhere more appropriate
-            urls = ["https://github.com/stratum/sonic-base-image/releases/download/2022-08-12/p4-sde-0.1.0-install.tgz"],
+            # urls = ["https://github.com/stratum/sonic-base-image/releases/download/2022-08-12/p4-sde-0.1.0-install.tgz"],
+            urls = ["file:///stratum/p4-sde-install.tgz"],
             build_file = "@//bazel:external/dpdk.BUILD",
         )
 

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -278,9 +278,9 @@ message PortConfigParams {
   }
   // DPDK packet direction types.
   enum DpdkPacketDirection {
-    DIRECTION_HOST = 0;
-    DIRECTION_NETWORK = 1;
-    DIRECTION_UNKNOWN = 2;
+    DIRECTION_UNKNOWN = 0;
+    DIRECTION_HOST = 1;
+    DIRECTION_NETWORK = 2;
   };
   // The configured admin state for this port.
   AdminState admin_state = 1;

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -280,7 +280,7 @@ message PortConfigParams {
   enum PacketDirection {
     DIRECTION_HOST = 0;
     DIRECTION_NETWORK = 1;
-    DIRECTION_NONE = 2;
+    DIRECTION_UNKNOWN = 2;
   };
   // The configured admin state for this port.
   AdminState admin_state = 1;

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -276,6 +276,12 @@ message PortConfigParams {
     DEVICE_TYPE_VIRTIO_NET = 1;
     DEVICE_TYPE_VIRTIO_BLK = 2;
   }
+  // Packet Direction types
+  enum PacketDirection {
+    DIRECTION_HOST = 0;
+    DIRECTION_NETWORK = 1;
+    DIRECTION_NONE = 2;
+  };
   // The configured admin state for this port.
   AdminState admin_state = 1;
   // The per port MTU (aka max frame size) for this port.
@@ -312,6 +318,8 @@ message PortConfigParams {
   string control_port = 17;
   // PCI BDF value to be used for the LINK port
   string pci_bdf = 18;
+  // Packet direction
+  PacketDirection packet_dir = 19;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,

--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -276,8 +276,8 @@ message PortConfigParams {
     DEVICE_TYPE_VIRTIO_NET = 1;
     DEVICE_TYPE_VIRTIO_BLK = 2;
   }
-  // Packet Direction types
-  enum PacketDirection {
+  // DPDK packet direction types.
+  enum DpdkPacketDirection {
     DIRECTION_HOST = 0;
     DIRECTION_NETWORK = 1;
     DIRECTION_UNKNOWN = 2;
@@ -319,7 +319,7 @@ message PortConfigParams {
   // PCI BDF value to be used for the LINK port
   string pci_bdf = 18;
   // Packet direction
-  PacketDirection packet_dir = 19;
+  DpdkPacketDirection packet_dir = 19;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -42,8 +42,6 @@ constexpr int DpdkChassisManager::kMaxXcvrEventDepth;
 constexpr int DpdkChassisManager::kSdkPortControlBase;
 constexpr int DpdkChassisManager::kDefaultMtu;
 constexpr int DpdkChassisManager::kMaxMtu;
-constexpr hal::PortConfigParams::PacketDirection
-    DpdkChassisManager::kDefaultPortPacketDirection;
 constexpr char DpdkChassisManager::kDefaultPipelineName[];
 constexpr char DpdkChassisManager::kDefaultMempoolName[];
 
@@ -139,7 +137,6 @@ DpdkChassisManager::~DpdkChassisManager() = default;
     LOG(INFO) << "Autocreating Control TAP port";
     // Packet direction for control port will always be host type
     sde_params.port_type = PortConfigParams::PORT_TYPE_TAP;
-    sde_params.packet_dir = kDefaultPortPacketDirection;
 
     /* sdk_ctl_port_id is uniquely derived from the kSdkPortControlBase range
      * and maps 1:1 to parent port's sdk_port_id.

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -42,7 +42,7 @@ constexpr int DpdkChassisManager::kMaxXcvrEventDepth;
 constexpr int DpdkChassisManager::kSdkPortControlBase;
 constexpr int DpdkChassisManager::kDefaultMtu;
 constexpr int DpdkChassisManager::kMaxMtu;
-constexpr TdiSdeInterface::PacketDirection
+constexpr hal::PortConfigParams::PacketDirection
     DpdkChassisManager::kDefaultPortPacketDirection;
 constexpr char DpdkChassisManager::kDefaultPipelineName[];
 constexpr char DpdkChassisManager::kDefaultMempoolName[];
@@ -115,8 +115,7 @@ DpdkChassisManager::~DpdkChassisManager() = default;
   TdiSdeInterface::PortConfigParams sde_params;
   sde_params.port_type = config_params.port_type();
   sde_params.device_type = config->device_type;
-  sde_params.packet_dir =
-      config->packet_dir ? config->packet_dir : kDefaultPortPacketDirection;
+  sde_params.packet_dir = config_params.packet_dir();
   sde_params.queues = config->queues;
   sde_params.mtu = *config->mtu;
   sde_params.socket_path = config->socket_path;
@@ -133,7 +132,7 @@ DpdkChassisManager::~DpdkChassisManager() = default;
             << " (SDK Port " << sdk_port_id << ").";
 
   RETURN_IF_ERROR(sde_interface_->AddPort(
-      device, port_id, singleton_port.speed_bps(), sde_params));
+      device, port_id-1, singleton_port.speed_bps(), sde_params));
 
   // Check if Control Port Creation is opted in CLI.
   if (config->control_port.length()) {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -132,7 +132,7 @@ DpdkChassisManager::~DpdkChassisManager() = default;
             << " (SDK Port " << sdk_port_id << ").";
 
   RETURN_IF_ERROR(sde_interface_->AddPort(
-      device, port_id-1, singleton_port.speed_bps(), sde_params));
+      device, port_id, singleton_port.speed_bps(), sde_params));
 
   // Check if Control Port Creation is opted in CLI.
   if (config->control_port.length()) {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
@@ -122,8 +122,8 @@ class DpdkChassisManager {
   // DPDK uses a L2 MTU including the Ethernet header.
   static constexpr int kDefaultMtu = 1514;
   static constexpr int kMaxMtu = 65535;
-  static constexpr TdiSdeInterface::PacketDirection
-      kDefaultPortPacketDirection = TdiSdeInterface::DIRECTION_HOST;
+  static constexpr hal::PortConfigParams::PacketDirection
+      kDefaultPortPacketDirection = hal::PortConfigParams::DIRECTION_HOST;
   static constexpr char kDefaultPipelineName[] = "pipe";
   static constexpr char kDefaultMempoolName[] = "MEMPOOL0";
 

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
@@ -98,7 +98,7 @@ class DpdkChassisManager {
 
     PortConfigParams::DpdkPortType port_type;
     PortConfigParams::DpdkDeviceType device_type;
-    TdiSdeInterface::PacketDirection packet_dir;
+    PortConfigParams::DpdkPacketDirection packet_dir;
     int32 queues;
     std::string socket_path;
     std::string host_name;
@@ -111,7 +111,7 @@ class DpdkChassisManager {
         : admin_state(ADMIN_STATE_UNKNOWN),
           port_type(PortConfigParams::PORT_TYPE_NONE),
           device_type(PortConfigParams::DEVICE_TYPE_NONE),
-          packet_dir(TdiSdeInterface::DIRECTION_HOST),
+          packet_dir(PortConfigParams::DIRECTION_HOST),
           queues(0) {}
   };
 
@@ -122,8 +122,6 @@ class DpdkChassisManager {
   // DPDK uses a L2 MTU including the Ethernet header.
   static constexpr int kDefaultMtu = 1514;
   static constexpr int kMaxMtu = 65535;
-  static constexpr hal::PortConfigParams::PacketDirection
-      kDefaultPortPacketDirection = hal::PortConfigParams::DIRECTION_HOST;
   static constexpr char kDefaultPipelineName[] = "pipe";
   static constexpr char kDefaultMempoolName[] = "MEMPOOL0";
 

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -143,8 +143,8 @@ namespace {
             << " pipeline_in_name=" << port_attrs->pipe_in
             << " pipeline_out_name=" << port_attrs->pipe_out
             << " mempool_name=" << port_attrs->mempool_name
-            << " net_port = " << int(port_attrs->net_port)
-            << " sdk_port_id = " << port;
+            << " net_port=" << static_cast<int>(port_attrs->net_port)
+            << " sdk_port_id=" << port;
 
   if (port_attrs->port_type == BF_DPDK_LINK) {
     // Update LINK parameters

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -132,7 +132,8 @@ namespace {
   port_attrs->port_dir = PM_PORT_DIR_DEFAULT;
   port_attrs->port_in_id = port;
   port_attrs->port_out_id = port;
-  port_attrs->net_port = config.packet_dir;
+  port_attrs->net_port =
+      config.packet_dir == hal::PortConfigParams::DIRECTION_NETWORK ? 1 : 0;
 
   LOG(INFO) << "Parameters for backend are:"
             << " port_name=" << port_attrs->port_name
@@ -142,7 +143,7 @@ namespace {
             << " pipeline_in_name=" << port_attrs->pipe_in
             << " pipeline_out_name=" << port_attrs->pipe_out
             << " mempool_name=" << port_attrs->mempool_name
-            << " net_port=" << port_attrs->net_port
+            << " net_port = " << int(port_attrs->net_port)
             << " sdk_port_id = " << port;
 
   if (port_attrs->port_type == BF_DPDK_LINK) {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -132,6 +132,8 @@ namespace {
   port_attrs->port_dir = PM_PORT_DIR_DEFAULT;
   port_attrs->port_in_id = port;
   port_attrs->port_out_id = port;
+  // From DPDK port_attributes_t header: "if [net_port is] set, port is network
+  // port, else host port".
   port_attrs->net_port =
       config.packet_dir == hal::PortConfigParams::DIRECTION_NETWORK ? 1 : 0;
 

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -58,13 +58,6 @@ class TdiSdeInterface {
     HOTPLUG_MODE_DEL = 2,
   };
 
-  // Packet Direction type.
-  enum PacketDirection {
-    DIRECTION_HOST = 0,
-    DIRECTION_NETWORK = 1,
-    DIRECTION_NONE = 2,
-  };
-
   struct HotplugConfigParams {
     uint32 qemu_socket_port;
     uint64 qemu_vm_mac_address;
@@ -79,7 +72,7 @@ class TdiSdeInterface {
   struct PortConfigParams {
     hal::PortConfigParams::DpdkPortType port_type;
     hal::PortConfigParams::DpdkDeviceType device_type;
-    hal::PortConfigParams::PacketDirection packet_dir;
+    hal::PortConfigParams::DpdkPacketDirection packet_dir;
     int queues;
     int mtu;
     std::string socket_path;

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -79,7 +79,7 @@ class TdiSdeInterface {
   struct PortConfigParams {
     hal::PortConfigParams::DpdkPortType port_type;
     hal::PortConfigParams::DpdkDeviceType device_type;
-    PacketDirection packet_dir;
+    hal::PortConfigParams::PacketDirection packet_dir;
     int queues;
     int mtu;
     std::string socket_path;


### PR DESCRIPTION
This PR adds support to set per-port packet direction for the DPDK target. Under the hood, it sets `net_port_mask` that is used to populate direction registers in P4-DPDK: https://github.com/p4lang/p4-dpdk-target/blob/main/src/pipe_mgr/shared/dal/dpdk/dal_init.c#L159. 

Note that it puts restrictions on a chassis config - DPDK port indexes must always start from 0. Otherwise, mapping done by net_port_mask won't work. 