### PR TITLE
fix gnmi subscribe request sample_interval and heartbeat_interval unit bug

### DIFF
--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
+load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/bazel/external/bmv2.BUILD
+++ b/bazel/external/bmv2.BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/bazel/external/gnoi.BUILD
+++ b/bazel/external/gnoi.BUILD
@@ -1,8 +1,8 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 
 licenses(["notice"])  # Apache v2
 

--- a/bazel/external/p4c.BUILD
+++ b/bazel/external/p4c.BUILD
@@ -264,9 +264,9 @@ cc_library(
         "midend/*.cpp",
     ]),
     hdrs = [
-        "frontends/parsers/p4/p4lexer.hpp",
-        "frontends/parsers/p4/p4AnnotationLexer.hpp",
         "frontends/parsers/p4/abstractP4Lexer.hpp",
+        "frontends/parsers/p4/p4AnnotationLexer.hpp",
+        "frontends/parsers/p4/p4lexer.hpp",
         "frontends/parsers/p4/p4parser.hpp",
         "frontends/parsers/p4/stack.hh",
         "frontends/parsers/v1/stack.hh",

--- a/bazel/external/taish_proto.BUILD
+++ b/bazel/external/taish_proto.BUILD
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/hal/bin/bcm/standalone/BUILD
+++ b/stratum/hal/bin/bcm/standalone/BUILD
@@ -59,8 +59,8 @@ stratum_cc_binary(
         "-lyaml",
     ],
     deps = stratum_bcm_common_deps + [
-        "//stratum/hal/lib/bcm/sdklt:bcm_sdk_wrapper",
         "//stratum/hal/lib/bcm/sdklt:bcm_diag_shell",
+        "//stratum/hal/lib/bcm/sdklt:bcm_sdk_wrapper",
     ],
 )
 
@@ -76,8 +76,8 @@ stratum_cc_binary(
         "-lutil",
     ],
     deps = stratum_bcm_common_deps + [
-        "//stratum/hal/lib/bcm/sdk:bcm_sdk_wrapper",
         "//stratum/hal/lib/bcm/sdk:bcm_diag_shell",
+        "//stratum/hal/lib/bcm/sdk:bcm_sdk_wrapper",
     ],
 )
 

--- a/stratum/hal/bin/bmv2/BUILD
+++ b/stratum/hal/bin/bmv2/BUILD
@@ -2,8 +2,8 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary", "stratum_license_tar")
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary", "stratum_license_tar")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/hal/bin/np4intel/BUILD
+++ b/stratum/hal/bin/np4intel/BUILD
@@ -3,10 +3,10 @@
 # Copyright 2019-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
-load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb", "pkg_tar")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/hal/config/BUILD
+++ b/stratum/hal/config/BUILD
@@ -2,13 +2,13 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_binary",
 )
 load(":platform_config_test.bzl", "platform_config_test")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(default_visibility = STRATUM_INTERNAL)
 

--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -2,8 +2,8 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:rules.bzl",
     "HOST_ARCHES",

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -2,13 +2,13 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("//bazel:deps.bzl", "P4RUNTIME_VER")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
     "stratum_cc_test",
 )
-load("//bazel:deps.bzl", "P4RUNTIME_VER")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -449,12 +449,14 @@ constexpr int kThousandMilliseconds = 1000 /* milliseconds */;
         }
       }
       if (subscription.mode() == ::gnmi::SubscriptionMode::SAMPLE) {
-        uint64 sample_interval = subscription.sample_interval() == 0
-                                     ? kThousandMilliseconds
-                                     : subscription.sample_interval();
-        uint64 heartbeat_interval = subscription.heartbeat_interval() == 0
-                                        ? kThousandMilliseconds
-                                        : subscription.heartbeat_interval();
+        uint64 sample_interval =
+            subscription.sample_interval() == 0
+                ? kThousandMilliseconds
+                : subscription.sample_interval() / 1000 / 1000;
+        uint64 heartbeat_interval =
+            subscription.heartbeat_interval() == 0
+                ? kThousandMilliseconds
+                : subscription.heartbeat_interval() / 1000 / 1000;
         if (!subscription.suppress_redundant()) {
           status = publisher->SubscribePeriodic(
               Periodic(sample_interval), subscription.path(), stream, &h);

--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -355,7 +355,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathSuccess) {
         elem { name: "interface" key { key: "name" value: "*" } }
       }
       mode: SAMPLE
-      sample_interval: 1
+      sample_interval: 1000000000
     }
   }
   )pb";
@@ -391,7 +391,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathFail) {
         elem { name: "blah" }
       }
       mode: SAMPLE
-      sample_interval: 1
+      sample_interval: 1000000000
     }
   }
   )pb";
@@ -446,7 +446,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathPassFail) {
         elem { name: "blah" }
       }
       mode: SAMPLE
