### PR TITLE
override go net, text, and sys modules after grpc dependencies due to new go version

### DIFF
--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -388,7 +388,7 @@ jobs:
 
   license-check:
     docker:
-      - image: fsfe/reuse:latest
+      - image: fsfe/reuse:1.1
     resource_class: small  # 1 vCPU, 2GB RAM
     steps:
       - checkout

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,6 +93,33 @@ load("@io_bazel_rules_go//tests:grpc_repos.bzl", "grpc_dependencies")
 grpc_dependencies()
 
 # ---------------------------------------------------------------------------
+#       Overiride net, text, and sys Go modules to patch new Go update
+# ---------------------------------------------------------------------------
+
+go_repository(
+    name = "org_golang_x_net",
+    importpath = "golang.org/x/net",
+    sum = "h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=",
+    version = "v0.1.0",
+)
+
+go_repository(
+    name = "org_golang_x_text",
+    importpath = "golang.org/x/text",
+    sum = "h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=",
+    version = "v0.3.0",
+)
+
+go_repository(
+    name = "org_golang_x_sys",
+    importpath = "golang.org/x/sys",
+    sum = "h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=",
+    version = "v0.5.0",
+)
+
+
+
+# ---------------------------------------------------------------------------
 #       Load CDLang dependencies.
 # ---------------------------------------------------------------------------
 load("//stratum/testing/cdlang:deps.bzl", "cdlang_rules_dependencies")


### PR DESCRIPTION
override go net, text, and sys modules after grpc dependencies due to new go version