### PR TITLE
Fix crash when startum restart with pipe config before controller con…

### DIFF
--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -572,11 +572,6 @@ namespace {
       continue;
     }
 
-    if (rx_writer_ == nullptr) {
-      VLOG(1) << "Controller not connected, just skip PacketIn.";
-      continue;
-    }
-
     ::p4::v1::PacketIn packet_in;
     ::util::Status status = ParsePacketIn(buffer, &packet_in);
     if (!status.ok()) {

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -586,7 +586,8 @@ namespace {
     }
     {
       absl::WriterMutexLock l(&rx_writer_lock_);
-      rx_writer_->Write(translated_packet_in.ValueOrDie());
+      if (rx_writer_ != nullptr)
+        rx_writer_->Write(translated_packet_in.ValueOrDie());
     }
     VLOG(1) << "Handled PacketIn: " << packet_in.ShortDebugString();
   }

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -572,6 +572,11 @@ namespace {
       continue;
     }
 
+    if (rx_writer_ == nullptr) {
+      VLOG(1) << "Controller not connected, just skip PacketIn.";
+      continue;
+    }
+
     ::p4::v1::PacketIn packet_in;
     ::util::Status status = ParsePacketIn(buffer, &packet_in);
     if (!status.ok()) {

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -591,8 +591,7 @@ namespace {
     }
     {
       absl::WriterMutexLock l(&rx_writer_lock_);
-      if (rx_writer_ != nullptr)
-        rx_writer_->Write(translated_packet_in.ValueOrDie());
+      rx_writer_->Write(translated_packet_in.ValueOrDie());
     }
     VLOG(1) << "Handled PacketIn: " << packet_in.ShortDebugString();
   }

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -591,7 +591,8 @@ namespace {
     }
     {
       absl::WriterMutexLock l(&rx_writer_lock_);
-      rx_writer_->Write(translated_packet_in.ValueOrDie());
+      if (rx_writer_ != nullptr)
+        rx_writer_->Write(translated_packet_in.ValueOrDie());
     }
     VLOG(1) << "Handled PacketIn: " << packet_in.ShortDebugString();
   }


### PR DESCRIPTION
…nected.

When the controller is connected, rx_writer_ will be set through BfrtPacketioManager::RegisterPacketReceiveWriter. However, Stratum can restart with an existing pipe configuration and enter the 'SdeRxThreadFunc' thread to process PacketIn before the controller is connected. In this case, rx_writer_ will be null and lead to a crash when the 'Write' callback is called.