-      sample_interval: 1
+      sample_interval: 1000000000
     }
   }
   )pb";
@@ -545,7 +545,7 @@ TEST_P(ConfigMonitoringServiceTest, DoubleSubscribeFail) {
         elem { name: "interface" key { key: "name" value: "*" } }
       }
       mode: SAMPLE
-      sample_interval: 1
+      sample_interval: 1000000000
     }
   }
   )pb";
@@ -603,7 +603,7 @@ TEST_P(ConfigMonitoringServiceTest, DuplicateSubscribeFail) {
         elem { name: "interface" key { key: "name" value: "*" } }
       }
       mode: SAMPLE
-      sample_interval: 1
+      sample_interval: 1000000000
     }
   }
   )pb";

--- a/stratum/hal/lib/dummy/BUILD
+++ b/stratum/hal/lib/dummy/BUILD
@@ -1,14 +1,14 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
     "stratum_cc_library",
 )
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/hal/lib/phal/BUILD
+++ b/stratum/hal/lib/phal/BUILD
@@ -849,11 +849,11 @@ stratum_cc_library(
         ":sfp_adapter",
         ":sfp_configurator",
         ":switch_configurator_interface",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/synchronization",
         "//stratum/hal/lib/common:constants",
         "//stratum/hal/lib/common:phal_interface",
         "//stratum/lib:macros",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/synchronization",
     ] + phal_deps,
 )
 

--- a/stratum/hal/lib/phal/test/BUILD
+++ b/stratum/hal/lib/phal/test/BUILD
@@ -2,8 +2,8 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",

--- a/stratum/lib/security/BUILD
+++ b/stratum/lib/security/BUILD
@@ -2,6 +2,7 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load(
     "//bazel:rules.bzl",
     "HOST_ARCHES",
@@ -9,7 +10,6 @@ load(
     "stratum_cc_library",
     "stratum_cc_test",
 )
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/p4c_backends/common/build_defs.bzl
+++ b/stratum/p4c_backends/common/build_defs.bzl
@@ -128,7 +128,7 @@ p4_fpm_compile = rule(
             default = Label("@com_github_p4lang_p4c//:p4include/core.p4"),
         ),
         "_p4c_stratum_fpm_binary": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("//stratum/p4c_backends/fpm:p4c-fpm"),
         ),

--- a/stratum/p4c_backends/fpm/BUILD
+++ b/stratum/p4c_backends/fpm/BUILD
@@ -2,6 +2,8 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+
 # This file builds the switch-specific p4c_backends components.
 load(
     "//bazel:rules.bzl",
@@ -12,7 +14,6 @@ load(
     "//stratum/p4c_backends/test:build_defs.bzl",
     "p4c_save_ir",
 )
-load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/p4c_backends/test/build_defs.bzl
+++ b/stratum/p4c_backends/test/build_defs.bzl
@@ -86,7 +86,7 @@ p4c_save_ir = rule(
             default = Label("@com_github_p4lang_p4c//:p4include/core.p4"),  # FIXME
         ),
         "_p4c_ir_json_saver": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("//stratum/p4c_backends/test:p4c_ir_json_saver"),
         ),

--- a/stratum/pipelines/main/BUILD
+++ b/stratum/pipelines/main/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2019-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-load("//stratum/p4c_backends/common:build_defs.bzl", "p4_fpm_compile")
-load("//bazel/rules:p4c_build_defs.bzl", "p4_bmv2_compile")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/rules:p4c_build_defs.bzl", "p4_bmv2_compile")
+load("//stratum/p4c_backends/common:build_defs.bzl", "p4_fpm_compile")
 
 licenses(["notice"])  # Apache v2
 

--- a/stratum/portage/build_defs.bzl
+++ b/stratum/portage/build_defs.bzl
@@ -40,13 +40,13 @@ Currently supported architectures:
   x86
 """
 
-load("//tools/build_defs/label:def.bzl", "parse_label")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//devtools/build_cleaner/skylark:build_defs.bzl",
     "register_extension_info",
 )
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("//tools/build_defs/label:def.bzl", "parse_label")
 
 # Generic path & label helpers. ============================================
 

--- a/stratum/procmon/BUILD
+++ b/stratum/procmon/BUILD
@@ -2,6 +2,7 @@
 # Copyright 2018-present Open Networking Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load(
     "//bazel:rules.bzl",
     "STRATUM_INTERNAL",
@@ -10,7 +11,6 @@ load(
     "stratum_cc_test",
     "stratum_package",
 )
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache v2
 


### PR DESCRIPTION
According to [gnmi-specification](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md), STREAM subscription mode **sample_interval** param is unsigned 64-bit integer representing nanoseconds and **heartbeat_interval** is specified as an unsigned 64-bit integer in nanoseconds.

But in stratum, the logic directly apply the sample_interval and heartbeat_interval in nanoseconds unit to function Periodic which param is ms unit.

So, here need to be converted.